### PR TITLE
v0.11.3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+# New Features
+* tbd
+
+# Changes
+* tbd
+
+# Bug Fixes
+* tbd

--- a/.idea/pyVHDLModel.iml
+++ b/.idea/pyVHDLModel.iml
@@ -6,6 +6,10 @@
       <excludeFolder url="file://$MODULE_DIR$/tests/.pytest_cache" />
       <excludeFolder url="file://$MODULE_DIR$/.pytest_cache" />
       <excludeFolder url="file://$MODULE_DIR$/doc/_theme" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/pyVHDLModel.egg-info" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.9" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -3,6 +3,22 @@
 Dependency
 ##########
 
+.. |img-pyVHDLModel-lib-status| image:: https://img.shields.io/librariesio/release/pypi/pyVHDLModel
+   :alt: Libraries.io status for latest release
+   :height: 22
+   :target: https://libraries.io/github/Paebbels/pyVHDLModel
+.. |img-pyVHDLModel-req-status| image:: https://img.shields.io/requires/github/Paebbels/pyVHDLModel
+   :alt: Requires.io
+   :height: 22
+   :target: https://requires.io/github/Paebbels/pyVHDLModel/requirements/?branch=master
+
++------------------------------------------+------------------------------------------+
+| `Libraries.io <https://libraries.io/>`_  | `Requires.io <https://requires.io/>`_    |
++==========================================+==========================================+
+| |img-pyVHDLModel-lib-status|             | |img-pyVHDLModel-req-status|             |
++------------------------------------------+------------------------------------------+
+
+
 .. _dependency-package:
 
 pyVHDLModel Package

--- a/doc/LanguageModel/ConcurrentStatements.rst
+++ b/doc/LanguageModel/ConcurrentStatements.rst
@@ -220,7 +220,7 @@ Case Generate
      def SelectExpression(self) -> BaseExpression:
 
      @property
-     def Cases(self) -> List[ConcurrentCase]:
+     def Cases(self) -> List[GenerateCase]:
 
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,7 @@ def _LatestTagName():
 
 # The full version, including alpha/beta/rc tags
 version = "0.11"     # The short X.Y version.
-release = "0.11.2"   # The full version, including alpha/beta/rc tags.
+release = "0.11.3"   # The full version, including alpha/beta/rc tags.
 try:
 	if _IsUnderGitControl:
 		latestTagName = _LatestTagName()[1:]		# remove prefix "v"

--- a/pyVHDLModel/SemanticModel.py
+++ b/pyVHDLModel/SemanticModel.py
@@ -8,7 +8,7 @@
 # ==============================================================================
 # Authors:            Patrick Lehmann
 #
-# Python module:      An abstract PSL language model.
+# Python module:      An abstract VHDL language model.
 #
 # Description:
 # ------------------------------------
@@ -35,55 +35,9 @@
 # ==============================================================================
 #
 """
-This module contains a document language model for PSL.
+This module contains a document language model for VHDL.
 
 :copyright: Copyright 2007-2021 Patrick Lehmann - Bötzingen, Germany
 :license: Apache License, Version 2.0
 """
 # load dependencies
-from pydecor.decorators import export
-
-from pyVHDLModel import ModelEntity, PrimaryUnit
-
-
-__all__ = []
-
-@export
-class PSLPrimaryUnit(PrimaryUnit):
-	pass
-
-
-@export
-class PSLEntity(ModelEntity):
-	pass
-
-
-@export
-class VerificationUnit(PSLPrimaryUnit):
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-
-
-@export
-class VerificationProperty(PSLPrimaryUnit):
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-
-
-@export
-class VerificationMode(PSLPrimaryUnit):
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-
-
-@export
-class DefaultClock(PSLEntity):
-	_identifier: str
-
-	def __init__(self, identifier: str):
-		super().__init__()
-		self._identifier = identifier
-
-	@property
-	def Identifier(self) -> str:
-		return self._identifier

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -1699,7 +1699,7 @@ class SubProgramm(ModelEntity, NamedEntity):
 	_genericItems:   List['GenericInterfaceItem']
 	_parameterItems: List['ParameterInterfaceItem']
 	_declaredItems:  List
-	_bodyItems:      List['SequentialStatement']
+	_statements:     List['SequentialStatement']
 	_isPure:         bool
 
 	def __init__(self, identifier: str):
@@ -1709,7 +1709,7 @@ class SubProgramm(ModelEntity, NamedEntity):
 		self._genericItems =    []
 		self._parameterItems =  []
 		self._declaredItems =   []
-		self._bodyItems =       []
+		self._statements =      []
 
 	@property
 	def GenericItems(self) -> List['GenericInterfaceItem']:
@@ -1724,8 +1724,8 @@ class SubProgramm(ModelEntity, NamedEntity):
 		return self._declaredItems
 
 	@property
-	def BodyItems(self) -> List['SequentialStatement']:
-		return self._bodyItems
+	def Statements(self) -> List['SequentialStatement']:
+		return self._statements
 
 	@property
 	def IsPure(self) -> bool:
@@ -2084,7 +2084,7 @@ class Entity(PrimaryUnit, MixinDesignUnitWithContext):
 	_genericItems:  List[GenericInterfaceItem]
 	_portItems:     List[PortInterfaceItem]
 	_declaredItems: List   # FIXME: define list prefix type e.g. via Union
-	_bodyItems:     List['ConcurrentStatement']
+	_statements:    List['ConcurrentStatement']
 
 	def __init__(
 		self,
@@ -2092,7 +2092,7 @@ class Entity(PrimaryUnit, MixinDesignUnitWithContext):
 		genericItems: Iterable[GenericInterfaceItem] = None,
 		portItems: Iterable[PortInterfaceItem] = None,
 		declaredItems: Iterable = None,
-		bodyItems: Iterable['ConcurrentStatement'] = None
+		statements: Iterable['ConcurrentStatement'] = None
 	):
 		super().__init__(identifier)
 		MixinDesignUnitWithContext.__init__(self)
@@ -2100,7 +2100,7 @@ class Entity(PrimaryUnit, MixinDesignUnitWithContext):
 		self._genericItems  = [] if genericItems is None else [g for g in genericItems]
 		self._portItems     = [] if portItems is None else [p for p in portItems]
 		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
-		self._bodyItems     = [] if bodyItems is None else [i for i in bodyItems]
+		self._statements    = [] if statements is None else [s for s in statements]
 
 	@property
 	def GenericItems(self) -> List[GenericInterfaceItem]:
@@ -2115,23 +2115,23 @@ class Entity(PrimaryUnit, MixinDesignUnitWithContext):
 		return self._declaredItems
 
 	@property
-	def BodyItems(self) -> List['ConcurrentStatement']:
-		return self._bodyItems
+	def Statements(self) -> List['ConcurrentStatement']:
+		return self._statements
 
 
 @export
 class Architecture(SecondaryUnit, MixinDesignUnitWithContext):
 	_entity:        EntityOrSymbol
 	_declaredItems: List   # FIXME: define list prefix type e.g. via Union
-	_bodyItems:     List['ConcurrentStatement']
+	_statements:    List['ConcurrentStatement']
 
-	def __init__(self, identifier: str, entity: EntityOrSymbol, declaredItems: Iterable = None, bodyItems: Iterable['ConcurrentStatement'] = None):
+	def __init__(self, identifier: str, entity: EntityOrSymbol, declaredItems: Iterable = None, statements: Iterable['ConcurrentStatement'] = None):
 		super().__init__(identifier)
 		MixinDesignUnitWithContext.__init__(self)
 
 		self._entity        = entity
 		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
-		self._bodyItems     = [] if bodyItems is None else [i for i in bodyItems]
+		self._statements    = [] if statements is None else [s for s in statements]
 
 	@property
 	def Entity(self) -> EntityOrSymbol:
@@ -2142,8 +2142,8 @@ class Architecture(SecondaryUnit, MixinDesignUnitWithContext):
 		return self._declaredItems
 
 	@property
-	def BodyItems(self) -> List['ConcurrentStatement']:
-		return self._bodyItems
+	def Statements(self) -> List['ConcurrentStatement']:
+		return self._statements
 
 
 @export
@@ -2461,7 +2461,7 @@ class BlockStatement:
 class ConcurrentBlockStatement(ConcurrentStatement, BlockStatement, LabeledEntity, ConcurrentDeclarations, ConcurrentStatements):
 	_portItems:     List[PortInterfaceItem]
 
-	def __init__(self, label: str, portItems: Iterable[PortInterfaceItem] = None, declaredItems: Iterable = None, bodyItems: Iterable['ConcurrentStatement'] = None):
+	def __init__(self, label: str, portItems: Iterable[PortInterfaceItem] = None, declaredItems: Iterable = None, statements: Iterable['ConcurrentStatement'] = None):
 		super().__init__(label)
 		BlockStatement.__init__(self)
 		LabeledEntity.__init__(self, label)
@@ -2470,7 +2470,7 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatement, LabeledEntit
 
 		self._portItems     = [] if portItems is None else [i for i in portItems]
 		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
-		self._bodyItems     = [] if bodyItems is None else [i for i in bodyItems]
+		self._statements    = [] if statements is None else [s for s in statements]
 
 	# Extract to MixIn?
 	@property
@@ -2482,8 +2482,8 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatement, LabeledEntit
 		return self._declaredItems
 
 	@property
-	def BodyItems(self) -> List['ConcurrentStatement']:
-		return self._bodyItems
+	def Statements(self) -> List['ConcurrentStatement']:
+		return self._statements
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2715,16 +2715,19 @@ class CaseGenerateStatement(GenerateStatement):
 
 @export
 class ForGenerateStatement(GenerateStatement, ConcurrentDeclarations, ConcurrentStatements):
-	_loopIndex: Constant
+	_loopIndex: str
 	_range:     Range
 
-	def __init__(self, label: str = None):
+	def __init__(self, label: str, loopIndex: str, range: Range, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None):
 		super().__init__(label)
-		ConcurrentDeclarations.__init__(self)
-		ConcurrentStatements.__init__(self)
+		ConcurrentDeclarations.__init__(self, declaredItems)
+		ConcurrentStatements.__init__(self, statements)
+
+		self._loopIndex = loopIndex
+		self._range = range
 
 	@property
-	def LoopIndex(self) -> Constant:
+	def LoopIndex(self) -> str:
 		return self._loopIndex
 
 	@property

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -815,19 +815,14 @@ class ArrayType(CompositeType):
 
 
 @export
-class RecordTypeElement(ModelEntity):
-	_identifier:    str
+class RecordTypeElement(ModelEntity, MultipleNamedEntity):
 	_subtype: SubtypeOrSymbol
 
-	def __init__(self, identifier: str, subtype: SubtypeOrSymbol):
+	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol):
 		super().__init__()
+		MultipleNamedEntity.__init__(self, identifiers)
 
-		self._identifier =    identifier
 		self._subtype = subtype
-
-	@property
-	def Identifier(self) -> str:
-		return self._identifier
 
 	@property
 	def Subtype(self) -> SubtypeOrSymbol:

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2738,19 +2738,14 @@ class Assignment:
 	An ``Assignment`` is a base-class for all assignment statements.
 	"""
 
-	_target:     Obj
-	_expression: Expression
+	_target:     Name
 
-	def __init__(self):
-		pass
+	def __init__(self, target: Name):
+		self._target = target
 
 	@property
-	def Target(self) -> Obj:
+	def Target(self) -> Name:
 		return self._target
-
-	@property
-	def Expression(self) -> Expression:
-		return self._expression
 
 
 @export
@@ -2768,17 +2763,65 @@ class VariableAssignment(Assignment):
 
 
 @export
+class WaveformElement(ModelEntity):
+	_expression: Expression
+	_after: Expression
+
+	def __init__(self, expression: Expression, after: Expression = None):
+		super().__init__()
+
+		self._expression = expression
+		self._after = after
+
+	@property
+	def Expression(self) -> Expression:
+		return self._expression
+
+	@property
+	def After(self) -> Expression:
+		return self._after
+
+
+@export
 class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignment):
-	def __init__(self, label: str = None):
+	def __init__(self, label: str, target: Name):
 		super().__init__(label)
-		SignalAssignment.__init__(self)
+		SignalAssignment.__init__(self, target)
+
+
+@export
+class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment):
+	_waveform: List[WaveformElement]
+
+	def __init__(self, label: str, target: Name, waveform: Iterable[WaveformElement]):
+		super().__init__(label, target)
+
+		self._waveform = [e for e in waveform]
+
+	@property
+	def Waveform(self) -> List[WaveformElement]:
+		return self._waveform
+
+
+@export
+class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
+	def __init__(self, label: str, target: Name, expression: Expression):
+		super().__init__(label, target)
+		expression
+
+
+@export
+class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment):
+	def __init__(self, label: str, target: Name, expression: Expression):
+		super().__init__(label, target)
+		expression
 
 
 @export
 class SequentialSignalAssignment(SequentialStatement, SignalAssignment):
-	def __init__(self):
+	def __init__(self, target: Name, expression: Expression, label: str = None):
 		super().__init__()
-		SignalAssignment.__init__(self)
+		SignalAssignment.__init__(self, target, expression)
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2368,17 +2368,50 @@ class Instantiation(ConcurrentStatement):
 
 @export
 class ComponentInstantiation(Instantiation):
-	pass
+	_component: Component
+
+	def __init__(self, label: str, componentName: Name):
+		super().__init__(label)
+
+		self._component = componentName
+
+	@property
+	def Component(self) -> Component:
+		return self._component
 
 
 @export
 class EntityInstantiation(Instantiation):
-	pass
+	_entity: Entity
+	_architecture: Architecture
+
+	def __init__(self, label: str, entityName: Name, architectureName: Name = None):
+		super().__init__(label)
+
+		self._entity = entityName
+		self._architecture = architectureName
+
+	@property
+	def Entity(self) -> Entity:
+		return self._entity
+
+	@property
+	def Architecture(self) -> Entity:
+		return self._architecture
 
 
 @export
 class ConfigurationInstantiation(Instantiation):
-	pass
+	_configuration: Configuration
+
+	def __init__(self, label: str, configurationName: Name):
+		super().__init__(label)
+
+		self._configuration = configurationName
+
+	@property
+	def Configuration(self) -> Entity:
+		return self._configuration
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2476,18 +2476,34 @@ class ProcessStatement(ConcurrentStatement, SequentialDeclarations, SequentialSt
 
 @export
 class ProcedureCall:
-	def __init__(self):
-		pass
+	_procedure: Name
+	_parameterMappings: List
+
+	def __init__(self, procedureName: Name, parameterMappings: Iterable = None):
+		self._procedure = procedureName
+		self._parameterMappings = [] if procedureName is None else [m for m in parameterMappings]
+
+	@property
+	def Procedure(self) -> Name:
+		return self._procedure
+
+	@property
+	def ParameterMappings(self) -> List:
+		return self._parameterMappings
 
 
 @export
 class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCall):
-	pass
+	def __init__(self, label: str, procedureName: Name, parameterMappings: Iterable = None):
+		super().__init__(label)
+		ProcedureCall.__init__(self, procedureName, parameterMappings)
 
 
 @export
 class SequentialProcedureCall(SequentialStatement, ProcedureCall):
-	pass
+	def __init__(self, label: str, procedureName: Name, parameterMappings: Iterable = None):
+		super().__init__(label)
+		ProcedureCall.__init__(self, procedureName, parameterMappings)
 
 
 # TODO: could be unified with ProcessStatement if 'List[ConcurrentStatement]' becomes parametric to T

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2590,31 +2590,34 @@ class GenerateBranch(ModelEntity, ConcurrentDeclarations, ConcurrentStatements):
 	"""
 	A ``GenerateBranch`` is a base-class for all branches in a generate statements.
 	"""
+	_alternativeLabel: str = None
 
-	def __init__(self, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None):
+	def __init__(self, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None, alternativeLabel: str = None):
 		super().__init__()
 		ConcurrentDeclarations.__init__(self, declaredItems)
 		ConcurrentStatements.__init__(self, statements)
 
+		self._alternativeLabel = alternativeLabel
+
 
 @export
 class IfGenerateBranch(GenerateBranch, MixinIfBranch):
-	def __init__(self, condition: Expression, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None):
-		super().__init__(declaredItems, statements)
+	def __init__(self, condition: Expression, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None, alternativeLabel: str = None):
+		super().__init__(declaredItems, statements, alternativeLabel)
 		MixinIfBranch.__init__(self, condition)
 
 
 @export
 class ElsifGenerateBranch(GenerateBranch, MixinElsifBranch):
-	def __init__(self):
-		super().__init__()
-		MixinElsifBranch.__init__(self)
+	def __init__(self, condition: Expression, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None, alternativeLabel: str = None):
+		super().__init__(declaredItems, statements, alternativeLabel)
+		MixinElsifBranch.__init__(self, condition)
 
 
 @export
 class ElseGenerateBranch(GenerateBranch, MixinElseBranch):
-	def __init__(self):
-		super().__init__()
+	def __init__(self, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None, alternativeLabel: str = None):
+		super().__init__(declaredItems, statements, alternativeLabel)
 		MixinElseBranch.__init__(self)
 
 

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -42,7 +42,7 @@ This module contains a document language model for VHDL.
 """
 # load dependencies
 from pathlib              import Path
-from typing               import List, Tuple, Union, Dict, Iterator, Optional, Any
+from typing import List, Tuple, Union, Dict, Iterator, Optional, Any, Iterable
 
 from pydecor.decorators   import export
 
@@ -153,9 +153,9 @@ class SimpleName(Name):
 class ParenthesisName(Name):
 	_associations: List
 
-	def __init__(self, prefix: Name, associations: List):
+	def __init__(self, prefix: Name, associations: Iterable):
 		super().__init__("", prefix)
-		self._associations = associations
+		self._associations = [a for a in associations]
 
 	@property
 	def Associations(self) -> List:
@@ -348,10 +348,10 @@ class ConstrainedScalarSubtypeSymbol(SubtypeSymbol):
 class ConstrainedCompositeSubtypeSymbol(SubtypeSymbol):
 	_constraints: List[Constraint]
 
-	def __init__(self, subtypeName: Name, constraints: List[Constraint] = None):
+	def __init__(self, subtypeName: Name, constraints: Iterable[Constraint] = None):
 		super().__init__(subtypeName, PossibleReference.Unknown)
 		self._subtype = None
-		self._constraints = constraints
+		self._constraints = [c for c in constraints]
 
 	@property
 	def Constraints(self) -> List[Constraint]:
@@ -753,7 +753,7 @@ class FileType(FullType):
 class EnumeratedType(ScalarType, DiscreteType):
 	_literals: List['EnumerationLiteral']
 
-	def __init__(self, identifier: str, literals: List['EnumerationLiteral']):
+	def __init__(self, identifier: str, literals: Iterable['EnumerationLiteral']):
 		super().__init__(identifier)
 
 		self._literals = [] if literals is None else [lit for lit in literals]
@@ -780,11 +780,11 @@ class PhysicalType(RangedScalarType, NumericType):
 	_primaryUnit:    str
 	_secondaryUnits: List[Tuple[str, 'PhysicalIntegerLiteral']]
 
-	def __init__(self, identifier: str, rng: Union['Range', Name], primaryUnit: str, units: List[Tuple[str, 'PhysicalIntegerLiteral']]):
+	def __init__(self, identifier: str, rng: Union['Range', Name], primaryUnit: str, units: Iterable[Tuple[str, 'PhysicalIntegerLiteral']]):
 		super().__init__(identifier, rng)
 
 		self._primaryUnit = primaryUnit
-		self._secondaryUnits = units
+		self._secondaryUnits = [u for u in units]
 
 	@property
 	def PrimaryUnit(self) -> str:
@@ -818,7 +818,7 @@ class ArrayType(CompositeType):
 class RecordTypeElement(ModelEntity, MultipleNamedEntity):
 	_subtype: SubtypeOrSymbol
 
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol):
 		super().__init__()
 		MultipleNamedEntity.__init__(self, identifiers)
 
@@ -833,7 +833,7 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntity):
 class RecordType(CompositeType):
 	_elements: List[RecordTypeElement]
 
-	def __init__(self, identifier: str, elements: List[RecordTypeElement] = None):
+	def __init__(self, identifier: str, elements: Iterable[RecordTypeElement] = None):
 		super().__init__(identifier)
 
 		self._elements = [] if elements is None else [i for i in elements]
@@ -1550,10 +1550,10 @@ class OthersAggregateElement(AggregateElement):
 class Aggregate(BaseExpression):
 	_elements: List[AggregateElement]
 
-	def __init__(self, elements: List[AggregateElement]):
+	def __init__(self, elements: Iterable[AggregateElement]):
 		super().__init__()
 
-		self._elements = elements
+		self._elements = [e for e in elements]
 
 	@property
 	def Elements(self) -> List[AggregateElement]:
@@ -1619,7 +1619,7 @@ class RangeSubtype(BaseConstraint):
 class Obj(ModelEntity, MultipleNamedEntity):
 	_subtype: SubtypeOrSymbol
 
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol):
 		super().__init__()
 		MultipleNamedEntity.__init__(self, identifiers)
 
@@ -1653,7 +1653,7 @@ class BaseConstant(Obj):
 
 @export
 class Constant(BaseConstant, WithDefaultExpressionMixin):
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype)
 		WithDefaultExpressionMixin.__init__(self, defaultExpression)
 
@@ -1662,7 +1662,7 @@ class Constant(BaseConstant, WithDefaultExpressionMixin):
 class DeferredConstant(BaseConstant):
 	_constantReference: Constant
 
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol):
 		super().__init__(identifiers, subtype)
 
 	@property
@@ -1672,7 +1672,7 @@ class DeferredConstant(BaseConstant):
 
 @export
 class Variable(Obj, WithDefaultExpressionMixin):
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype)
 		WithDefaultExpressionMixin.__init__(self, defaultExpression)
 
@@ -1684,7 +1684,7 @@ class SharedVariable(Obj):
 
 @export
 class Signal(Obj, WithDefaultExpressionMixin):
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super(Signal, self).__init__(identifiers, subtype)
 		WithDefaultExpressionMixin.__init__(self, defaultExpression)
 
@@ -1801,10 +1801,10 @@ class AttributeSpecification(ModelEntity):
 	_entityClass: EntityClass
 	_expression: Expression
 
-	def __init__(self, identifiers: List[Name], attribute: Name, entityClass: EntityClass, expression: Expression):
+	def __init__(self, identifiers: Iterable[Name], attribute: Name, entityClass: EntityClass, expression: Expression):
 		super().__init__()
 
-		self._identifiers = identifiers
+		self._identifiers = [i for i in identifiers]
 		self._attribute = attribute
 		self._entityClass = entityClass
 		self._expression = expression
@@ -1880,7 +1880,7 @@ class ParameterInterfaceItem(InterfaceItem):
 
 @export
 class GenericConstantInterfaceItem(Constant, GenericInterfaceItem, InterfaceItemWithMode):
-	def __init__(self, identifiers: List[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype, defaultExpression)
 		GenericInterfaceItem.__init__(self)
 		InterfaceItemWithMode.__init__(self, mode)
@@ -1921,14 +1921,14 @@ class GenericPackageInterfaceItem(GenericInterfaceItem):
 
 @export
 class PortSignalInterfaceItem(Signal, PortInterfaceItem):
-	def __init__(self, identifiers: List[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype, defaultExpression)
 		PortInterfaceItem.__init__(self, mode)
 
 
 @export
 class ParameterConstantInterfaceItem(Constant, ParameterInterfaceItem, InterfaceItemWithMode):
-	def __init__(self, identifiers: List[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype, defaultExpression)
 		ParameterInterfaceItem.__init__(self)
 		InterfaceItemWithMode.__init__(self, mode)
@@ -1936,7 +1936,7 @@ class ParameterConstantInterfaceItem(Constant, ParameterInterfaceItem, Interface
 
 @export
 class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItem, InterfaceItemWithMode):
-	def __init__(self, identifiers: List[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype, defaultExpression)
 		ParameterInterfaceItem.__init__(self)
 		InterfaceItemWithMode.__init__(self, mode)
@@ -1944,7 +1944,7 @@ class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItem, Interface
 
 @export
 class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItem, InterfaceItemWithMode):
-	def __init__(self, identifiers: List[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
+	def __init__(self, identifiers: Iterable[str], mode: Mode, subtype: SubtypeOrSymbol, defaultExpression: Expression = None):
 		super().__init__(identifiers, subtype, defaultExpression)
 		ParameterInterfaceItem.__init__(self)
 		InterfaceItemWithMode.__init__(self, mode)
@@ -1952,7 +1952,7 @@ class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItem, InterfaceItem
 
 @export
 class ParameterFileInterfaceItem(File, ParameterInterfaceItem):
-	def __init__(self, identifiers: List[str], subtype: SubtypeOrSymbol):
+	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol):
 		super().__init__(identifiers, subtype)
 		ParameterInterfaceItem.__init__(self)
 
@@ -2089,10 +2089,10 @@ class Entity(PrimaryUnit, MixinDesignUnitWithContext):
 	def __init__(
 		self,
 		identifier: str,
-		genericItems: List[GenericInterfaceItem] = None,
-		portItems: List[PortInterfaceItem] = None,
-		declaredItems: List = None,
-		bodyItems: List['ConcurrentStatement'] = None
+		genericItems: Iterable[GenericInterfaceItem] = None,
+		portItems: Iterable[PortInterfaceItem] = None,
+		declaredItems: Iterable = None,
+		bodyItems: Iterable['ConcurrentStatement'] = None
 	):
 		super().__init__(identifier)
 		MixinDesignUnitWithContext.__init__(self)
@@ -2125,7 +2125,7 @@ class Architecture(SecondaryUnit, MixinDesignUnitWithContext):
 	_declaredItems: List   # FIXME: define list prefix type e.g. via Union
 	_bodyItems:     List['ConcurrentStatement']
 
-	def __init__(self, identifier: str, entity: EntityOrSymbol, declaredItems: List = None, bodyItems: List['ConcurrentStatement'] = None):
+	def __init__(self, identifier: str, entity: EntityOrSymbol, declaredItems: Iterable = None, bodyItems: Iterable['ConcurrentStatement'] = None):
 		super().__init__(identifier)
 		MixinDesignUnitWithContext.__init__(self)
 
@@ -2151,7 +2151,7 @@ class Component(ModelEntity, NamedEntity):
 	_genericItems:      List[GenericInterfaceItem]
 	_portItems:         List[PortInterfaceItem]
 
-	def __init__(self, identifier: str, genericItems: List[GenericInterfaceItem] = None, portItems: List[PortInterfaceItem] = None):
+	def __init__(self, identifier: str, genericItems: Iterable[GenericInterfaceItem] = None, portItems: Iterable[PortInterfaceItem] = None):
 		super().__init__()
 		NamedEntity.__init__(self, identifier)
 
@@ -2235,7 +2235,7 @@ class Package(PrimaryUnit, MixinDesignUnitWithContext):
 	_genericItems:      List[GenericInterfaceItem]
 	_declaredItems:     List
 
-	def __init__(self, identifier: str, genericItems: List[GenericInterfaceItem] = None, declaredItems: List = None):
+	def __init__(self, identifier: str, genericItems: Iterable[GenericInterfaceItem] = None, declaredItems: Iterable = None):
 		super().__init__(identifier)
 		MixinDesignUnitWithContext.__init__(self)
 
@@ -2256,7 +2256,7 @@ class PackageBody(SecondaryUnit, MixinDesignUnitWithContext):
 	_package:           Package
 	_declaredItems:     List
 
-	def __init__(self, identifier: str, declaredItems: List = None):
+	def __init__(self, identifier: str, declaredItems: Iterable = None):
 		super().__init__(identifier)
 		MixinDesignUnitWithContext.__init__(self)
 
@@ -2422,20 +2422,32 @@ class BlockStatement:
 
 
 @export
-class ConcurrentBlockStatement(ConcurrentStatement, BlockStatement, ConcurrentDeclarations, ConcurrentStatements):
+class ConcurrentBlockStatement(ConcurrentStatement, BlockStatement, LabeledEntity, ConcurrentDeclarations, ConcurrentStatements):
 	_portItems:     List[PortInterfaceItem]
 
-	def __init__(self, label: str = None):
+	def __init__(self, label: str, portItems: Iterable[PortInterfaceItem] = None, declaredItems: Iterable = None, bodyItems: Iterable['ConcurrentStatement'] = None):
 		super().__init__(label=label)
 		BlockStatement.__init__(self)
+		LabeledEntity.__init__(self, label)
 		ConcurrentDeclarations.__init__(self)
 		ConcurrentStatements.__init__(self)
 
-		self._portItems =     []
+		self._portItems     = [] if portItems is None else [i for i in portItems]
+		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
+		self._bodyItems     = [] if bodyItems is None else [i for i in bodyItems]
 
+	# Extract to MixIn?
 	@property
 	def PortItems(self) -> List[PortInterfaceItem]:
 		return self._portItems
+
+	@property
+	def DeclaredItems(self) -> List:   # FIXME: define list prefix type e.g. via Union
+		return self._declaredItems
+
+	@property
+	def BodyItems(self) -> List['ConcurrentStatement']:
+		return self._bodyItems
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2317,8 +2317,8 @@ class SequentialStatement(Statement):
 class ConcurrentDeclarations:
 	_declaredItems: List
 
-	def __init__(self):
-		self._declaredItems = []
+	def __init__(self, declaredItems: Iterable = None):
+		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
 
 	@property
 	def DeclaredItems(self) -> List:
@@ -2329,8 +2329,8 @@ class ConcurrentDeclarations:
 class ConcurrentStatements:
 	_statements: List[ConcurrentStatement]
 
-	def __init__(self):
-		self._statements = []
+	def __init__(self, statements: Iterable[ConcurrentStatement] = None):
+		self._statements = [] if statements is None else [s for s in statements]
 
 	@property
 	def Statements(self) -> List[ConcurrentStatement]:
@@ -2493,8 +2493,8 @@ class MixinConditional:
 	"""
 	_condition: Expression
 
-	def __init__(self):
-		pass
+	def __init__(self, condition: Expression):
+		self._condition = condition
 
 	@property
 	def Condition(self) -> Expression:
@@ -2516,9 +2516,9 @@ class MixinConditionalBranch(MixinBranch, MixinConditional):
 	"""
 	A ``BaseBranch`` is a mixin-class for all branch statements with a condition.
 	"""
-	def __init__(self):
+	def __init__(self, condition: Expression):
 		super().__init__()
-		MixinConditional.__init__(self)
+		MixinConditional.__init__(self, condition)
 
 
 @export
@@ -2548,17 +2548,17 @@ class GenerateBranch(ModelEntity, ConcurrentDeclarations, ConcurrentStatements):
 	A ``GenerateBranch`` is a base-class for all branches in a generate statements.
 	"""
 
-	def __init__(self):
+	def __init__(self, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None):
 		super().__init__()
-		ConcurrentDeclarations.__init__(self)
-		ConcurrentStatements.__init__(self)
+		ConcurrentDeclarations.__init__(self, declaredItems)
+		ConcurrentStatements.__init__(self, statements)
 
 
 @export
 class IfGenerateBranch(GenerateBranch, MixinIfBranch):
-	def __init__(self):
-		super().__init__()
-		MixinIfBranch.__init__(self)
+	def __init__(self, condition: Expression, declaredItems: Iterable = None, statements: Iterable[ConcurrentStatement] = None):
+		super().__init__(declaredItems, statements)
+		MixinIfBranch.__init__(self, condition)
 
 
 @export
@@ -2591,10 +2591,12 @@ class IfGenerateStatement(GenerateStatement):
 	_elsifBranches: List[ElsifGenerateBranch]
 	_elseBranch:    ElseGenerateBranch
 
-	def __init__(self, label: str):
+	def __init__(self, label: str, ifBranch: IfGenerateBranch, elsifBranches: Iterable[ElsifGenerateBranch] = None, elseBranch: ElseGenerateBranch = None):
 		super().__init__(label)
 
-		self._elsifBranches = []
+		self._ifBranch = ifBranch
+		self._elsifBranches = [] if elsifBranches is None else [b for b in elsifBranches]
+		self._elseBranch = elseBranch
 
 	@property
 	def IfBranch(self) -> IfGenerateBranch:

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2341,8 +2341,8 @@ class ConcurrentStatements:
 class SequentialDeclarations:
 	_declaredItems: List
 
-	def __init__(self):
-		self._declaredItems = []
+	def __init__(self, declaredItems: Iterable):
+		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
 
 	@property
 	def DeclaredItems(self) -> List:
@@ -2353,8 +2353,8 @@ class SequentialDeclarations:
 class SequentialStatements:
 	_statements: List[SequentialStatement]
 
-	def __init__(self):
-		self._statements = []
+	def __init__(self, statements: Iterable[SequentialStatement]):
+		self._statements = [] if statements is None else [s for s in statements]
 
 	@property
 	def Statements(self) -> List[SequentialStatement]:
@@ -2416,12 +2416,15 @@ class ConfigurationInstantiation(Instantiation):
 
 @export
 class ProcessStatement(ConcurrentStatement, SequentialDeclarations, SequentialStatements):
-	_sensitivityList: List[Signal]
+	_sensitivityList: List[Signal] = None
 
-	def __init__(self, label: str = None):
-		super().__init__(label=label)
-		SequentialDeclarations.__init__(self)
-		SequentialStatements.__init__(self)
+	def __init__(self, label: str = None, declaredItems: Iterable = None, statements: Iterable[SequentialStatement] = None, sensitivityList: Iterable[Name] = None):
+		super().__init__(label)
+		SequentialDeclarations.__init__(self, declaredItems)
+		SequentialStatements.__init__(self, statements)
+
+		if sensitivityList is not None:
+			self._sensitivityList = [s for s in sensitivityList]
 
 	@property
 	def SensitivityList(self) -> List[Signal]:
@@ -2459,7 +2462,7 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatement, LabeledEntit
 	_portItems:     List[PortInterfaceItem]
 
 	def __init__(self, label: str, portItems: Iterable[PortInterfaceItem] = None, declaredItems: Iterable = None, bodyItems: Iterable['ConcurrentStatement'] = None):
-		super().__init__(label=label)
+		super().__init__(label)
 		BlockStatement.__init__(self)
 		LabeledEntity.__init__(self, label)
 		ConcurrentDeclarations.__init__(self)
@@ -2579,7 +2582,7 @@ class GenerateStatement(ConcurrentStatement):
 	"""
 
 	def __init__(self, label: str = None):
-		super().__init__(label=label)
+		super().__init__(label)
 
 
 @export
@@ -2588,8 +2591,8 @@ class IfGenerateStatement(GenerateStatement):
 	_elsifBranches: List[ElsifGenerateBranch]
 	_elseBranch:    ElseGenerateBranch
 
-	def __init__(self, label: str = None):
-		super().__init__(label=label)
+	def __init__(self, label: str):
+		super().__init__(label)
 
 		self._elsifBranches = []
 
@@ -2668,7 +2671,7 @@ class ForGenerateStatement(GenerateStatement, ConcurrentDeclarations, Concurrent
 	_range:     Range
 
 	def __init__(self, label: str = None):
-		super().__init__(label=label)
+		super().__init__(label)
 		ConcurrentDeclarations.__init__(self)
 		ConcurrentStatements.__init__(self)
 
@@ -2719,7 +2722,7 @@ class VariableAssignment(Assignment):
 @export
 class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignment):
 	def __init__(self, label: str = None):
-		super().__init__(label=label)
+		super().__init__(label)
 		SignalAssignment.__init__(self)
 
 
@@ -2775,7 +2778,7 @@ class MixinAssertStatement(MixinReportStatement):
 @export
 class ConcurrentAssertStatement(ConcurrentStatement, MixinAssertStatement):
 	def __init__(self, label: str = None):
-		super().__init__(label=label)
+		super().__init__(label)
 		MixinAssertStatement.__init__(self)
 
 

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -274,6 +274,13 @@ class PrimaryUnit(DesignUnit):
 	A ``PrimaryUnit`` is a base-class for all primary units.
 	"""
 
+	@property
+	def Library(self) -> 'Library':
+		return self._parent
+	@Library.setter
+	def Library(self, library: 'Library') -> None:
+		self._parent = library
+
 
 @export
 class SecondaryUnit(DesignUnit):

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -40,4 +40,4 @@ An abstract VHDL language model.
 :copyright: Copyright 2007-2021 Patrick Lehmann - Bötzingen, Germany
 :license: Apache License, Version 2.0
 """
-__version__ = "0.11.2"
+__version__ = "0.11.3"

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -40,4 +40,243 @@ An abstract VHDL language model.
 :copyright: Copyright 2007-2021 Patrick Lehmann - Bötzingen, Germany
 :license: Apache License, Version 2.0
 """
+from enum import IntEnum, unique, Enum
+from typing import List
+
+from pydecor import export
+
+
 __version__ = "0.11.3"
+
+
+@export
+@unique
+class Direction(Enum):
+	"""
+	A ``Direction`` is an enumeration and represents a direction in a range
+	(``to`` or ``downto``).
+	"""
+	To =      0
+	DownTo =  1
+
+	def __str__(self):
+		index: int = self.value
+		return ("to", "downto")[index]       # TODO: check performance
+
+
+@export
+@unique
+class Mode(Enum):
+	"""
+	A ``Mode`` is an enumeration. It represents the direction of data exchange
+	(``in``, ``out``, ...) for objects in generic, port or parameter lists.
+
+	In case no *mode* is define, ``Default`` is used, so the *mode* is inferred
+	from context.
+	"""
+	Default = 0
+	In =      1
+	Out =     2
+	InOut =   3
+	Buffer =  4
+	Linkage = 5
+
+	def __str__(self):
+		index: int = self.value
+		return ("", "in", "out", "inout", "buffer", "linkage")[index]       # TODO: check performance
+
+
+@export
+@unique
+class ObjectClass(Enum):
+	"""
+	An ``ObjectClass`` is an enumeration. It represents an object's class (``constant``,
+	``signal``, ...).
+
+	In case no *object class* is define, ``Default`` is used, so the *object class*
+	is inferred from context.
+	"""
+	Default =    0
+	Constant =   1
+	Variable =   2
+	Signal =     3
+	File =       4
+	Type =       5
+	Procedure =  6
+	Function =   7
+
+
+@export
+@unique
+class EntityClass(Enum):
+	"""
+	A ``Class`` is an enumeration. It represents an object's class (``constant``,
+	``signal``, ...).
+
+	In case no *object class* is define, ``Default`` is used, so the *object class*
+	is inferred from context.
+	"""
+	Entity =        0
+	Architecture =  1
+	Configuration = 2
+	Procedure =     3
+	Function =      4
+	Package =       5
+	Type =          6
+	Subtype =       7
+	Constant =      8
+	Signal =        9
+	Variable =      10
+	Component =     11
+	Label =         12
+	Literal =       13
+	Units =         14
+	Group =         15
+	File =          16
+	Property =      17
+	Sequence =      18
+	View =          19
+	Others  =       20
+
+
+@export
+class PossibleReference(IntEnum):
+	Unknown =         0
+	Library =         2**0
+	Entity =          2**1
+	Architecture =    2**2
+	Component =       2**3
+	Package =         2**4
+	Configuration =   2**5
+	Context =         2**6
+	Type =            2**7
+	Subtype =         2**8
+	ScalarType =      2**9
+	ArrayType =       2**10
+	RecordType =      2**11
+	AccessType =      2**12
+	ProtectedType =   2**13
+	FileType =        2**14
+#	Alias =           2**14   # TODO: Is this needed?
+	Attribute =       2**15
+	TypeAttribute =   2**16
+	ValueAttribute =  2**17
+	SignalAttribute = 2**18
+	RangeAttribute =  2**19
+	ViewAttribute =   2**20
+	Constant =        2**16
+	Variable =        2**17
+	Signal =          2**18
+	File =            2**19
+	Object =          2**20   # TODO: Is this needed?
+	EnumLiteral =     2**21
+	Procedure =       2**22
+	Function =        2**23
+	Label =           2**24
+	View =            2**25
+	SimpleNameInExpression = Constant + Variable + Signal + ScalarType + EnumLiteral + Function
+
+
+@export
+class ModelEntity:
+	"""
+	``ModelEntity`` is the base class for all classes in the VHDL language model,
+	except for mixin classes (see multiple inheritance) and enumerations.
+
+	Each entity in this model has a reference to its parent entity. Therefore
+	a protected variable :attr:`_parent` is available and a readonly property
+	:attr:`Parent`.
+	"""
+	_parent: 'ModelEntity'      #: Reference to a parent entity in the model.
+
+	def __init__(self):
+		pass
+
+	@property
+	def Parent(self) -> 'ModelEntity':
+		"""Returns a reference to the parent entity."""
+		return self._parent
+
+
+@export
+class NamedEntity:
+	"""
+	A ``NamedEntity`` is a mixin class for all VHDL entities that have identifiers.
+
+	A protected variable :attr:`_identifier` is available to derived classes as
+	well as a readonly property :attr:`Identifier` for public access.
+	"""
+	_identifier: str                  #: The identifier of a model entity.
+
+	def __init__(self, identifier: str):
+		self._identifier = identifier
+
+	@property
+	def Identifier(self) -> str:
+		"""Returns a model entity's identifier (name)."""
+		return self._identifier
+
+
+@export
+class MultipleNamedEntity:
+	"""
+	A ``MultipleNamedEntity`` is a mixin class for all VHDL entities that declare
+	multiple instances at once by giving multiple identifiers.
+
+	A protected variable :attr:`_identifiers` is available to derived classes as
+	well as a readonly property :attr:`Identifiers` for public access.
+	"""
+	_identifiers: List[str]           #: A list of identifiers.
+
+	def __init__(self, identifiers: List[str]):
+		self._identifiers = identifiers
+
+	@property
+	def Identifiers(self) -> List[str]:
+		"""Returns a model entity's list of identifiers (name)."""
+		return self._identifiers
+
+
+@export
+class LabeledEntity:
+	"""
+	A ``LabeledEntity`` is a mixin class for all VHDL entities that can have
+	labels.
+
+	A protected variable :attr:`_label` is available to derived classes as well
+	as a readonly property :attr:`Label` for public access.
+	"""
+	_label: str                 #: The label of a model entity.
+
+	def __init__(self, label: str):
+		self._label = label
+
+	@property
+	def Label(self) -> str:
+		"""Returns a model entity's label."""
+		return self._label
+
+
+@export
+class DesignUnit(ModelEntity, NamedEntity):
+	"""
+	A ``DesignUnit`` is a base-class for all design units.
+	"""
+
+	def __init__(self, identifier: str):
+		super().__init__()
+		NamedEntity.__init__(self, identifier)
+
+
+@export
+class PrimaryUnit(DesignUnit):
+	"""
+	A ``PrimaryUnit`` is a base-class for all primary units.
+	"""
+
+
+@export
+class SecondaryUnit(DesignUnit):
+	"""
+	A ``SecondaryUnit`` is a base-class for all secondary units.
+	"""

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ documentationURL =  "https://{namespace}.github.io/{projectName}".format(namespa
 # Assemble all package information
 setuptools_setup(
 	name=projectName,
-	version="0.11.2",
+	version="0.11.3",
 
 	author="Patrick Lehmann",
 	author_email="Paebbels@gmail.com",

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -37,9 +37,9 @@
 from pathlib  import Path
 from unittest import TestCase
 
-from pyVHDLModel.VHDLModel import Design, Library, Document, Subtype, Range, IntegerLiteral, Direction, FloatingPointLiteral
-from pyVHDLModel.VHDLModel import Entity, Architecture, PackageBody, Package, Configuration, Context
-from pyVHDLModel.VHDLModel import IntegerType, RealType, ArrayType, RecordType
+from pyVHDLModel.SyntaxModel import Design, Library, Document, Subtype, Range, IntegerLiteral, Direction, FloatingPointLiteral
+from pyVHDLModel.SyntaxModel import Entity, Architecture, PackageBody, Package, Configuration, Context
+from pyVHDLModel.SyntaxModel import IntegerType, RealType, ArrayType, RecordType
 
 
 if __name__ == "__main__":

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -87,7 +87,7 @@ class Instantiate(TestCase):
 		self.assertEqual(0, len(entity.GenericItems))
 		self.assertEqual(0, len(entity.PortItems))
 		self.assertEqual(0, len(entity.DeclaredItems))
-		self.assertEqual(0, len(entity.BodyItems))
+		self.assertEqual(0, len(entity.Statements))
 
 	def test_Architecture(self):
 		entity = Entity("entity_1")
@@ -96,7 +96,7 @@ class Instantiate(TestCase):
 		self.assertIsNotNone(architecture)
 		self.assertEqual("arch_1", architecture.Identifier)
 		self.assertEqual(0, len(architecture.DeclaredItems))
-		self.assertEqual(0, len(architecture.BodyItems))
+		self.assertEqual(0, len(architecture.Statements))
 
 	def test_Package(self):
 		package = Package("pack_1")


### PR DESCRIPTION
# New Features
* Added properties `Architectures` and `PackageBodies` to class `Library` for easier architecture to entity resolution.  
  `Architectures` is a dictionary of *Name*: *Architecture*.
* New `Library` property on `PrimaryUnit`.  
  When adding design units to a library, the Library property is set.
* New `MultipleNamedEntity` class to handle declarations with multiple identifiers.  
  **Note:** parameter and property `Identifier` was changed to `Identifiers`.
* Added property `Architectures` to class `Entity`.
* New class `ConcurrentChoice`, `IndexedGenerateChoice`, `RangedGenerateChoice`, `GenerateCase` and `OthersGenerateCase`.
* New class `WaveformElement`, `ConcurrentSelectedSignalAssignment`, `ConcurrentConditionalSignalAssignment`

# Changes
* Renamed `ConcurrentCase` to `GenerateCase`.
* Moved enumerations (`Direction`, `Mode`, `ObjectClass`, `EntityClass` and `PossibleReference`) to `pyVHDLModel`.
* Moved base classes (`ModelEntity`, `NamedEntity`, `LabeledEntity`, `DesignUnit`, `PrimaryUnit` and `SecondaryUnit`) to `pyVHDLModel`.
* Changed method parameter type `List`/`List[T]` to `Iterable`/`Iterable[T]`.
* Renamed parameter and property `Identifier` to `Identifiers` in case multiple identifiers are supported.
* Renamed `BodyItems` to `Statements`.
* Reworked:
  * `ConcurrentDeclarations`
  * `ConcurrentStatements`
  * `SequentialDeclarations`
  * `ComponentInstantiation`, `EntityInstantiation` and `ConfigurationInstantiation`
  * `ProcessStatement`
  * `ProcedureCall`, `ConcurrentProcedureCall` and `SequentialProcedureCall`.
  * `ConcurrentBlockStatement`
  * `MixinConditional`
  * `GenerateBranch`, `IfGenerateBranch`, `ElsifGenerateBranch` and `ElseGenerateBranch`
  * `ConcurrentCase`
  * `IfGenerateStatement`, `CaseGenerateStatement` and `ForGenerateStatement`
  * `ConcurrentSignalAssignment`, `ConcurrentSimpleSignalAssignment`, `SequentialSignalAssignment`

# Bug Fixes
* None