### PR TITLE
v0.20.2

### DIFF
--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -1013,7 +1013,7 @@ class Library(ModelEntity, NamedEntityMixin):
 	def IndexArchitectures(self):
 		for architectures in self._architectures.values():
 			for architecture in architectures.values():
-				architecture.IndexArchitecture()
+				architecture.Index()
 
 	def __str__(self):
 		return f"VHDL Library: '{self.Identifier}'"

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -3406,6 +3406,10 @@ class CaseGenerateStatement(GenerateStatement):
 	def Cases(self) -> List[GenerateCase]:
 		return self._cases
 
+	def Index(self):
+		for case in self._cases:
+			case.Index()
+
 
 @export
 class ForGenerateStatement(GenerateStatement, ConcurrentDeclarations, ConcurrentStatements):

--- a/pyVHDLModel/SyntaxModel.py
+++ b/pyVHDLModel/SyntaxModel.py
@@ -2853,12 +2853,12 @@ class SequentialStatements:
 
 @export
 class Context(PrimaryUnit):
-	_references:        List[Union[LibraryClause, UseClause, ContextReference]]
+	_references:        List[ContextUnion]
 	_libraryReferences: List[LibraryClause]
 	_packageReferences: List[UseClause]
 	_contextReferences: List[ContextReference]
 
-	def __init__(self, identifier: str, references: Iterable[Union[LibraryClause, UseClause, ContextReference]] = None, documentation: str = None):
+	def __init__(self, identifier: str, references: Iterable[ContextUnion] = None, documentation: str = None):
 		super().__init__(identifier, documentation)
 
 		self._references = []

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -39,7 +39,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2016-2022, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.20.1"
+__version__ =   "0.20.2"
 
 
 from enum            import unique, Enum, Flag, auto

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -50,13 +50,8 @@ from typing          import List, Iterable, Union, Optional as Nullable, Dict, c
 from pyTooling.Decorators import export
 
 
-SimpleOrAttribute =     Union['SimpleName',    'AttributeName']
-
 SubtypeOrSymbol =       Union['Subtype',       'SubtypeSymbol']
 
-ConstantOrSymbol =      Union['Constant',      'ConstantSymbol']
-VariableOrSymbol =      Union['Variable',      'VariableSymbol']
-SignalOrSymbol =        Union['Signal',        'SignalSymbol']
 
 ConstraintUnion = Union[
 	'RangeExpression',

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -64,9 +64,7 @@ ExpressionUnion = Union[
 	'QualifiedExpression',
 	'FunctionCall',
 	'TypeConversion',
-	ConstantOrSymbol,
-	VariableOrSymbol,
-	SignalOrSymbol,
+	# ConstantOrSymbol,     TODO: ObjectSymbol
 	'Literal',
 ]
 


### PR DESCRIPTION
# New Features
 
*None*

# Changes

* Removed unused `***OrSymbol` union types.

# Bug Fixes

* Fixed `architecture.IndexArchitecture()` call to `architecture.Index()`.
* Added missing `Index` method on `CaseGenerateStatement`.
* Used predefined `ContextUnion` instead of `Union[LibraryClause, UseClause, ContextReference]`
