### PR TITLE
v0.18.0

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,7 +12,6 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: pyVHDLModel
-      disable_list: "windows:3.11"
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev

--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -55,7 +55,7 @@ the mandatory dependencies too.
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `pytest-cov <https://GitHub.com/pytest-dev/pytest-cov>`__ | ≥4.0.0      | `MIT <https://GitHub.com/pytest-dev/pytest-cov/blob/master/LICENSE>`__                 | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
-| `Coverage <https://GitHub.com/nedbat/coveragepy>`__       | ≥6.5        | `Apache License, 2.0 <https://GitHub.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__ | *Not yet evaluated.* |
+| `Coverage <https://GitHub.com/nedbat/coveragepy>`__       | ≥7.0        | `Apache License, 2.0 <https://GitHub.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__ | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `mypy <https://GitHub.com/python/mypy>`__                 | ≥0.990      | `MIT <https://GitHub.com/python/mypy/blob/master/LICENSE>`__                           | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,11 +1,20 @@
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
 BUILDDIR      = _build
 
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees -T -D language=en $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-%:
-	$(SPHINXBUILD) -b $@ $(ALLSPHINXOPTS) $(BUILDDIR)/$@
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -41,7 +41,7 @@ from typing               import List, Tuple, Union, Dict, Iterator, Optional as
 from pyTooling.Decorators import export
 
 from pyVHDLModel import ModelEntity, NamedEntityMixin, MultipleNamedEntityMixin, LabeledEntityMixin, PossibleReference, Direction, EntityClass, Mode, \
-	DocumentedEntityMixin, DesignUnit
+	DocumentedEntityMixin, DesignUnit, LibraryClause, UseClause, Name, Symbol
 from pyVHDLModel          import PrimaryUnit, SecondaryUnit
 from pyVHDLModel          import ExpressionUnion, ConstraintUnion, ContextUnion, SubtypeOrSymbol, DesignUnitWithContextMixin, PackageOrSymbol
 from pyVHDLModel.PSLModel import VerificationUnit, VerificationProperty, VerificationMode
@@ -51,40 +51,6 @@ try:
 except ImportError:
 	class Protocol:
 		pass
-
-
-@export
-class Name(ModelEntity):
-	"""``Name`` is the base-class for all *names* in the VHDL language model."""
-
-	_identifier: str
-	_root: Nullable['Name']
-	_prefix: Nullable['Name']
-
-	def __init__(self, identifier: str, prefix: 'Name' = None):
-		self._identifier = identifier
-		if prefix is None:
-			self._prefix = self
-			self._root = None
-		else:
-			self._prefix = prefix
-			self._root = prefix._root
-
-	@property
-	def Identifier(self) -> str:
-		return self._identifier
-
-	@property
-	def Root(self) -> 'Name':
-		return self._root
-
-	@property
-	def Prefix(self) -> Nullable['Name']:
-		return self._prefix
-
-	@property
-	def Has_Prefix(self) -> bool:
-		return self._prefix is not None
 
 
 @export
@@ -157,40 +123,6 @@ class OpenName(Name):
 
 	def __str__(self):
 		return "open"
-
-
-@export
-class Symbol(ModelEntity):
-	_symbolName: Name
-	_possibleReferences: PossibleReference
-	_reference: Any
-
-	def __init__(self, symbolName: Name, possibleReferences: PossibleReference):
-		super().__init__()
-
-		self._symbolName = symbolName
-		self._possibleReferences = possibleReferences
-		self._reference = None
-
-	@property
-	def SymbolName(self) -> Name:
-		return self._symbolName
-
-	@property
-	def Reference(self) -> Any:
-		return self._reference
-
-	@property
-	def IsResolved(self) -> bool:
-		return self._reference is not None
-
-	def __bool__(self) -> bool:
-		return self._reference is not None
-
-	def __str__(self) -> str:
-		if self._reference is not None:
-			return str(self._reference)
-		return str(self._symbolName)
 
 
 @export
@@ -2161,35 +2093,6 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItem):
 	def __init__(self, identifiers: Iterable[str], subtype: SubtypeOrSymbol, documentation: str = None):
 		super().__init__(identifiers, subtype, documentation)
 		ParameterInterfaceItem.__init__(self)
-
-
-@export
-class Reference(ModelEntity):
-	_names:       List[Name]
-
-	def __init__(self, names: Iterable[Name]):
-		super().__init__()
-
-		self._names = [n for n in names]
-
-	@property
-	def Names(self) -> List[Name]:
-		return self._names
-
-
-@export
-class LibraryClause(Reference):
-	pass
-
-
-@export
-class UseClause(Reference):
-	pass
-
-
-@export
-class ContextReference(Reference):
-	pass
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -211,7 +211,12 @@ class LibrarySymbol(Symbol):
 
 @export
 class EntitySymbol(Symbol):
-	def __init__(self, entityName: Name):
+	"""An entity reference in an architecture declaration."""
+
+	def __init__(self, entityName: SimpleName):
+		if not isinstance(entityName, SimpleName):
+			raise TypeError(f"Parameter 'entityName' is not of type 'SimpleName'.")
+
 		super().__init__(entityName, PossibleReference.Entity)
 
 	@property
@@ -225,8 +230,11 @@ class EntitySymbol(Symbol):
 
 @export
 class ArchitectureSymbol(Symbol):
-	def __init__(self, symbolName: Name):
-		super().__init__(symbolName, PossibleReference.Architecture)
+	def __init__(self, architectureName: SimpleName):
+		if not isinstance(architectureName, SimpleName):
+			raise TypeError(f"Parameter 'architectureName' is not of type 'SimpleName'.")
+
+		super().__init__(architectureName, PossibleReference.Architecture)
 
 	@property
 	def Architecture(self) -> 'Architecture':

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -466,30 +466,55 @@ class Design(ModelEntity):
 		self._documents.append(document)
 		document._parent = self
 
-		for entity in document._entities:
+		for entityName, entity in document._entities.items():
+			if entityName in library._entities:
+				raise ValueError(f"Entity '{entityName}' already exists in library '{library.Identifier}'.")
+
+			library._entities[entityName] = entity
 			entity.Library = library
-			library._entities.append(entity)
 
-		for architecture in document.Architectures:
-			architecture.Library = library
+		for entityName, architectures in document._architectures.items():
 			try:
-				library.Architectures[architecture.Entity.SymbolName].append(architecture)
+				architecturesPerEntity = library._architectures[entityName]
+				for architectureName, architecture in document._architectures.items():
+					if architectureName in architecturesPerEntity:
+						raise ValueError(f"Architecture '{architectureName}' for entity '{entityName}' already exists in library '{library.Identifier}'.")
+
+					architecturesPerEntity[architectureName] = architecture
+					architecture.Library = library
 			except KeyError:
-				library.Architectures[architecture.Entity.SymbolName] = [architecture]
+				architecturesPerEntity = document._architectures[entityName].copy()
+				library._architectures[entityName] = architecturesPerEntity
 
-		for package in document.Packages:
+				for architecture in architecturesPerEntity.values():
+					architecture.Library = library
+
+		for packageName, package in document._packages.items():
+			if packageName in library._packages:
+				raise ValueError(f"Package '{packageName}' already exists in library '{library.Identifier}'.")
+
+			library._packages[packageName] = package
 			package.Library = library
-			library.Packages.append(package)
 
-		for packageBody in document.PackageBodies:
+		for packageBodyName, packageBody in document._packageBodies.items():
+			if packageBodyName in library._packageBodies:
+				raise ValueError(f"Package body '{packageBodyName}' already exists in library '{library.Identifier}'.")
+
+			library._packageBodies[packageBodyName] = packageBody
 			packageBody.Library = library
-			library.PackageBodies.append(packageBody)
 
-		for configuration in document.Configurations:
+		for configurationName, configuration in document._configurations.items():
+			if configurationName in library._configurations:
+				raise ValueError(f"Configuration '{configurationName}' already exists in library '{library.Identifier}'.")
+
+			library._configurations[configurationName] = configuration
 			configuration.Library = library
-			library.Configurations.append(configuration)
 
-		for context in document.Contexts:
+		for contextName, context in document._contexts.items():
+			if contextName in library._contexts:
+				raise ValueError(f"Context '{contextName}' already exists in library '{library.Identifier}'.")
+
+			library._contexts[contextName] = context
 			context.Library = library
 			library.Contexts.append(context)
 

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -519,6 +519,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 	"""A ``Document`` represents a sourcefile. It contains primary and secondary design units."""
 
 	_path:                   Path                          #: path to the document. ``None`` if virtual document.
+	_designUnits:            List['DesignUnit']            #: List of all design units defined in a document.
 	_contexts:               List['Context']               #: List of all contexts defined in a document.
 	_configurations:         List['Configuration']         #: List of all configurations defined in a document.
 	_entities:               List['Entity']                #: List of all entities defined in a document.
@@ -534,7 +535,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		DocumentedEntityMixin.__init__(self, documentation)
 
 		self._path =                   path
-		self._designUnit =             []
+		self._designUnits =            []
 		self._contexts =               []
 		self._configurations =         []
 		self._entities =               []
@@ -550,7 +551,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._entities.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 
@@ -559,15 +560,15 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._architectures.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddPackage(self, item: 'Package'):
-		if not isinstance(item, Package):
+		if not isinstance(item, (Package, PackageInstantiation)):
 			raise TypeError()
 
 		self._packages.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddPackageBody(self, item: 'PackageBody'):
@@ -575,7 +576,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._packageBodies.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddContext(self, item: 'Context'):
@@ -583,7 +584,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._contexts.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddConfiguration(self, item: 'Configuration'):
@@ -591,7 +592,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._configurations.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddVerificationUnit(self, item: VerificationUnit):
@@ -599,7 +600,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._verificationUnits.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddVerificationProperty(self, item: VerificationProperty):
@@ -607,7 +608,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._verificationProperties.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddVerificationMode(self, item: VerificationMode):
@@ -615,7 +616,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError()
 
 		self._verificationModes.append(item)
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddDesignUnit(self, item: DesignUnit):
@@ -640,12 +641,17 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		else:
 			raise TypeError()
 
-		self._items.append(item)
+		self._designUnits.append(item)
 		item.Document = self
 
 	@property
 	def Path(self) -> Path:
 		return self._path
+
+	@property
+	def DesignUnits(self) -> List['DesignUnit']:
+		"""Returns a list of all design units declarations found in this document."""
+		return self._designUnits
 
 	@property
 	def Contexts(self) -> List['Context']:

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -246,6 +246,23 @@ class ArchitectureSymbol(Symbol):
 
 
 @export
+class PackageSymbol(Symbol):
+	def __init__(self, packageName: SimpleName):
+		if not isinstance(packageName, SimpleName):
+			raise TypeError(f"Parameter 'packageName' is not of type 'SimpleName'.")
+
+		super().__init__(packageName, PossibleReference.Package)
+
+	@property
+	def Package(self) -> 'Package':
+		return self._reference
+
+	@Package.setter
+	def Package(self, value: 'Package') -> None:
+		self._reference = value
+
+
+@export
 class ComponentSymbol(Symbol):
 	def __init__(self, symbolName: Name):
 		super().__init__(symbolName, PossibleReference.Component)

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -455,30 +455,11 @@ class Design(ModelEntity):
 
 	def LinkArchitectures(self):
 		for library in self._libraries.values():
-			for entityName, architecturesPerEntity in library._architectures.items():
-				if entityName not in library._entities:
-					architectureNames = "', '".join(architecturesPerEntity.keys())
-					raise Exception(f"Entity '{entityName}' referenced by architecture(s) '{architectureNames}' doesn't exist in library '{library.Identifier}'.")
-
-				for architecture in architecturesPerEntity.values():
-					# entitySymbolName = architecture.Entity.SymbolName
-					# if entitySymbolName.Identifier != entityName:
-					# 	raise Exception(f"Internal error. Dictionary key doesn't match objects name/identifier.")
-
-					entity = library._entities[entityName]
-					# if entity.Identifier != entityName:
-					# 	raise Exception(f"Internal error. Dictionary key doesn't match objects name/identifier.")
-
-					architecture.Entity.Entity = entity
+			library.LinkArchitectures()
 
 	def LinkPackageBodies(self):
 		for library in self._libraries.values():
-			for packageBodyName, packageBody in library._packageBodies.items():
-				if packageBodyName not in library._packages:
-					raise Exception(f"Package '{packageBodyName}' referenced by package body '{packageBodyName}' doesn't exist in library '{library.Identifier}'.")
-
-				package = library._packages[packageBodyName]
-				packageBody.Package.Package = package
+			library.LinkPackageBodies()
 
 
 @export
@@ -532,6 +513,31 @@ class Library(ModelEntity, NamedEntityMixin):
 	def PackageBodies(self) -> Dict[str, 'PackageBody']:
 		"""Returns a list of all package body declarations declared in this library."""
 		return self._packageBodies
+
+	def LinkArchitectures(self):
+		for entityName, architecturesPerEntity in self._architectures.items():
+			if entityName not in self._entities:
+				architectureNames = "', '".join(architecturesPerEntity.keys())
+				raise Exception(f"Entity '{entityName}' referenced by architecture(s) '{architectureNames}' doesn't exist in library '{self.Identifier}'.")
+
+			for architecture in architecturesPerEntity.values():
+				# entitySymbolName = architecture.Entity.SymbolName
+				# if entitySymbolName.Identifier != entityName:
+				# 	raise Exception(f"Internal error. Dictionary key doesn't match objects name/identifier.")
+
+				entity = self._entities[entityName]
+				# if entity.Identifier != entityName:
+				# 	raise Exception(f"Internal error. Dictionary key doesn't match objects name/identifier.")
+
+				architecture.Entity.Entity = entity
+
+	def LinkPackageBodies(self):
+		for packageBodyName, packageBody in self._packageBodies.items():
+			if packageBodyName not in self._packages:
+				raise Exception(f"Package '{packageBodyName}' referenced by package body '{packageBodyName}' doesn't exist in library '{self.Identifier}'.")
+
+			package = self._packages[packageBodyName]
+			packageBody.Package.Package = package
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -450,8 +450,20 @@ class Design(ModelEntity):
 			context.Library = library
 
 	def Analyze(self):
+		self.LinkLibraryReferences()
+		self.LinkPackageReferences()
+		self.LinkContextReferences()
 		self.LinkArchitectures()
 		self.LinkPackageBodies()
+
+	def LinkLibraryReferences(self):
+		pass
+
+	def LinkPackageReferences(self):
+		pass
+
+	def LinkContextReferences(self):
+		pass
 
 	def LinkArchitectures(self):
 		for library in self._libraries.values():

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -435,6 +435,25 @@ class Design(ModelEntity):
 		"""Returns a list of all documents (files) loaded for this design."""
 		return self._documents
 
+	def _LoadLibrary(self, library):
+		identifier = library.Identifier.lower()
+		if identifier in self._libraries:
+			raise Exception(f"Library '{library.Identifier}' already exists in design.")
+		self._libraries[identifier] = library
+		library._parent = self
+
+	def LoadStdLibrary(self):
+		from pyVHDLModel.std import Std
+
+		library = Std()
+		self._LoadLibrary(library)
+
+	def LoadIEEELibrary(self):
+		from pyVHDLModel.ieee import Ieee
+
+		library = Ieee()
+		self._LoadLibrary(library)
+
 	def GetLibrary(self, libraryName: str) -> 'Library':
 		try:
 			return self._libraries[libraryName]

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -516,7 +516,37 @@ class Design(ModelEntity):
 
 			library._contexts[contextName] = context
 			context.Library = library
-			library.Contexts.append(context)
+
+	def Analyze(self):
+		self.LinkArchitectures()
+		self.LinkPackageBodies()
+
+	def LinkArchitectures(self):
+		for library in self._libraries.values():
+			for entityName, architecturesPerEntity in library._architectures.items():
+				if entityName not in library._entities:
+					architectureNames = "', '".join(architecturesPerEntity.keys())
+					raise Exception(f"Entity '{entityName}' referenced by architecture(s) '{architectureNames}' doesn't exist in library '{library.Identifier}'.")
+
+				for architecture in architecturesPerEntity.values():
+					# entitySymbolName = architecture.Entity.SymbolName
+					# if entitySymbolName.Identifier != entityName:
+					# 	raise Exception(f"Internal error. Dictionary key doesn't match objects name/identifier.")
+
+					entity = library._entities[entityName]
+					# if entity.Identifier != entityName:
+					# 	raise Exception(f"Internal error. Dictionary key doesn't match objects name/identifier.")
+
+					architecture.Entity.Entity = entity
+
+	def LinkPackageBodies(self):
+		for library in self._libraries.values():
+			for packageBodyName, packageBody in library._packageBodies.items():
+				if packageBodyName not in library._packages:
+					raise Exception(f"Package '{packageBodyName}' referenced by package body '{packageBodyName}' doesn't exist in library '{library.Identifier}'.")
+
+				package = library._packages[packageBodyName]
+				packageBody.Package.Package = package
 
 
 @export

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -170,6 +170,7 @@ class Symbol(ModelEntity):
 
 		self._symbolName = symbolName
 		self._possibleReferences = possibleReferences
+		self._reference = None
 
 	@property
 	def SymbolName(self) -> Name:
@@ -178,6 +179,13 @@ class Symbol(ModelEntity):
 	@property
 	def Reference(self) -> Any:
 		return self._reference
+
+	@property
+	def IsResolved(self) -> bool:
+		return self._reference is not None
+
+	def __bool__(self) -> bool:
+		return self._reference is not None
 
 	def __str__(self) -> str:
 		if self._reference is not None:

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -163,7 +163,7 @@ class OpenName(Name):
 class Symbol(ModelEntity):
 	_symbolName: Name
 	_possibleReferences: PossibleReference
-	_reference: Any = None
+	_reference: Any
 
 	def __init__(self, symbolName: Name, possibleReferences: PossibleReference):
 		super().__init__()
@@ -553,51 +553,51 @@ class Design(ModelEntity):
 class Library(ModelEntity, NamedEntityMixin):
 	"""A ``Library`` represents a VHDL library. It contains all *primary* design units."""
 
-	_contexts:       List['Context']                     #: List of all contexts defined in a library.
-	_configurations: List['Configuration']               #: List of all configurations defined in a library.
-	_entities:       List['Entity']                      #: List of all entities defined in a library.
-	_architectures:  Dict['Name', List['Architecture']]  #: Dictionary of all architectures defined in a library.
-	_packages:       List['Package']                     #: List of all packages defined in a library.
-	_packageBodies:  List['PackageBody']                 #: List of all package bodies defined in a library.
+	_contexts:       Dict[str, 'Context']                  #: Dictionary of all contexts defined in a library.
+	_configurations: Dict[str, 'Configuration']            #: Dictionary of all configurations defined in a library.
+	_entities:       Dict[str, 'Entity']                   #: Dictionary of all entities defined in a library.
+	_architectures:  Dict[str, Dict[str, 'Architecture']]  #: Dictionary of all architectures defined in a library.
+	_packages:       Dict[str, 'Package']                  #: Dictionary of all packages defined in a library.
+	_packageBodies:  Dict[str, 'PackageBody']              #: Dictionary of all package bodies defined in a library.
 
 	def __init__(self, identifier: str):
 		super().__init__()
 		NamedEntityMixin.__init__(self, identifier)
 
-		self._contexts =        []
-		self._configurations =  []
-		self._entities =        []
+		self._contexts =        {}
+		self._configurations =  {}
+		self._entities =        {}
 		self._architectures =   {}
-		self._packages =        []
-		self._packageBodies =   []
+		self._packages =        {}
+		self._packageBodies =   {}
 
 	@property
-	def Contexts(self) -> List['Context']:
+	def Contexts(self) -> Dict[str, 'Context']:
 		"""Returns a list of all context declarations declared in this library."""
 		return self._contexts
 
 	@property
-	def Configurations(self) -> List['Configuration']:
+	def Configurations(self) -> Dict[str, 'Configuration']:
 		"""Returns a list of all configuration declarations declared in this library."""
 		return self._configurations
 
 	@property
-	def Entities(self) -> List['Entity']:
+	def Entities(self) -> Dict[str, 'Entity']:
 		"""Returns a list of all entity declarations declared in this library."""
 		return self._entities
 
 	@property
-	def Architectures(self) -> Dict['Name', List['Architecture']]:
+	def Architectures(self) -> Dict[str, Dict[str, 'Architecture']]:
 		"""Returns a list of all architectures declarations declared in this library."""
 		return self._architectures
 
 	@property
-	def Packages(self) -> List['Package']:
+	def Packages(self) -> Dict[str, 'Package']:
 		"""Returns a list of all package declarations declared in this library."""
 		return self._packages
 
 	@property
-	def PackageBodies(self) -> List['PackageBody']:
+	def PackageBodies(self) -> Dict[str, 'PackageBody']:
 		"""Returns a list of all package body declarations declared in this library."""
 		return self._packageBodies
 
@@ -606,17 +606,17 @@ class Library(ModelEntity, NamedEntityMixin):
 class Document(ModelEntity, DocumentedEntityMixin):
 	"""A ``Document`` represents a sourcefile. It contains primary and secondary design units."""
 
-	_path:                   Path                          #: path to the document. ``None`` if virtual document.
-	_designUnits:            List['DesignUnit']            #: List of all design units defined in a document.
-	_contexts:               List['Context']               #: List of all contexts defined in a document.
-	_configurations:         List['Configuration']         #: List of all configurations defined in a document.
-	_entities:               List['Entity']                #: List of all entities defined in a document.
-	_architectures:          List['Architecture']          #: List of all architectures defined in a document.
-	_packages:               List['Package']               #: List of all packages defined in a document.
-	_packageBodies:          List['PackageBody']           #: List of all package bodies defined in a document.
-	_verificationUnits:      List['VerificationUnit']      #: List of all PSL verification units defined in a document.
-	_verificationProperties: List['VerificationProperty']  #: List of all PSL verification properties defined in a document.
-	_verificationModes:      List['VerificationMode']      #: List of all PSL verification modes defined in a document.
+	_path:                   Path                                  #: path to the document. ``None`` if virtual document.
+	_designUnits:            List['DesignUnit']                    #: List of all design units defined in a document.
+	_contexts:               Dict[str, 'Context']                  #: Dictionary of all contexts defined in a document.
+	_configurations:         Dict[str, 'Configuration']            #: Dictionary of all configurations defined in a document.
+	_entities:               Dict[str, 'Entity']                   #: Dictionary of all entities defined in a document.
+	_architectures:          Dict[str, Dict[str, 'Architecture']]  #: Dictionary of all architectures defined in a document.
+	_packages:               Dict[str, 'Package']                  #: Dictionary of all packages defined in a document.
+	_packageBodies:          Dict[str, 'PackageBody']              #: Dictionary of all package bodies defined in a document.
+	_verificationUnits:      Dict[str, 'VerificationUnit']         #: Dictionary of all PSL verification units defined in a document.
+	_verificationProperties: Dict[str, 'VerificationProperty']     #: Dictionary of all PSL verification properties defined in a document.
+	_verificationModes:      Dict[str, 'VerificationMode']         #: Dictionary of all PSL verification modes defined in a document.
 
 	def __init__(self, path: Path, documentation: str = None):
 		super().__init__()
@@ -624,110 +624,153 @@ class Document(ModelEntity, DocumentedEntityMixin):
 
 		self._path =                   path
 		self._designUnits =            []
-		self._contexts =               []
-		self._configurations =         []
-		self._entities =               []
-		self._architectures =          []
-		self._packages =               []
-		self._packageBodies =          []
-		self._verificationUnits =      []
-		self._verificationProperties = []
-		self._verificationModes =      []
+		self._contexts =               {}
+		self._configurations =         {}
+		self._entities =               {}
+		self._architectures =          {}
+		self._packages =               {}
+		self._packageBodies =          {}
+		self._verificationUnits =      {}
+		self._verificationProperties = {}
+		self._verificationModes =      {}
 
 	def _AddEntity(self, item: 'Entity'):
 		if not isinstance(item, Entity):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'Entity'.")
 
-		self._entities.append(item)
+		if item.Identifier in self._entities:
+			raise ValueError(f"An entity '{item.Identifier}' already exists in this document.")
+
+		self._entities[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 
 	def _AddArchitecture(self, item: 'Architecture'):
 		if not isinstance(item, Architecture):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'Architecture'.")
 
-		self._architectures.append(item)
+		entityName = item.Entity.SymbolName.Identifier
+		try:
+			architectures = self._architectures[entityName]
+			if item.Identifier in architectures:
+				raise ValueError(f"An architecture '{item.Identifier}' for entity '{entityName}' already exists in this document.")
+
+			architectures[item.Identifier] = item
+		except KeyError:
+			self._architectures[entityName] = {item.Identifier: item}
+
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddPackage(self, item: 'Package'):
 		if not isinstance(item, (Package, PackageInstantiation)):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'Package' or 'PackageInstantiation'.")
 
-		self._packages.append(item)
+		if item.Identifier in self._packages:
+			raise ValueError(f"A package '{item.Identifier}' already exists in this document.")
+
+		self._packages[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddPackageBody(self, item: 'PackageBody'):
 		if not isinstance(item, PackageBody):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'PackageBody'.")
 
-		self._packageBodies.append(item)
+		if item.Identifier in self._packageBodies:
+			raise ValueError(f"A package body '{item.Identifier}' already exists in this document.")
+
+		self._packageBodies[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddContext(self, item: 'Context'):
 		if not isinstance(item, Context):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'Context'.")
 
-		self._contexts.append(item)
+		if item.Identifier in self._contexts:
+			raise ValueError(f"A context '{item.Identifier}' already exists in this document.")
+
+		self._contexts[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddConfiguration(self, item: 'Configuration'):
 		if not isinstance(item, Configuration):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'Configuration'.")
 
-		self._configurations.append(item)
+		if item.Identifier in self._configurations:
+			raise ValueError(f"A configuration '{item.Identifier}' already exists in this document.")
+
+		self._configurations[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddVerificationUnit(self, item: VerificationUnit):
 		if not isinstance(item, VerificationUnit):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'VerificationUnit'.")
 
-		self._verificationUnits.append(item)
+		if item.Identifier in self._verificationUnits:
+			raise ValueError(f"A verification unit '{item.Identifier}' already exists in this document.")
+
+		self._verificationUnits[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddVerificationProperty(self, item: VerificationProperty):
 		if not isinstance(item, VerificationProperty):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'VerificationProperty'.")
 
-		self._verificationProperties.append(item)
+		if item.Identifier in self._verificationProperties:
+			raise ValueError(f"A verification property '{item.Identifier}' already exists in this document.")
+
+		self._verificationProperties[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddVerificationMode(self, item: VerificationMode):
 		if not isinstance(item, VerificationMode):
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'VerificationMode'.")
 
-		self._verificationModes.append(item)
+		if item.Identifier in self._verificationModes:
+			raise ValueError(f"A verification mode '{item.Identifier}' already exists in this document.")
+
+		self._verificationModes[item.Identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddDesignUnit(self, item: DesignUnit):
 		if isinstance(item, Entity):
-			self._entities.append(item)
+			self._entities[item.Identifier] = item
 		elif isinstance(item, Architecture):
-			self._architectures.append(item)
+			entityName = item.Entity.SymbolName.Identifier
+			try:
+				architectures = self._architectures[entityName]
+				if item.Identifier in architectures:
+					raise ValueError(f"An architecture '{item.Identifier}' for entity '{entityName}' already exists in this document.")
+
+				architectures[item.Identifier] = item
+			except KeyError:
+				self._architectures[entityName] = {item.Identifier: item}
 		elif isinstance(item, Package):
-			self._packages.append(item)
+			self._packages[item.Identifier] = item
 		elif isinstance(item, PackageBody):
-			self._packageBodies.append(item)
+			self._packageBodies[item.Identifier] = item
 		elif isinstance(item, Context):
-			self._contexts.append(item)
+			self._contexts[item.Identifier] = item
 		elif isinstance(item, Configuration):
-			self._configurations.append(item)
+			self._configurations[item.Identifier] = item
 		elif isinstance(item, VerificationUnit):
-			self._verificationUnits.append(item)
+			self._verificationUnits[item.Identifier] = item
 		elif isinstance(item, VerificationProperty):
-			self._verificationProperties.append(item)
+			self._verificationProperties[item.Identifier] = item
 		elif isinstance(item, VerificationMode):
-			self._verificationModes.append(item)
+			self._verificationModes[item.Identifier] = item
+		elif isinstance(item, DesignUnit):
+			raise TypeError(f"Parameter 'item' is an unknown 'DesignUnit'.")
 		else:
-			raise TypeError()
+			raise TypeError(f"Parameter 'item' is not of type 'DesignUnit'.")
 
 		self._designUnits.append(item)
 		item.Document = self
@@ -742,47 +785,47 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		return self._designUnits
 
 	@property
-	def Contexts(self) -> List['Context']:
+	def Contexts(self) -> Dict[str, 'Context']:
 		"""Returns a list of all context declarations found in this document."""
 		return self._contexts
 
 	@property
-	def Configurations(self) -> List['Configuration']:
+	def Configurations(self) -> Dict[str, 'Configuration']:
 		"""Returns a list of all configuration declarations found in this document."""
 		return self._configurations
 
 	@property
-	def Entities(self) -> List['Entity']:
+	def Entities(self) -> Dict[str, 'Entity']:
 		"""Returns a list of all entity declarations found in this document."""
 		return self._entities
 
 	@property
-	def Architectures(self) -> List['Architecture']:
+	def Architectures(self) -> Dict[str, Dict[str, 'Architecture']]:
 		"""Returns a list of all architecture declarations found in this document."""
 		return self._architectures
 
 	@property
-	def Packages(self) -> List['Package']:
+	def Packages(self) -> Dict[str, 'Package']:
 		"""Returns a list of all package declarations found in this document."""
 		return self._packages
 
 	@property
-	def PackageBodies(self) -> List['PackageBody']:
+	def PackageBodies(self) -> Dict[str, 'PackageBody']:
 		"""Returns a list of all package body declarations found in this document."""
 		return self._packageBodies
 
 	@property
-	def VerificationUnits(self) -> List['VerificationUnit']:
+	def VerificationUnits(self) -> Dict[str, 'VerificationUnit']:
 		"""Returns a list of all verification unit declarations found in this document."""
 		return self._verificationUnits
 
 	@property
-	def VerificationProperties(self) -> List['VerificationProperty']:
+	def VerificationProperties(self) -> Dict[str, 'VerificationProperty']:
 		"""Returns a list of all verification property declarations found in this document."""
 		return self._verificationProperties
 
 	@property
-	def VerificationModes(self) -> List['VerificationMode']:
+	def VerificationModes(self) -> Dict[str, 'VerificationMode']:
 		"""Returns a list of all verification mode declarations found in this document."""
 		return self._verificationModes
 

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -126,18 +126,72 @@ class OpenName(Name):
 
 
 @export
-class LibrarySymbol(Symbol):
-	_library: 'Library'
+class LibraryReferenceSymbol(Symbol):
+	"""A library reference in a library clause."""
 
-	def __init__(self, symbolName: Name):
-		super().__init__(symbolName, PossibleReference.Library)
+	def __init__(self, libraryName: SimpleName):
+		if not isinstance(libraryName, SimpleName):
+			raise TypeError(f"Parameter 'libraryName' is not of type 'SimpleName'.")
+		super().__init__(libraryName, PossibleReference.Library)
 
 	@property
 	def Library(self) -> 'Library':
-		return self._library
+		return self._reference
 
 	@Library.setter
 	def Library(self, value: 'Library') -> None:
+		self._reference = value
+
+
+@export
+class PackageReferenceSymbol(Symbol):
+	"""A package reference in a use clause."""
+
+	def __init__(self, packageName: SelectedName):
+		if not isinstance(packageName, (SelectedName, AllName)):
+			raise TypeError(f"Parameter 'packageName' is not of type 'SelectedName' or 'AllName'.")
+		super().__init__(packageName, PossibleReference.Package)
+
+	@property
+	def Library(self) -> 'Library':
+		return self._reference
+
+	@Library.setter
+	def Library(self, value: 'Library') -> None:
+		self._reference = value
+
+	@property
+	def Package(self) -> 'Package':
+		return self._reference
+
+	@Package.setter
+	def Package(self, value: 'Package') -> None:
+		self._reference = value
+
+
+@export
+class ContextReferenceSymbol(Symbol):
+	"""A context reference in a use clause."""
+
+	def __init__(self, contextName: SelectedName):
+		if not isinstance(contextName, SelectedName):
+			raise TypeError(f"Parameter 'contextName' is not of type 'SelectedName'.")
+		super().__init__(contextName, PossibleReference.Context)
+
+	@property
+	def Library(self) -> 'Library':
+		return self._reference
+
+	@Library.setter
+	def Library(self, value: 'Library') -> None:
+		self._reference = value
+
+	@property
+	def Context(self) -> 'Context':
+		return self._reference
+
+	@Context.setter
+	def Context(self, value: 'Context') -> None:
 		self._reference = value
 
 
@@ -148,7 +202,6 @@ class EntitySymbol(Symbol):
 	def __init__(self, entityName: SimpleName):
 		if not isinstance(entityName, SimpleName):
 			raise TypeError(f"Parameter 'entityName' is not of type 'SimpleName'.")
-
 		super().__init__(entityName, PossibleReference.Entity)
 
 	@property
@@ -165,7 +218,6 @@ class ArchitectureSymbol(Symbol):
 	def __init__(self, architectureName: SimpleName):
 		if not isinstance(architectureName, SimpleName):
 			raise TypeError(f"Parameter 'architectureName' is not of type 'SimpleName'.")
-
 		super().__init__(architectureName, PossibleReference.Architecture)
 
 	@property
@@ -182,7 +234,6 @@ class PackageSymbol(Symbol):
 	def __init__(self, packageName: SimpleName):
 		if not isinstance(packageName, SimpleName):
 			raise TypeError(f"Parameter 'packageName' is not of type 'SimpleName'.")
-
 		super().__init__(packageName, PossibleReference.Package)
 
 	@property

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2267,11 +2267,11 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin):
 	_declaredItems: List   # FIXME: define list prefix type e.g. via Union
 	_statements:    List['ConcurrentStatement']
 
-	def __init__(self, identifier: str, entity: Name, contextItems: Iterable[Context] = None, declaredItems: Iterable = None, statements: Iterable['ConcurrentStatement'] = None, documentation: str = None):
+	def __init__(self, identifier: str, entity: EntitySymbol, contextItems: Iterable[Context] = None, declaredItems: Iterable = None, statements: Iterable['ConcurrentStatement'] = None, documentation: str = None):
 		super().__init__(identifier, documentation)
 		DesignUnitWithContextMixin.__init__(self, contextItems)
 
-		self._entity        = EntitySymbol(entity)
+		self._entity        = entity
 		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
 		self._statements    = [] if statements is None else [s for s in statements]
 
@@ -2412,17 +2412,18 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin):
 
 @export
 class PackageBody(SecondaryUnit, DesignUnitWithContextMixin):
-	_package:           Package
+	_package:           PackageSymbol
 	_declaredItems:     List
 
 	def __init__(self, identifier: str, contextItems: Iterable[Context] = None, declaredItems: Iterable = None, documentation: str = None):
 		super().__init__(identifier, documentation)
 		DesignUnitWithContextMixin.__init__(self, contextItems)
 
+		self._package = PackageSymbol(SimpleName(identifier))
 		self._declaredItems = [] if declaredItems is None else [i for i in declaredItems]
 
 	@property
-	def Package(self) -> Package:
+	def Package(self) -> PackageSymbol:
 		return self._package
 
 	@property

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -436,14 +436,13 @@ class Design(ModelEntity):
 		return self._documents
 
 	def GetLibrary(self, libraryName: str) -> 'Library':
-		if libraryName not in self._libraries:
+		try:
+			return self._libraries[libraryName]
+		except KeyError:
 			lib = Library(libraryName)
-			self._libraries[libraryName] = lib
+			self._libraries[libraryName.lower()] = lib
 			lib._parent = self
-		else:
-			lib = self._libraries[libraryName]
-
-		return lib
+			return lib
 
 	def AddDocument(self, document: 'Document', library: 'Library') -> None:
 		self._documents.append(document)

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -657,10 +657,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, Entity):
 			raise TypeError(f"Parameter 'item' is not of type 'Entity'.")
 
-		if item.Identifier in self._entities:
+		identifier = item.Identifier.lower()
+		if identifier in self._entities:
 			raise ValueError(f"An entity '{item.Identifier}' already exists in this document.")
 
-		self._entities[item.Identifier] = item
+		self._entities[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -670,14 +671,15 @@ class Document(ModelEntity, DocumentedEntityMixin):
 			raise TypeError(f"Parameter 'item' is not of type 'Architecture'.")
 
 		entityName = item.Entity.SymbolName.Identifier
+		identifier = entityName.lower()
 		try:
-			architectures = self._architectures[entityName]
+			architectures = self._architectures[identifier]
 			if item.Identifier in architectures:
 				raise ValueError(f"An architecture '{item.Identifier}' for entity '{entityName}' already exists in this document.")
 
 			architectures[item.Identifier] = item
 		except KeyError:
-			self._architectures[entityName] = {item.Identifier: item}
+			self._architectures[identifier] = {item.Identifier: item}
 
 		self._designUnits.append(item)
 		item.Document = self
@@ -686,10 +688,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, (Package, PackageInstantiation)):
 			raise TypeError(f"Parameter 'item' is not of type 'Package' or 'PackageInstantiation'.")
 
-		if item.Identifier in self._packages:
+		identifier = item.Identifier.lower()
+		if identifier in self._packages:
 			raise ValueError(f"A package '{item.Identifier}' already exists in this document.")
 
-		self._packages[item.Identifier] = item
+		self._packages[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -697,10 +700,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, PackageBody):
 			raise TypeError(f"Parameter 'item' is not of type 'PackageBody'.")
 
-		if item.Identifier in self._packageBodies:
+		identifier = item.Identifier.lower()
+		if identifier in self._packageBodies:
 			raise ValueError(f"A package body '{item.Identifier}' already exists in this document.")
 
-		self._packageBodies[item.Identifier] = item
+		self._packageBodies[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -708,10 +712,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, Context):
 			raise TypeError(f"Parameter 'item' is not of type 'Context'.")
 
-		if item.Identifier in self._contexts:
+		identifier = item.Identifier.lower()
+		if identifier in self._contexts:
 			raise ValueError(f"A context '{item.Identifier}' already exists in this document.")
 
-		self._contexts[item.Identifier] = item
+		self._contexts[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -719,10 +724,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, Configuration):
 			raise TypeError(f"Parameter 'item' is not of type 'Configuration'.")
 
-		if item.Identifier in self._configurations:
+		identifier = item.Identifier.lower()
+		if identifier in self._configurations:
 			raise ValueError(f"A configuration '{item.Identifier}' already exists in this document.")
 
-		self._configurations[item.Identifier] = item
+		self._configurations[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -730,10 +736,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, VerificationUnit):
 			raise TypeError(f"Parameter 'item' is not of type 'VerificationUnit'.")
 
-		if item.Identifier in self._verificationUnits:
+		identifier = item.Identifier.lower()
+		if identifier in self._verificationUnits:
 			raise ValueError(f"A verification unit '{item.Identifier}' already exists in this document.")
 
-		self._verificationUnits[item.Identifier] = item
+		self._verificationUnits[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -741,10 +748,11 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, VerificationProperty):
 			raise TypeError(f"Parameter 'item' is not of type 'VerificationProperty'.")
 
-		if item.Identifier in self._verificationProperties:
+		identifier = item.Identifier.lower()
+		if identifier in self._verificationProperties:
 			raise ValueError(f"A verification property '{item.Identifier}' already exists in this document.")
 
-		self._verificationProperties[item.Identifier] = item
+		self._verificationProperties[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
@@ -752,40 +760,43 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, VerificationMode):
 			raise TypeError(f"Parameter 'item' is not of type 'VerificationMode'.")
 
-		if item.Identifier in self._verificationModes:
+		identifier = item.Identifier.lower()
+		if identifier in self._verificationModes:
 			raise ValueError(f"A verification mode '{item.Identifier}' already exists in this document.")
 
-		self._verificationModes[item.Identifier] = item
+		self._verificationModes[identifier] = item
 		self._designUnits.append(item)
 		item.Document = self
 
 	def _AddDesignUnit(self, item: DesignUnit):
+		identifier = item.Identifier.lower()
 		if isinstance(item, Entity):
-			self._entities[item.Identifier] = item
+			self._entities[identifier] = item
 		elif isinstance(item, Architecture):
 			entityName = item.Entity.SymbolName.Identifier
+			entityIdentifier = entityName.lower()
 			try:
-				architectures = self._architectures[entityName]
-				if item.Identifier in architectures:
+				architectures = self._architectures[entityIdentifier]
+				if identifier in architectures:
 					raise ValueError(f"An architecture '{item.Identifier}' for entity '{entityName}' already exists in this document.")
 
-				architectures[item.Identifier] = item
+				architectures[identifier] = item
 			except KeyError:
-				self._architectures[entityName] = {item.Identifier: item}
+				self._architectures[entityIdentifier] = {identifier: item}
 		elif isinstance(item, Package):
-			self._packages[item.Identifier] = item
+			self._packages[identifier] = item
 		elif isinstance(item, PackageBody):
-			self._packageBodies[item.Identifier] = item
+			self._packageBodies[identifier] = item
 		elif isinstance(item, Context):
-			self._contexts[item.Identifier] = item
+			self._contexts[identifier] = item
 		elif isinstance(item, Configuration):
-			self._configurations[item.Identifier] = item
+			self._configurations[identifier] = item
 		elif isinstance(item, VerificationUnit):
-			self._verificationUnits[item.Identifier] = item
+			self._verificationUnits[identifier] = item
 		elif isinstance(item, VerificationProperty):
-			self._verificationProperties[item.Identifier] = item
+			self._verificationProperties[identifier] = item
 		elif isinstance(item, VerificationMode):
-			self._verificationModes[item.Identifier] = item
+			self._verificationModes[identifier] = item
 		elif isinstance(item, DesignUnit):
 			raise TypeError(f"Parameter 'item' is an unknown 'DesignUnit'.")
 		else:

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -526,7 +526,16 @@ class Design(ModelEntity):
 		self.LinkPackageBodies()
 
 	def LinkLibraryReferences(self):
-		pass
+		for library in self._libraries.values():
+			for entity in library._entities.values():  # TODO: provide an 'iterate design units' generator
+				for libraryReference in entity.LibraryReferences:
+					for symbol in libraryReference.Symbols:
+						try:
+							libraryName = symbol.SymbolName.Identifier
+							lib = self._libraries[libraryName.lower()]
+							symbol.Library = lib
+						except KeyError:
+							raise Exception(f"Library '{libraryName}' referenced by library clause of design unit '{entity.Identifier}' doesn't exist in design.")
 
 	def LinkPackageReferences(self):
 		pass

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -649,18 +649,28 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
 
+	@property
+	def Document(self) -> 'Document':
+		return self._parent
+
+	@Document.setter
+	def Document(self, document: 'Document') -> None:
+		self._parent = document
+
 
 @export
 class PrimaryUnit(DesignUnit):
 	"""A ``PrimaryUnit`` is a base-class for all primary units."""
 
+	_library: 'Library'
+
 	@property
 	def Library(self) -> 'Library':
-		return self._parent
+		return self._library
 
 	@Library.setter
 	def Library(self, library: 'Library') -> None:
-		self._parent = library
+		self._library = library
 
 
 @export

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -645,7 +645,7 @@ class Reference(ModelEntity):
 		self._symbols = [s for s in symbols]
 
 	@property
-	def Symbols(self) -> List[Name]:
+	def Symbols(self) -> List[Symbol]:
 		return self._symbols
 
 

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -39,7 +39,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2016-2022, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.17.2"
+__version__ =   "0.18.0"
 
 
 from enum     import IntEnum, unique, Enum

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -43,7 +43,7 @@ __version__ =   "0.17.2"
 
 
 from enum     import IntEnum, unique, Enum
-from typing   import List, Iterable, Union, Optional as Nullable, Dict, cast, Tuple
+from typing   import List, Iterable, Union, Optional as Nullable, Dict, cast, Tuple, Any
 
 from pyTooling.Decorators import export
 
@@ -567,7 +567,105 @@ class DocumentedEntityMixin:
 
 
 @export
-class DesignUnitWithContextMixin:
+class Name(ModelEntity):
+	"""``Name`` is the base-class for all *names* in the VHDL language model."""
+
+	_identifier: str
+	_root: Nullable['Name']
+	_prefix: Nullable['Name']
+
+	def __init__(self, identifier: str, prefix: 'Name' = None):
+		super().__init__()
+		self._identifier = identifier
+		if prefix is None:
+			self._prefix = self
+			self._root = None
+		else:
+			self._prefix = prefix
+			self._root = prefix._root
+
+	@property
+	def Identifier(self) -> str:
+		return self._identifier
+
+	@property
+	def Root(self) -> 'Name':
+		return self._root
+
+	@property
+	def Prefix(self) -> Nullable['Name']:
+		return self._prefix
+
+	@property
+	def Has_Prefix(self) -> bool:
+		return self._prefix is not None
+
+
+@export
+class Symbol(ModelEntity):
+	_symbolName: Name
+	_possibleReferences: PossibleReference
+	_reference: Any
+
+	def __init__(self, symbolName: Name, possibleReferences: PossibleReference):
+		super().__init__()
+
+		self._symbolName = symbolName
+		self._possibleReferences = possibleReferences
+		self._reference = None
+
+	@property
+	def SymbolName(self) -> Name:
+		return self._symbolName
+
+	@property
+	def Reference(self) -> Any:
+		return self._reference
+
+	@property
+	def IsResolved(self) -> bool:
+		return self._reference is not None
+
+	def __bool__(self) -> bool:
+		return self._reference is not None
+
+	def __str__(self) -> str:
+		if self._reference is not None:
+			return str(self._reference)
+		return str(self._symbolName)
+
+
+@export
+class Reference(ModelEntity):
+	_symbols:       List[Symbol]
+
+	def __init__(self, symbols: Iterable[Symbol]):
+		super().__init__()
+
+		self._symbols = [s for s in symbols]
+
+	@property
+	def Symbols(self) -> List[Name]:
+		return self._symbols
+
+
+@export
+class LibraryClause(Reference):
+	pass
+
+
+@export
+class UseClause(Reference):
+	pass
+
+
+@export
+class ContextReference(Reference):
+	pass
+
+
+@export
+class DesignUnitWithContextMixin: #(metaclass=ExtendedType, useSlots=True):
 	_contextItems:      List['ContextUnion']      #: List of all context items (library, use and context clauses).
 	_libraryReferences: List['LibraryClause']     #: List of library clauses.
 	_packageReferences: List['UseClause']         #: List of use clauses.
@@ -579,7 +677,6 @@ class DesignUnitWithContextMixin:
 
 		:param contextItems: A sequence of library, use or context clauses.
 		"""
-		from pyVHDLModel.SyntaxModel import LibraryClause, UseClause, ContextReference
 
 		self._contextItems = []
 		self._libraryReferences = []

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -39,7 +39,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2016-2022, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.17.1"
+__version__ =   "0.17.2"
 
 
 from enum     import IntEnum, unique, Enum

--- a/pyVHDLModel/ieee.py
+++ b/pyVHDLModel/ieee.py
@@ -1,0 +1,94 @@
+from pyVHDLModel.SyntaxModel import Library, Package, PackageBody
+
+
+class Ieee(Library):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+		for packageType, packageBodyType in PACKAGES:
+			package: Package = packageType()
+			packageBody: PackageBody = packageBodyType()
+
+			self._packages[package.Identifier.lower()] = package
+			self._packageBodies[packageBody.Identifier.lower()] = packageBody
+
+
+class Math_Real(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Math_Real_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Math_Complex(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Math_Complex_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Std_logic_1164(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Std_logic_1164_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Numeric_Bit(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Numeric_Bit_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Numeric_Bit_Unsigned(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Numeric_Bit_Unsigned_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Numeric_Std(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Numeric_Std_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Numeric_Std_Unsigned(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Numeric_Std_Unsigned_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+PACKAGES = (
+	(Math_Real, Math_Real_Body),
+	(Math_Complex, Math_Complex_Body),
+	(Std_logic_1164, Std_logic_1164_Body),
+	(Numeric_Bit, Numeric_Bit_Body),
+	(Numeric_Bit_Unsigned, Numeric_Bit_Unsigned_Body),
+	(Numeric_Std, Numeric_Std_Body),
+	(Numeric_Std_Unsigned, Numeric_Std_Unsigned_Body),
+)

--- a/pyVHDLModel/std.py
+++ b/pyVHDLModel/std.py
@@ -1,0 +1,50 @@
+from pyVHDLModel.SyntaxModel import Package, PackageBody, Library
+
+
+class Std(Library):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+		for packageType, packageBodyType in PACKAGES:
+			package: Package = packageType()
+			packageBody: PackageBody = packageBodyType()
+
+			self._packages[package.Identifier.lower()] = package
+			self._packageBodies[packageBody.Identifier.lower()] = packageBody
+
+
+class Standard(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Standard_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class TextIO(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class TextIO_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+class Env(Package):
+	def __init__(self):
+		super().__init__(self.__class__.__name__)
+
+
+class Env_Body(PackageBody):
+	def __init__(self):
+		super().__init__(self.__class__.__name__[:-5])
+
+
+PACKAGES = (
+	(Standard, Standard_Body),
+	(TextIO, TextIO_Body),
+	(Env, Env_Body),
+)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 -r ../requirements.txt
 
 # Coverage collection
-Coverage>=6.5
+Coverage>=7.0
 
 # Test Runner
 pytest>=7.2.0


### PR DESCRIPTION
# New Features
 
* Added `Document` property to `DesignUnit`.
* Added `LibraryReferenceSymbol`, `PackageReferenceSymbol` and `ContextReferenceSymbol`.
* Added new packages `std` and `ieee` containing pre-defined VHDL libraries and VHDL packages.
* Added `LoadStdLibrary` and `LoadIEEELibrary` to `Design`.
* Added `IterateDesignUnits` generator on `Design` and `Library`.
* Implemented various analyze methods on `Design`:
  * `LinkLibraryReferences`
  * `LinkArchitectures`
  * `LinkPackageBodies`
* Added `_Add***` methods to `Document`.
* Added `DesignUnits`, `VerificationUnits`, `VerificationProperties` and `VerificationModes` properties to `Document`.

# Changes

* Moved classes:
  * `pyVHDLModel.SyntaxModel.Name` &rarr; `pyVHDLModel.Name`
  * `pyVHDLModel.SyntaxModel.Symbol` &rarr; `pyVHDLModel.Symbol`
  * `pyVHDLModel.SyntaxModel.Reference` &rarr; `pyVHDLModel.Reference`
  * `pyVHDLModel.SyntaxModel.LibraryClause` &rarr; `pyVHDLModel.LibraryClause`
  * `pyVHDLModel.SyntaxModel.UseClause` &rarr; `pyVHDLModel.UseClause`
  * `pyVHDLModel.SyntaxModel.ContextReference` &rarr; `pyVHDLModel.ContextReference`
* Property `PrimaryUnit.Library` uses it's own private field `_library` instead of `_parent`, so `_parent` can be used to refer to the document a design unit is in.
* Improved `EntitySymbol`, `ArchitectureSymbol`, `PackageSymbol`.
* Improved `GetLibrary` in `Design`.
* Improved `AddDocument` in `Library`.
* Changed almost all internal lists in `Library` and `Document` to dictionaries for quick name lookups.
* Enabled CI job Windows + Python 3.11 again.
* Bumped dependencies.
* Updated MAKEFILE for Sphinx documentation.

# Bug Fixes

* Fixed usage of Names vs. Symbols.

----------
# Related PRs:

*None*
