### PR TITLE
ci/Pipeline: change name to just 'Pipeline'

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -1,4 +1,4 @@
-name: Unit Testing, Coverage Collection, Package, Release, Documentation and Publish
+name: Pipeline
 
 on: [ push ]
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/pyVHDLModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)](https://pypi.org/project/pyVHDLModel/)
 ![PyPI - Status](https://img.shields.io/pypi/status/pyVHDLModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyVHDLModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)  
-[![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Unit%20Testing,%20Coverage%20Collection,%20Package,%20Release,%20Documentation%20and%20Publish/main?longCache=true&style=flat-square&label=Build%20and%20test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://github.com/vhdl/pyVHDLModel/actions?query=workflow%3A%22Test+and+Coverage%22)
+[![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://github.com/VHDL/pyVHDLModel/actions/workflows/Pipeline.yml)
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pyVHDLModel?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/vhdl/pyVHDLModel)
 [![Codacy - Quality](https://img.shields.io/codacy/grade/2286426d2b11417e90010427b7fed8e7?longCache=true&style=flat-square&logo=Codacy)](https://www.codacy.com/manual/VHDL/pyVHDLModel)
 [![Codacy - Coverage](https://img.shields.io/codacy/coverage/2286426d2b11417e90010427b7fed8e7?longCache=true&style=flat-square&logo=Codacy)](https://www.codacy.com/manual/VHDL/pyVHDLModel)

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -53,15 +53,15 @@
    :height: 22
    :target: https://github.com/vhdl/pyVHDLModel/network/dependents
 
-.. # GHA test and coverage
-.. |SHIELD:svg:pyVHDLModel-gha-test| image:: https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Unit%20Testing,%20Coverage%20Collection,%20Package,%20Release,%20Documentation%20and%20Publish/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
+.. # GHA workflow
+.. |SHIELD:svg:pyVHDLModel-gha-test| image:: https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
    :alt: GitHub Workflow - Build and Test Status
    :height: 22
-   :target: https://github.com/vhdl/pyVHDLModel/actions?query=workflow%3A%22Test+and+Coverage%22
-.. |SHIELD:png:pyVHDLModel-gha-test| image:: https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Unit%20Testing,%20Coverage%20Collection,%20Package,%20Release,%20Documentation%20and%20Publish/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
+   :target: https://github.com/VHDL/pyVHDLModel/actions/workflows/Pipeline.yml
+.. |SHIELD:png:pyVHDLModel-gha-test| image:: https://raster.shields.io/github/workflow/status/vhdl/pyVHDLModel/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
    :alt: GitHub Workflow - Build and Test Status
    :height: 22
-   :target: https://github.com/vhdl/pyVHDLModel/actions?query=workflow%3A%22Test+and+Coverage%22
+   :target: https://github.com/VHDL/pyVHDLModel/actions/workflows/Pipeline.yml
 
 .. # Codacy - quality
 .. |SHIELD:svg:pyVHDLModel-codacy-quality| image:: https://img.shields.io/codacy/grade/2286426d2b11417e90010427b7fed8e7?longCache=true&style=flat-square&logo=codacy
@@ -102,16 +102,6 @@
    :alt: Libraries.io SourceRank
    :height: 22
    :target: https://libraries.io/github/vhdl/pyVHDLModel/sourcerank
-
-.. # GHA release
-.. |SHIELD:svg:pyVHDLModel-gha-release| image:: https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Release?longCache=true&style=flat-square&label=release&logo=GitHub%20Actions&logoColor=FFFFFF
-   :alt: GitHub Workflow - Release Status
-   :height: 22
-   :target: https://github.com/vhdl/pyVHDLModel/actions?query=workflow%3A%22Release%22
-.. |SHIELD:png:pyVHDLModel-gha-release| image:: https://img.shields.io/github/workflow/status/vhdl/pyVHDLModel/Release?longCache=true&style=flat-square&label=release&logo=GitHub%20Actions&logoColor=FFFFFF
-   :alt: GitHub Workflow - Release Status
-   :height: 22
-   :target: https://github.com/vhdl/pyVHDLModel/actions?query=workflow%3A%22Release%22
 
 .. # PyPI tag
 .. |SHIELD:svg:pyVHDLModel-pypi-tag| image:: https://img.shields.io/pypi/v/pyVHDLModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072


### PR DESCRIPTION
This PR changes the Pipeline name from a large list of words to just `Pipeline`. That allows simplifying the shields. At the same time, the target of CI shields is updated to use `...actions/workflows/Pipeline.yml` instead of a query argument. By the way, a redundant shield is removed from `doc/shields.inc`.