### PR TITLE
Add refs to IEEE-P1076.gitlab.io through intersphinx

### DIFF
--- a/doc/Glossary.rst
+++ b/doc/Glossary.rst
@@ -12,3 +12,5 @@ Glossary
      * `1076-2000 <https://ieeexplore.ieee.org/document/893288>`__.
      * `1076-1993 <https://ieeexplore.ieee.org/document/392561>`__.
      * `1076-1987 <https://ieeexplore.ieee.org/document/26487>`__.
+
+     See :ref:`VASG:About:Standards` for further details.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,7 +211,8 @@ extensions = [
 # Sphinx.Ext.InterSphinx
 # ==============================================================================
 intersphinx_mapping = {
-	'python':   ('https://docs.python.org/3', None),
+	'python': ('https://docs.python.org/3', None),
+	'vasg':   ('https://IEEE-P1076.gitlab.io/', None),
 }
 
 


### PR DESCRIPTION
I'm trying to add references to IEEE-P1076.gitlab.io through intersphinx, with no success. This PR is for showcasing the issue, in the hope that someone can help me understand what's going on.

This is the output I get:

![image](https://user-images.githubusercontent.com/38422348/134902413-de47608a-c187-4bf8-83ef-45af53ed1be0.png)

- Using role `label`, the targets are not correct.
- Using `ref` without the `VASG` namespace is correct, however, it does not work if the namespace is specified.
- Using `doc` works regardless of the namespace being used.

My understanding is that this might be a bug in Sphinx/Intersphinx.