### PR TITLE
v0.25.0

### DIFF
--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -51,13 +51,13 @@ the mandatory dependencies too.
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | **Package**                                               | **Version** | **License**                                                                            | **Dependencies**     |
 +===========================================================+=============+========================================================================================+======================+
-| `pytest <https://GitHub.com/pytest-dev/pytest>`__         | ≥7.2.0      | `MIT <https://GitHub.com/pytest-dev/pytest/blob/master/LICENSE>`__                     | *Not yet evaluated.* |
+| `pytest <https://GitHub.com/pytest-dev/pytest>`__         | ≥7.3.0      | `MIT <https://GitHub.com/pytest-dev/pytest/blob/master/LICENSE>`__                     | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `pytest-cov <https://GitHub.com/pytest-dev/pytest-cov>`__ | ≥4.0.0      | `MIT <https://GitHub.com/pytest-dev/pytest-cov/blob/master/LICENSE>`__                 | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `Coverage <https://GitHub.com/nedbat/coveragepy>`__       | ≥7.2        | `Apache License, 2.0 <https://GitHub.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__ | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
-| `mypy <https://GitHub.com/python/mypy>`__                 | ≥1.1.1      | `MIT <https://GitHub.com/python/mypy/blob/master/LICENSE>`__                           | *Not yet evaluated.* |
+| `mypy <https://GitHub.com/python/mypy>`__                 | ≥1.2.0      | `MIT <https://GitHub.com/python/mypy/blob/master/LICENSE>`__                           | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `lxml <https://GitHub.com/lxml/lxml>`__                   | ≥4.9        | `BSD 3-Clause <https://GitHub.com/lxml/lxml/blob/master/LICENSE.txt>`__                | *Not yet evaluated.* |
 +-----------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+

--- a/pyVHDLModel/Association.py
+++ b/pyVHDLModel/Association.py
@@ -69,7 +69,7 @@ class AssociationItem(ModelEntity):
 		if self._formal is None:
 			return str(self._actual)
 		else:
-			return "{formal!s} => {actual!s}".format(formal=self._formal, actual=self._actual)
+			return f"{self._formal!s} => {self._actual!s}"
 
 
 @export

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -410,11 +410,7 @@ class Range(ModelEntity):
 		return self._direction
 
 	def __str__(self) -> str:
-		return "{leftBound!s} {direction!s} {rightBound!s}".format(
-			leftBound=self._leftBound,
-			direction=self._direction,
-			rightBound=self._rightBound,
-		)
+		return f"{self._leftBound!s} {self._direction!s} {self._rightBound!s}"
 
 
 @export

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -437,7 +437,7 @@ class GenerateCase(ConcurrentCase):
 		return self._choices
 
 	def __str__(self) -> str:
-		return "when {choices} =>".format(choices=" | ".join([str(c) for c in self._choices]))
+		return "when {choices} =>".format(choices=" | ".join(str(c) for c in self._choices))
 
 
 @export
@@ -575,7 +575,7 @@ class IndexedGenerateChoice(ConcurrentChoice):
 		return self._expression
 
 	def __str__(self) -> str:
-		return "{expression!s}".format(expression=self._expression)
+		return str(self._expression)
 
 
 @export
@@ -593,4 +593,4 @@ class RangedGenerateChoice(ConcurrentChoice):
 		return self._range
 
 	def __str__(self) -> str:
-		return "{range!s}".format(range=self._range)
+		return str(self._range)

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -399,7 +399,7 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin):
 	_declaredItems:     List
 
 	def __init__(self, packageSymbol: PackageSymbol, contextItems: Iterable['Context'] = None, declaredItems: Iterable = None, documentation: str = None):
-		super().__init__(packageSymbol.Identifier, contextItems, documentation)
+		super().__init__(packageSymbol.Name.Identifier, contextItems, documentation)
 		DesignUnitWithContextMixin.__init__(self)
 
 		self._package = packageSymbol

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -383,12 +383,12 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin):
 				print(item)
 
 	def __str__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
 
-		return f"Package: {lib}.{self.Identifier}"
+		return f"Package: '{lib}.{self.Identifier}'"
 
 	def __repr__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
 
 		return f"{lib}.{self.Identifier}"
 

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -490,14 +490,16 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarations, Co
 		return self._architectures
 
 	def __str__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
+		archs = ', '.join(self._architectures.keys()) if self._architectures else "%"
 
-		return f"Entity: {lib}.{self.Identifier}({', '.join(self._architectures.keys())})"
+		return f"Entity: '{lib}.{self.Identifier}({archs})'"
 
 	def __repr__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
+		archs = ', '.join(self._architectures.keys()) if self._architectures else "%"
 
-		return f"{lib}.{self.Identifier}({', '.join(self._architectures.keys())})"
+		return f"{lib}.{self.Identifier}({archs})"
 
 
 @export
@@ -528,14 +530,14 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarat
 		self._library = library
 
 	def __str__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
-		ent = self._entity.Identifier + "?" if self._entity is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
+		ent = self._entity.Identifier if self._entity is not None else "%"
 
 		return f"Architecture: {lib}.{ent}({self.Identifier})"
 
 	def __repr__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
-		ent = self._entity.Identifier + "?" if self._entity is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
+		ent = self._entity.Identifier if self._entity is not None else "%"
 
 		return f"{lib}.{ent}({self.Identifier})"
 
@@ -590,11 +592,11 @@ class Configuration(PrimaryUnit, DesignUnitWithContextMixin):
 		DesignUnitWithContextMixin.__init__(self)
 
 	def __str__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
 
 		return f"Configuration: {lib}.{self.Identifier}"
 
 	def __repr__(self) -> str:
-		lib = self._library.Identifier + "?" if self._library is not None else ""
+		lib = self._library.Identifier if self._library is not None else "%"
 
 		return f"{lib}.{self.Identifier}"

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -615,7 +615,7 @@ class SubtypeAllocation(Allocation):
 		return self._subtype
 
 	def __str__(self) -> str:
-		return "new {subtype!s}".format(subtype=self._subtype)
+		return f"new {self._subtype!s}"
 
 
 @export
@@ -633,7 +633,7 @@ class QualifiedExpressionAllocation(Allocation):
 		return self._qualifiedExpression
 
 	def __str__(self) -> str:
-		return "new {expr!s}".format(expr=self._qualifiedExpression)
+		return f"new {self._qualifiedExpression!s}"
 
 
 @export
@@ -673,10 +673,7 @@ class IndexedAggregateElement(AggregateElement):
 		return self._index
 
 	def __str__(self) -> str:
-		return "{index!s} => {value!s}".format(
-			index=self._index,
-			value=self._expression,
-		)
+		return f"{self._index!s} => {self._expression!s}"
 
 
 @export
@@ -694,10 +691,7 @@ class RangedAggregateElement(AggregateElement):
 		return self._range
 
 	def __str__(self) -> str:
-		return "{range!s} => {value!s}".format(
-			range=self._range,
-			value=self._expression,
-		)
+		return f"{self._range!s} => {self._expression!s}"
 
 
 @export

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -114,6 +114,12 @@ class Name(ModelEntity):
 		"""
 		return self._prefix is not None
 
+	def __repr__(self) -> str:
+		return f"Name: '{self.__str__()}'"
+
+	def __str__(self) -> str:
+		return self._identifier
+
 
 @export
 class SimpleName(Name):
@@ -124,9 +130,6 @@ class SimpleName(Name):
 	itself is an identifier. The simple name references is again an identifier in the entity declaration, thus names
 	reference other (already) declared language entities.
 	"""
-
-	def __str__(self):
-		return self._identifier
 
 
 @export
@@ -145,8 +148,8 @@ class ParenthesisName(Name):
 	def Associations(self) -> List:
 		return self._associations
 
-	def __str__(self):
-		return str(self._prefix) + "(" + ", ".join([str(a) for a in self._associations]) + ")"
+	def __str__(self) -> str:
+		return f"{self._prefix!s}({', '.join(str(a) for a in self._associations)})"
 
 
 @export
@@ -164,6 +167,9 @@ class IndexedName(Name):
 	@property
 	def Indices(self) -> List[ExpressionUnion]:
 		return self._indices
+
+	def __str__(self) -> str:
+		return f"{self._prefix!s}({', '.join(str(i) for i in self._indices)})"
 
 
 @export
@@ -184,8 +190,8 @@ class SelectedName(Name):
 	def __init__(self, identifier: str, prefix: Name):
 		super().__init__(identifier, prefix)
 
-	def __str__(self):
-		return str(self._prefix) + "." + self._identifier
+	def __str__(self) -> str:
+		return f"{self._prefix!s}.{self._identifier}"
 
 
 @export
@@ -193,22 +199,19 @@ class AttributeName(Name):
 	def __init__(self, identifier: str, prefix: Name):
 		super().__init__(identifier, prefix)
 
-	def __str__(self):
-		return str(self._prefix) + "'" + self._identifier
+	def __str__(self) -> str:
+		return f"{self._prefix!s}'{self._identifier}"
 
 
 @export
-class AllName(Name):
+class AllName(SelectedName):
 	"""
 	The *all name* represents the reserved word ``all`` used in names.
 
 	Most likely this name is used in use-statements.
 	"""
 	def __init__(self, prefix: Name):
-		super().__init__("all", prefix)
-
-	def __str__(self):
-		return str(self._prefix) + "." + "all"
+		super().__init__("all", prefix)  # TODO: the case of 'ALL' is not preserved
 
 
 @export
@@ -216,10 +219,10 @@ class OpenName(Name):
 	"""
 	The *open name* represents the reserved word ``open``.
 
-	Most likely this name is used in port assoziations.
+	Most likely this name is used in port associations.
 	"""
 	def __init__(self):
-		super().__init__("open")
+		super().__init__("open")  # TODO: the case of 'ALL' is not preserved
 
-	def __str__(self):
+	def __str__(self) -> str:
 		return "open"

--- a/pyVHDLModel/STD.py
+++ b/pyVHDLModel/STD.py
@@ -35,6 +35,7 @@ from typing                  import Iterable
 from pyTooling.Decorators    import export
 
 from pyVHDLModel import Library
+from pyVHDLModel.Name import SimpleName, SelectedName, AllName
 from pyVHDLModel.Symbol      import LibraryReferenceSymbol, PackageReferenceSymbol, PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol, PackageSymbol
 from pyVHDLModel.DesignUnit  import LibraryClause, UseClause, Package, PackageBody
 
@@ -61,7 +62,7 @@ class PredefinedLibrary(Library):
 @export
 class PredefinedMixin:
 	def _AddLibraryClause(self, libraries: Iterable[str]):
-		symbols = [LibraryReferenceSymbol(libName) for libName in libraries]
+		symbols = [LibraryReferenceSymbol(SimpleName(libName)) for libName in libraries]
 		libraryClause = LibraryClause(symbols)
 
 		self._contextItems.append(libraryClause)
@@ -71,11 +72,12 @@ class PredefinedMixin:
 		symbols = []
 		for qualifiedPackageName in packages:
 			libName, packName, members = qualifiedPackageName.split(".")
-			packageSymbol = PackageReferenceSymbol(packName, LibraryReferenceSymbol(libName))
+
+			packageName = SelectedName(packName, SimpleName(libName))
 			if members.lower() == "all":
-				symbols.append(AllPackageMembersReferenceSymbol(packageSymbol))
+				symbols.append(AllPackageMembersReferenceSymbol(AllName(packageName)))
 			else:
-				symbols.append(PackageMembersReferenceSymbol(members, packageSymbol))
+				symbols.append(PackageMembersReferenceSymbol(SelectedName(members, packageName)))
 
 		useClause = UseClause(symbols)
 		self._contextItems.append(useClause)
@@ -91,7 +93,7 @@ class PredefinedPackage(Package, PredefinedMixin):
 @export
 class PredefinedPackageBody(PackageBody, PredefinedMixin):
 	def __init__(self):
-		packageSymbol = PackageSymbol(self.__class__.__name__[:-5])
+		packageSymbol = PackageSymbol(SimpleName(self.__class__.__name__[:-5]))
 		super().__init__(packageSymbol)
 
 
@@ -128,7 +130,7 @@ class Env(PredefinedPackage):
 
 		# Use clauses
 		useTextIOSymbols = (
-			AllPackageMembersReferenceSymbol(PackageReferenceSymbol("textio", LibraryReferenceSymbol("work"))),
+			AllPackageMembersReferenceSymbol(AllName(SelectedName("textio", SimpleName("work")))),
 		)
 		self._packageReferences.append(UseClause(useTextIOSymbols))
 

--- a/pyVHDLModel/STD.py
+++ b/pyVHDLModel/STD.py
@@ -34,9 +34,9 @@ from typing                  import Iterable
 
 from pyTooling.Decorators    import export
 
-from pyVHDLModel import Library
-from pyVHDLModel.Name import SimpleName, SelectedName, AllName
-from pyVHDLModel.Symbol      import LibraryReferenceSymbol, PackageReferenceSymbol, PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol, PackageSymbol
+from pyVHDLModel             import Library
+from pyVHDLModel.Name        import SimpleName, SelectedName, AllName
+from pyVHDLModel.Symbol      import LibraryReferenceSymbol, PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol, PackageSymbol
 from pyVHDLModel.DesignUnit  import LibraryClause, UseClause, Package, PackageBody
 
 
@@ -128,11 +128,7 @@ class Env(PredefinedPackage):
 	def __init__(self):
 		super().__init__()
 
-		# Use clauses
-		useTextIOSymbols = (
-			AllPackageMembersReferenceSymbol(AllName(SelectedName("textio", SimpleName("work")))),
-		)
-		self._packageReferences.append(UseClause(useTextIOSymbols))
+		self._AddPackageClause(("work.textio.all",))
 
 
 @export

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -214,7 +214,7 @@ class IndexedChoice(SequentialChoice):
 		return self._expression
 
 	def __str__(self) -> str:
-		return "{expression!s}".format(expression=self._expression)
+		return str(self._expression)
 
 
 @export
@@ -232,7 +232,7 @@ class RangedChoice(SequentialChoice):
 		return self._range
 
 	def __str__(self) -> str:
-		return "{range!s}".format(range=self._range)
+		return str(self._range)
 
 
 @export
@@ -268,7 +268,7 @@ class Case(SequentialCase):
 		return self._choices
 
 	def __str__(self) -> str:
-		return "when {choices} =>".format(choices=" | ".join([str(c) for c in self._choices]))
+		return "when {choices} =>".format(choices=" | ".join(str(c) for c in self._choices))
 
 
 @export

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -92,12 +92,18 @@ class PossibleReference(Flag):
 
 @export
 class Symbol:
+	_innerName:          Name
 	_possibleReferences: PossibleReference
-	_reference: Any
+	_reference:          Any
 
-	def __init__(self, possibleReferences: PossibleReference):
+	def __init__(self, name: Name, possibleReferences: PossibleReference):
+		self._innerName = name
 		self._possibleReferences = possibleReferences
 		self._reference = None
+
+	@property
+	def Name(self) -> Name:
+		return self._innerName
 
 	@property
 	def Reference(self) -> Any:
@@ -113,16 +119,16 @@ class Symbol:
 	def __str__(self) -> str:
 		if self._reference is not None:
 			return str(self._reference)
-		return str(self._symbolName)
+
+		return str(self._innerName)
 
 
 @export
-class LibraryReferenceSymbol(SimpleName, Symbol):
+class LibraryReferenceSymbol(Symbol):
 	"""A library reference in a library clause."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Library)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Library)
 
 	@property
 	def Library(self) -> 'Library':
@@ -134,16 +140,11 @@ class LibraryReferenceSymbol(SimpleName, Symbol):
 
 
 @export
-class PackageReferenceSymbol(SelectedName, Symbol):
+class PackageReferenceSymbol(Symbol):
 	"""A package reference in a use clause."""
 
-	def __init__(self, identifier: str, prefix: LibraryReferenceSymbol):
-		super().__init__(identifier, prefix)
-		Symbol.__init__(self, PossibleReference.Package)
-
-	@property
-	def Prefix(self) -> LibraryReferenceSymbol:
-		return cast(LibraryReferenceSymbol, self._prefix)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Package)
 
 	@property
 	def Package(self) -> 'Package':
@@ -155,58 +156,43 @@ class PackageReferenceSymbol(SelectedName, Symbol):
 
 
 @export
-class PackageMembersReferenceSymbol(SelectedName, Symbol):
+class PackageMembersReferenceSymbol(Symbol):
 	"""A package member reference in a use clause."""
 
-	def __init__(self, identifier: str, prefix: PackageReferenceSymbol):
-		super().__init__(identifier, prefix)
-		Symbol.__init__(self, PossibleReference.PackageMember)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.PackageMember)
 
 	@property
-	def Prefix(self) -> PackageReferenceSymbol:
-		return cast(PackageReferenceSymbol, self._prefix)
-
-	@property
-	def Member(self) -> 'Package':
+	def Member(self) -> 'Package':  # TODO: typehint
 		return self._reference
 
 	@Member.setter
-	def Member(self, value: 'Package') -> None:
+	def Member(self, value: 'Package') -> None:  # TODO: typehint
 		self._reference = value
 
 
 @export
-class AllPackageMembersReferenceSymbol(AllName, Symbol):
+class AllPackageMembersReferenceSymbol(Symbol):
 	"""A package reference in a use clause."""
 
-	def __init__(self, prefix: PackageReferenceSymbol):
-		super().__init__(prefix)
-		Symbol.__init__(self, PossibleReference.PackageMember)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.PackageMember)
 
 	@property
-	def Prefix(self) -> PackageReferenceSymbol:
-		return cast(PackageReferenceSymbol, self._prefix)
-
-	@property
-	def Members(self) -> 'Package':
+	def Members(self) -> 'Package':  # TODO: typehint
 		return self._reference
 
 	@Members.setter
-	def Members(self, value: 'Package') -> None:
+	def Members(self, value: 'Package') -> None:  # TODO: typehint
 		self._reference = value
 
 
 @export
-class ContextReferenceSymbol(SelectedName, Symbol):
+class ContextReferenceSymbol(Symbol):
 	"""A context reference in a context clause."""
 
-	def __init__(self, identifier: str, prefix: LibraryReferenceSymbol):
-		super().__init__(identifier, prefix)
-		Symbol.__init__(self, PossibleReference.Context)
-
-	@property
-	def Prefix(self) -> LibraryReferenceSymbol:
-		return cast(LibraryReferenceSymbol, self._prefix)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Context)
 
 	@property
 	def Context(self) -> 'Context':
@@ -218,12 +204,11 @@ class ContextReferenceSymbol(SelectedName, Symbol):
 
 
 @export
-class EntitySymbol(SimpleName, Symbol):
+class EntitySymbol(Symbol):
 	"""An entity reference in an architecture declaration."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Entity)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Entity)
 
 	@property
 	def Entity(self) -> 'Entity':
@@ -235,16 +220,11 @@ class EntitySymbol(SimpleName, Symbol):
 
 
 @export
-class ArchitectureSymbol(Name, Symbol):
+class ArchitectureSymbol(Symbol):
 	"""An entity reference in an entity instantiation with architecture name."""
 
-	def __init__(self, identifier: str, prefix: EntitySymbol):
-		super().__init__(identifier, prefix)
-		Symbol.__init__(self, PossibleReference.Architecture)
-
-	@property
-	def Prefix(self) -> EntitySymbol:
-		return cast(EntitySymbol, self._prefix)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Architecture)
 
 	@property
 	def Architecture(self) -> 'Architecture':
@@ -256,12 +236,11 @@ class ArchitectureSymbol(Name, Symbol):
 
 
 @export
-class PackageSymbol(SimpleName, Symbol):
+class PackageSymbol(Symbol):
 	"""A package reference in a package body declaration."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Package)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Package)
 
 	@property
 	def Package(self) -> 'Package':
@@ -273,16 +252,11 @@ class PackageSymbol(SimpleName, Symbol):
 
 
 @export
-class EntityInstantiationSymbol(SelectedName, Symbol):
+class EntityInstantiationSymbol(Symbol):
 	"""An entity reference in a direct entity instantiation."""
 
-	def __init__(self, identifier: str, prefix: LibraryReferenceSymbol):
-		super().__init__(identifier, prefix)
-		Symbol.__init__(self, PossibleReference.Entity)
-
-	@property
-	def Prefix(self) -> LibraryReferenceSymbol:
-		return cast(LibraryReferenceSymbol, self._prefix)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Entity)
 
 	@property
 	def Entity(self) -> 'Entity':
@@ -294,12 +268,11 @@ class EntityInstantiationSymbol(SelectedName, Symbol):
 
 
 @export
-class ComponentInstantiationSymbol(SimpleName, Symbol):
+class ComponentInstantiationSymbol(Symbol):
 	"""A component reference in a component instantiation."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Component)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Component)
 
 	@property
 	def Component(self) -> 'Component':
@@ -311,12 +284,11 @@ class ComponentInstantiationSymbol(SimpleName, Symbol):
 
 
 @export
-class ConfigurationInstantiationSymbol(SimpleName, Symbol):
+class ConfigurationInstantiationSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Configuration)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Configuration)
 
 	@property
 	def Configuration(self) -> 'Configuration':
@@ -328,12 +300,11 @@ class ConfigurationInstantiationSymbol(SimpleName, Symbol):
 
 
 @export
-class SimpleSubtypeSymbol(SimpleName, Symbol):
+class SimpleSubtypeSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Configuration)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Subtype)
 
 	@property
 	def Subtype(self) -> 'Subtype':
@@ -345,7 +316,7 @@ class SimpleSubtypeSymbol(SimpleName, Symbol):
 
 
 @export
-class ConstrainedScalarSubtypeSymbol(SimpleName, Symbol):
+class ConstrainedScalarSubtypeSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
 	def __init__(self, identifier: str):
@@ -354,7 +325,7 @@ class ConstrainedScalarSubtypeSymbol(SimpleName, Symbol):
 
 
 @export
-class ConstrainedCompositeSubtypeSymbol(SimpleName, Symbol):
+class ConstrainedCompositeSubtypeSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
 	def __init__(self, identifier: str):
@@ -363,7 +334,7 @@ class ConstrainedCompositeSubtypeSymbol(SimpleName, Symbol):
 
 
 @export
-class SimpleObjectOrFunctionCallSymbol(SimpleName, Symbol):
+class SimpleObjectOrFunctionCallSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
 	def __init__(self, identifier: str):
@@ -372,7 +343,7 @@ class SimpleObjectOrFunctionCallSymbol(SimpleName, Symbol):
 
 
 @export
-class IndexedObjectOrFunctionCallSymbol(IndexedName, Symbol):
+class IndexedObjectOrFunctionCallSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
 	def __init__(self, prefix: Name, indices: Iterable[ExpressionUnion]):

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -116,11 +116,14 @@ class Symbol:
 	def __bool__(self) -> bool:
 		return self._reference is not None
 
+	def __repr__(self) -> str:
+		return f"{self.__class__.__name__}: {self._innerName!s}"
+
 	def __str__(self) -> str:
 		if self._reference is not None:
 			return str(self._reference)
 
-		return str(self._innerName)
+		return f"{self._innerName!s} (unresolved)"
 
 
 @export

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -84,7 +84,7 @@ class PossibleReference(Flag):
 	View =            auto()  #: View
 
 	AnyType = ScalarType | ArrayType | RecordType | ProtectedType | AccessType | FileType | Subtype  #: Any possible type incl. subtypes.
-	Object = Constant | Variable | Signal | File                                                     #: Any object
+	Object = Constant | Variable | Signal  # | File                                                     #: Any object
 	SubProgram = Procedure | Function                                                                #: Any subprogram
 	PackageMember = AnyType | Object | SubProgram | Component                                        #: Any member of a package
 	SimpleNameInExpression = Constant | Variable | Signal | ScalarType | EnumLiteral | Function      #: Any possible item in an expression.
@@ -319,33 +319,25 @@ class SimpleSubtypeSymbol(Symbol):
 class ConstrainedScalarSubtypeSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Configuration)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Subtype)
 
 
 @export
 class ConstrainedCompositeSubtypeSymbol(Symbol):
 	"""A configuration reference in a configuration instantiation."""
 
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Configuration)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Subtype)
 
 
 @export
 class SimpleObjectOrFunctionCallSymbol(Symbol):
-	"""A configuration reference in a configuration instantiation."""
-
-	def __init__(self, identifier: str):
-		super().__init__(identifier)
-		Symbol.__init__(self, PossibleReference.Configuration)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.SimpleNameInExpression)
 
 
 @export
 class IndexedObjectOrFunctionCallSymbol(Symbol):
-	"""A configuration reference in a configuration instantiation."""
-
-	def __init__(self, prefix: Name, indices: Iterable[ExpressionUnion]):
-		super().__init__(prefix, indices)
-		Symbol.__init__(self, PossibleReference.Configuration)
+	def __init__(self, name: Name):
+		super().__init__(name, PossibleReference.Object | PossibleReference.Function)

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -117,13 +117,16 @@ class Symbol:
 		return self._reference is not None
 
 	def __repr__(self) -> str:
-		return f"{self.__class__.__name__}: {self._innerName!s}"
+		if self._reference is not None:
+			return f"{self.__class__.__name__}: '{self._innerName!s}' -> {self._reference!s}"
+
+		return f"{self.__class__.__name__}: '{self._innerName!s}' -> unresolved"
 
 	def __str__(self) -> str:
 		if self._reference is not None:
 			return str(self._reference)
 
-		return f"{self._innerName!s} (unresolved)"
+		return f"{self._innerName!s}?"
 
 
 @export

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -306,11 +306,14 @@ class ConfigurationInstantiationSymbol(Symbol):
 
 
 @export
-class SimpleSubtypeSymbol(Symbol):
-	"""A configuration reference in a configuration instantiation."""
-
+class SubtypeSymbol(Symbol):
 	def __init__(self, name: Name):
 		super().__init__(name, PossibleReference.Subtype)
+
+
+@export
+class SimpleSubtypeSymbol(SubtypeSymbol):
+	"""A configuration reference in a configuration instantiation."""
 
 	@property
 	def Subtype(self) -> 'Subtype':
@@ -322,19 +325,13 @@ class SimpleSubtypeSymbol(Symbol):
 
 
 @export
-class ConstrainedScalarSubtypeSymbol(Symbol):
+class ConstrainedScalarSubtypeSymbol(SubtypeSymbol):
 	"""A configuration reference in a configuration instantiation."""
-
-	def __init__(self, name: Name):
-		super().__init__(name, PossibleReference.Subtype)
 
 
 @export
-class ConstrainedCompositeSubtypeSymbol(Symbol):
+class ConstrainedCompositeSubtypeSymbol(SubtypeSymbol):
 	"""A configuration reference in a configuration instantiation."""
-
-	def __init__(self, name: Name):
-		super().__init__(name, PossibleReference.Subtype)
 
 
 @export

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -1042,6 +1042,11 @@ class Design(ModelEntity):
 	def GetUnusedDesignUnits(self) -> List[DesignUnit]:
 		raise NotImplementedError()
 
+	def __repr__(self) -> str:
+		return f"Design: {self._nane}"
+
+	__str__ = __repr__
+
 
 @export
 class Library(ModelEntity, NamedEntityMixin):
@@ -1181,8 +1186,10 @@ class Library(ModelEntity, NamedEntityMixin):
 			for architecture in architectures.values():
 				architecture.Index()
 
-	def __str__(self):
+	def __repr__(self) -> str:
 		return f"Library: '{self.Identifier}'"
+
+	__str__ = __repr__
 
 
 @export
@@ -1464,3 +1471,8 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		# 	yield entity
 		# for verificationMode in self._verificationModes.values():
 		# 	yield verificationMode
+
+	def __repr__(self) -> str:
+		return f"Document: '{self._path}'"
+
+	__str__ = __repr__

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -48,7 +48,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2016-2023, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.24.1"
+__version__ =   "0.25.0"
 
 
 from enum                      import unique, Enum, Flag, auto

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -471,13 +471,14 @@ class Design(ModelEntity):
 		return library
 
 	def AddLibrary(self, library: 'Library') -> None:
-		if library.NormalizedIdentifier in self._libraries:
+		libraryIdentifier = library.NormalizedIdentifier
+		if libraryIdentifier in self._libraries:
 			raise LibraryExistsInDesignError(library)
 
 		if library._parent is not None:
 			raise LibraryRegisteredToForeignDesignError(library)
 
-		self._libraries[library.NormalizedIdentifier] = library
+		self._libraries[libraryIdentifier] = library
 		library._parent = self
 
 	def GetLibrary(self, libraryName: str) -> 'Library':
@@ -648,7 +649,7 @@ class Design(ModelEntity):
 			for libraryReference in context._libraryReferences:
 				# A library clause can have multiple comma-separated references
 				for librarySymbol in libraryReference.Symbols:
-					libraryIdentifier = librarySymbol.NormalizedIdentifier
+					libraryIdentifier = librarySymbol.Name.NormalizedIdentifier
 					try:
 						library = self._libraries[libraryIdentifier]
 					except KeyError:
@@ -669,7 +670,7 @@ class Design(ModelEntity):
 			for packageReference in context.PackageReferences:
 				# A use clause can have multiple comma-separated references
 				for symbol in packageReference.Symbols:
-					packageSymbol = symbol.Prefix
+					packageSymbol = symbol.Name.Prefix
 					librarySymbol = packageSymbol.Prefix
 
 					libraryIdentifier = librarySymbol.NormalizedIdentifier

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -1239,7 +1239,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 		if not isinstance(item, Architecture):
 			raise TypeError(f"Parameter 'item' is not of type 'Architecture'.")
 
-		entity = item.Entity
+		entity = item.Entity.Name
 		entityIdentifier = entity.NormalizedIdentifier
 		try:
 			architectures = self._architectures[entityIdentifier]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,9 +4,9 @@
 Coverage>=7.2
 
 # Test Runner
-pytest>=7.2.0
+pytest>=7.3.0
 pytest-cov>=4.0.0
 
 # Static Type Checking
-mypy>=1.1.1
+mypy>=1.2.0
 lxml>=4.9

--- a/tests/unit/Analyze.py
+++ b/tests/unit/Analyze.py
@@ -34,6 +34,7 @@ from pathlib  import Path
 from unittest import TestCase
 
 from pyVHDLModel import Design, Document
+from pyVHDLModel.Name import SimpleName, SelectedName, AllName
 from pyVHDLModel.Symbol import LibraryReferenceSymbol, PackageReferenceSymbol, AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol, EntitySymbol, PackageSymbol, EntityInstantiationSymbol
 from pyVHDLModel.DesignUnit import Package, PackageBody, Context, Entity, Architecture, Configuration
@@ -57,10 +58,10 @@ class VHDLLibrary(TestCase):
 
 		contextReferences = [
 			LibraryClause([
-				LibraryReferenceSymbol("ieee"),
+				LibraryReferenceSymbol(SimpleName("ieee")),
 			]),
 			UseClause([
-				AllPackageMembersReferenceSymbol(PackageReferenceSymbol("std_logic_1164", LibraryReferenceSymbol("ieee"))),
+				AllPackageMembersReferenceSymbol(AllName(SelectedName("std_logic_1164", SimpleName("ieee")))),
 			])
 		]
 		context = Context("ctx_1", contextReferences, documentation="My first context.")
@@ -71,13 +72,13 @@ class VHDLLibrary(TestCase):
 			# 	PackageMembersReferenceSymbol("Stop", PackageReferenceSymbol("env", LibraryReferenceSymbol("std"))),
 			# ]),
 			LibraryClause([
-				LibraryReferenceSymbol("ieee"),
+				LibraryReferenceSymbol(SimpleName("ieee")),
 			]),
 			UseClause([
-				AllPackageMembersReferenceSymbol(PackageReferenceSymbol("numeric_std", LibraryReferenceSymbol("ieee"))),
+				AllPackageMembersReferenceSymbol(AllName(SelectedName("numeric_std", SimpleName("ieee")))),
 			]),
 			UseClause([
-				AllPackageMembersReferenceSymbol(PackageReferenceSymbol("pack_1", LibraryReferenceSymbol("work"))),
+				AllPackageMembersReferenceSymbol(AllName(SelectedName("pack_1", SimpleName("work")))),
 			])
 		]
 		entityA = Entity("entity_A", entityAReferences, documentation="My first entity.")
@@ -85,36 +86,36 @@ class VHDLLibrary(TestCase):
 
 		architectureAReferences = [
 			UseClause([
-				AllPackageMembersReferenceSymbol(PackageReferenceSymbol("textio", LibraryReferenceSymbol("std"))),
+				AllPackageMembersReferenceSymbol(AllName(SelectedName("textio", SimpleName("std")))),
 			]),
 		]
-		architectureA = Architecture("arch_A", EntitySymbol("entity_A"), architectureAReferences, documentation="My first entity implementation.")
+		architectureA = Architecture("arch_A", EntitySymbol(SimpleName("entity_A")), architectureAReferences, documentation="My first entity implementation.")
 		document._AddDesignUnit(architectureA)
 
 		entityBReferences = [
 			ContextReference([
-				ContextReferenceSymbol("ctx_1", LibraryReferenceSymbol("work")),
+				ContextReferenceSymbol(SelectedName("ctx_1", SimpleName("work"))),
 			]),
 		]
 		entityB = Entity("entity_B", entityBReferences, documentation="My second entity.")
 		document._AddDesignUnit(entityB)
 
 		architectureBStatements = [
-			EntityInstantiation("instWork", EntityInstantiationSymbol("entity_A", LibraryReferenceSymbol("work"))),
-			EntityInstantiation("instLib", EntityInstantiationSymbol("entity_A", LibraryReferenceSymbol("lib_1"))),
+			EntityInstantiation("instWork", EntityInstantiationSymbol(SelectedName("entity_A", SimpleName("work")))),
+			EntityInstantiation("instLib", EntityInstantiationSymbol(SelectedName("entity_A", SimpleName("lib_1")))),
 		]
-		architectureB = Architecture("arch_B", EntitySymbol("entity_B"), None, None, architectureBStatements, documentation="My second entity implementation.")
+		architectureB = Architecture("arch_B", EntitySymbol(SimpleName("entity_B")), None, None, architectureBStatements, documentation="My second entity implementation.")
 		document._AddDesignUnit(architectureB)
 
 		packageReferences = [
 			ContextReference([
-				ContextReferenceSymbol("ctx_1", LibraryReferenceSymbol("work")),
+				ContextReferenceSymbol(SelectedName("ctx_1", SimpleName("work"))),
 			]),
 		]
 		package = Package("pack_1", packageReferences, documentation="My first utility package.")
 		document._AddDesignUnit(package)
 
-		packageBody = PackageBody(PackageSymbol("pack_1"))
+		packageBody = PackageBody(PackageSymbol(SimpleName("pack_1")))
 		document._AddDesignUnit(packageBody)
 
 		configuration = Configuration("cfg_1")

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -150,18 +150,25 @@ class Symbols(TestCase):
 		self.assertEqual("Library: 'liB'", str(symbol))
 
 	def test_PackageReferenceSymbol(self):
-		symbol = PackageReferenceSymbol(SelectedName("pack", SimpleName("Lib")))
+		name = SelectedName("Pack", SimpleName("Lib"))
+		symbol = PackageReferenceSymbol(name)
 
-		self.assertEqual("pack", symbol.Name.NormalizedIdentifier)
-		self.assertEqual("lib", symbol.Name.Prefix.NormalizedIdentifier)
-		self.assertTrue(symbol.Name.HasPrefix)
+		self.assertIs(name, symbol.Name)
+		self.assertFalse(symbol.IsResolved)
+		self.assertIsNone(symbol.Reference)
+		self.assertIsNone(symbol.Package)
+		self.assertEqual("PackageReferenceSymbol: 'Lib.Pack' -> unresolved", repr(symbol))
+		self.assertEqual("Lib.Pack?", str(symbol))
 
-		# library = Library("liB")
-		package = Package("Pack")
+		library = Library("liB")
+		package = Package("pacK")
+		package.Library = library
 		symbol.Package = package
 
 		self.assertTrue(symbol.IsResolved)
 		self.assertIs(package, symbol.Package)
+		self.assertEqual("PackageReferenceSymbol: 'Lib.Pack' -> Package: 'liB.pacK'", repr(symbol))
+		self.assertEqual("Package: 'liB.pacK'", str(symbol))
 
 	def test_PackageMembersReferenceSymbol(self):
 		symbol = PackageMembersReferenceSymbol(SelectedName("obj", SelectedName("pack", SimpleName("Lib"))))

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -57,11 +57,11 @@ class Symbols(TestCase):
 	def test_LibraryReferenceSymbol(self):
 		symbol = LibraryReferenceSymbol(SimpleName("Lib"))
 
-		self.assertEqual("Lib", symbol.Identifier)
-		self.assertEqual("lib", symbol.NormalizedIdentifier)
-		self.assertIs(symbol, symbol.Root)
-		self.assertIsNone(symbol.Prefix)
-		self.assertFalse(symbol.HasPrefix)
+		self.assertEqual("Lib", symbol.Name.Identifier)
+		self.assertEqual("lib", symbol.Name.NormalizedIdentifier)
+		self.assertIs(symbol.Name, symbol.Name.Root)
+		self.assertIsNone(symbol.Name.Prefix)
+		self.assertFalse(symbol.Name.HasPrefix)
 		self.assertFalse(symbol.IsResolved)
 
 		library = Library("liB")
@@ -73,44 +73,41 @@ class Symbols(TestCase):
 	def test_PackageReferenceSymbol(self):
 		symbol = PackageReferenceSymbol(SelectedName("pack", SimpleName("Lib")))
 
-		self.assertEqual("pack", symbol.NormalizedIdentifier)
-		self.assertEqual("lib", symbol.Prefix.NormalizedIdentifier)
-		self.assertTrue(symbol.HasPrefix)
+		self.assertEqual("pack", symbol.Name.NormalizedIdentifier)
+		self.assertEqual("lib", symbol.Name.Prefix.NormalizedIdentifier)
+		self.assertTrue(symbol.Name.HasPrefix)
 
-		library = Library("liB")
+		# library = Library("liB")
 		package = Package("Pack")
 		symbol.Package = package
-		symbol.Prefix.Library = library
 
 		self.assertTrue(symbol.IsResolved)
-		self.assertTrue(symbol.Prefix.IsResolved)
-		self.assertIs(library, symbol.Prefix.Library)
 		self.assertIs(package, symbol.Package)
 
 	def test_PackageMembersReferenceSymbol(self):
 		symbol = PackageMembersReferenceSymbol(SelectedName("obj", SelectedName("pack", SimpleName("Lib"))))
 
-		self.assertEqual("obj", symbol.NormalizedIdentifier)
-		self.assertEqual("pack", symbol.Prefix.NormalizedIdentifier)
-		self.assertEqual("lib", symbol.Prefix.Prefix.NormalizedIdentifier)
+		self.assertEqual("obj", symbol.Name.NormalizedIdentifier)
+		self.assertEqual("pack", symbol.Name.Prefix.NormalizedIdentifier)
+		self.assertEqual("lib", symbol.Name.Prefix.Prefix.NormalizedIdentifier)
 
 	def test_AllPackageMembersReferenceSymbol(self):
 		symbol = AllPackageMembersReferenceSymbol(AllName(SelectedName("pack", SimpleName("Lib"))))
 
-		self.assertEqual("all", symbol.NormalizedIdentifier)
-		self.assertEqual("pack", symbol.Prefix.NormalizedIdentifier)
-		self.assertEqual("lib", symbol.Prefix.Prefix.NormalizedIdentifier)
+		self.assertEqual("all", symbol.Name.NormalizedIdentifier)
+		self.assertEqual("pack", symbol.Name.Prefix.NormalizedIdentifier)
+		self.assertEqual("lib", symbol.Name.Prefix.Prefix.NormalizedIdentifier)
 
 	def test_ContextReferenceSymbol(self):
 		symbol = ContextReferenceSymbol(SelectedName("ctx", SimpleName("Lib")))
 
-		self.assertEqual("ctx", symbol.NormalizedIdentifier)
-		self.assertEqual("lib", symbol.Prefix.NormalizedIdentifier)
+		self.assertEqual("ctx", symbol.Name.NormalizedIdentifier)
+		self.assertEqual("lib", symbol.Name.Prefix.NormalizedIdentifier)
 
 	def test_EntitySymbol(self):
 		symbol = EntitySymbol(SimpleName("ent"))
 
-		self.assertEqual("ent", symbol.NormalizedIdentifier)
+		self.assertEqual("ent", symbol.Name.NormalizedIdentifier)
 
 	# def test_ArchitectureSymbol(self):
 	# 	symbol = ArchitectureSymbol("rtl")
@@ -120,23 +117,23 @@ class Symbols(TestCase):
 	def test_PackageSymbol(self):
 		symbol = PackageSymbol(SimpleName("pack"))
 
-		self.assertEqual("pack", symbol.NormalizedIdentifier)
+		self.assertEqual("pack", symbol.Name.NormalizedIdentifier)
 
 	def test_EntityInstantiationSymbol(self):
 		symbol = EntityInstantiationSymbol(SelectedName("ent", SimpleName("Lib")))
 
-		self.assertEqual("ent", symbol.NormalizedIdentifier)
-		self.assertEqual("lib", symbol.Prefix.NormalizedIdentifier)
+		self.assertEqual("ent", symbol.Name.NormalizedIdentifier)
+		self.assertEqual("lib", symbol.Name.Prefix.NormalizedIdentifier)
 
 	def test_ComponentInstantiationSymbol(self):
 		symbol = ComponentInstantiationSymbol(SimpleName("comp"))
 
-		self.assertEqual("comp", symbol.NormalizedIdentifier)
+		self.assertEqual("comp", symbol.Name.NormalizedIdentifier)
 
 	def test_ConfigurationInstantiationSymbol(self):
 		symbol = ConfigurationInstantiationSymbol(SimpleName("cfg"))
 
-		self.assertEqual("cfg", symbol.NormalizedIdentifier)
+		self.assertEqual("cfg", symbol.Name.NormalizedIdentifier)
 
 
 class SimpleInstance(TestCase):
@@ -188,8 +185,8 @@ class SimpleInstance(TestCase):
 		self.assertEqual(0, len(entity.Statements))
 
 	def test_Architecture(self):
-		entity = EntitySymbol("entity_1")
-		architecture = Architecture("arch_1", entity)
+		entitySymbol = EntitySymbol(SimpleName("entity_1"))
+		architecture = Architecture("arch_1", entitySymbol)
 
 		self.assertIsNotNone(architecture)
 		self.assertEqual("arch_1", architecture.Identifier)
@@ -204,7 +201,7 @@ class SimpleInstance(TestCase):
 		self.assertEqual(0, len(package.DeclaredItems))
 
 	def test_PackageBody(self):
-		packageSymbol = PackageSymbol("pack_1")
+		packageSymbol = PackageSymbol(SimpleName("pack_1"))
 		packageBody = PackageBody(packageSymbol)
 
 		self.assertIsNotNone(packageBody)
@@ -275,8 +272,8 @@ class VHDLDocument(TestCase):
 		path = Path("tests.vhdl")
 		document = Document(path)
 
-		entity = EntitySymbol("entity_1")
-		architecture = Architecture("arch_1", entity)
+		entitySymbol = EntitySymbol(SimpleName("entity_1"))
+		architecture = Architecture("arch_1", entitySymbol)
 		document._AddArchitecture(architecture)
 
 		self.assertEqual(1, len(document.Architectures))
@@ -296,7 +293,7 @@ class VHDLDocument(TestCase):
 		path = Path("tests.vhdl")
 		document = Document(path)
 
-		packageSymbol = PackageSymbol("pack_1")
+		packageSymbol = PackageSymbol(SimpleName("pack_1"))
 		packageBody = PackageBody(packageSymbol)
 		document._AddPackageBody(packageBody)
 
@@ -327,17 +324,17 @@ class VHDLDocument(TestCase):
 		path = Path("tests.vhdl")
 		document = Document(path, documentation="Testing 'Document' class.")
 
-		entity = Entity("entity_1")
-		document._AddDesignUnit(entity)
+		entitySymbol = Entity("entity_1")
+		document._AddDesignUnit(entitySymbol)
 
-		entity = EntitySymbol("entity_1")
-		architecture = Architecture("arch_1", entity)
+		entitySymbol = EntitySymbol(SimpleName("entity_1"))
+		architecture = Architecture("arch_1", entitySymbol)
 		document._AddDesignUnit(architecture)
 
 		package = Package("pack_1")
 		document._AddDesignUnit(package)
 
-		packageSymbol = PackageSymbol("pack_1")
+		packageSymbol = PackageSymbol(SimpleName("pack_1"))
 		packageBody = PackageBody(packageSymbol)
 		document._AddDesignUnit(packageBody)
 
@@ -389,9 +386,9 @@ class VHDLLibrary(TestCase):
 		document = Document(path, documentation="Testing 'Library' class.")
 
 		document._AddDesignUnit(Entity("entity_1"))
-		document._AddDesignUnit(Architecture("arch_1", EntitySymbol("entity_1")))
+		document._AddDesignUnit(Architecture("arch_1", EntitySymbol(SimpleName("entity_1"))))
 		document._AddDesignUnit(Package("pack_1"))
-		document._AddDesignUnit(PackageBody(PackageSymbol("pack_1")))
+		document._AddDesignUnit(PackageBody(PackageSymbol(SimpleName("pack_1"))))
 		document._AddDesignUnit(Context("ctx_1"))
 		document._AddDesignUnit(Configuration("cfg_1"))
 

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -37,6 +37,7 @@ from pyTooling.Graph import Graph
 
 from pyVHDLModel import Design, Library, Document
 from pyVHDLModel.Base import Direction, Range
+from pyVHDLModel.Name import SelectedName, SimpleName, AllName
 from pyVHDLModel.Symbol import LibraryReferenceSymbol, PackageReferenceSymbol, PackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol, ContextReferenceSymbol, EntitySymbol
 from pyVHDLModel.Symbol import ArchitectureSymbol, PackageSymbol, EntityInstantiationSymbol
@@ -54,7 +55,7 @@ if __name__ == "__main__":  # pragma: no cover
 
 class Symbols(TestCase):
 	def test_LibraryReferenceSymbol(self):
-		symbol = LibraryReferenceSymbol("Lib")
+		symbol = LibraryReferenceSymbol(SimpleName("Lib"))
 
 		self.assertEqual("Lib", symbol.Identifier)
 		self.assertEqual("lib", symbol.NormalizedIdentifier)
@@ -70,7 +71,7 @@ class Symbols(TestCase):
 		self.assertIs(library, symbol.Library)
 
 	def test_PackageReferenceSymbol(self):
-		symbol = PackageReferenceSymbol("pack", LibraryReferenceSymbol("Lib"))
+		symbol = PackageReferenceSymbol(SelectedName("pack", SimpleName("Lib")))
 
 		self.assertEqual("pack", symbol.NormalizedIdentifier)
 		self.assertEqual("lib", symbol.Prefix.NormalizedIdentifier)
@@ -87,27 +88,27 @@ class Symbols(TestCase):
 		self.assertIs(package, symbol.Package)
 
 	def test_PackageMembersReferenceSymbol(self):
-		symbol = PackageMembersReferenceSymbol("obj", PackageReferenceSymbol("pack", LibraryReferenceSymbol("Lib")))
+		symbol = PackageMembersReferenceSymbol(SelectedName("obj", SelectedName("pack", SimpleName("Lib"))))
 
 		self.assertEqual("obj", symbol.NormalizedIdentifier)
 		self.assertEqual("pack", symbol.Prefix.NormalizedIdentifier)
 		self.assertEqual("lib", symbol.Prefix.Prefix.NormalizedIdentifier)
 
 	def test_AllPackageMembersReferenceSymbol(self):
-		symbol = AllPackageMembersReferenceSymbol(PackageReferenceSymbol("pack", LibraryReferenceSymbol("Lib")))
+		symbol = AllPackageMembersReferenceSymbol(AllName(SelectedName("pack", SimpleName("Lib"))))
 
 		self.assertEqual("all", symbol.NormalizedIdentifier)
 		self.assertEqual("pack", symbol.Prefix.NormalizedIdentifier)
 		self.assertEqual("lib", symbol.Prefix.Prefix.NormalizedIdentifier)
 
 	def test_ContextReferenceSymbol(self):
-		symbol = ContextReferenceSymbol("ctx", LibraryReferenceSymbol("Lib"))
+		symbol = ContextReferenceSymbol(SelectedName("ctx", SimpleName("Lib")))
 
 		self.assertEqual("ctx", symbol.NormalizedIdentifier)
 		self.assertEqual("lib", symbol.Prefix.NormalizedIdentifier)
 
 	def test_EntitySymbol(self):
-		symbol = EntitySymbol("ent")
+		symbol = EntitySymbol(SimpleName("ent"))
 
 		self.assertEqual("ent", symbol.NormalizedIdentifier)
 
@@ -117,23 +118,23 @@ class Symbols(TestCase):
 	# 	self.assertEqual("rtl", symbol.NormalizedIdentifier)
 
 	def test_PackageSymbol(self):
-		symbol = PackageSymbol("pack")
+		symbol = PackageSymbol(SimpleName("pack"))
 
 		self.assertEqual("pack", symbol.NormalizedIdentifier)
 
 	def test_EntityInstantiationSymbol(self):
-		symbol = EntityInstantiationSymbol("ent", LibraryReferenceSymbol("Lib"))
+		symbol = EntityInstantiationSymbol(SelectedName("ent", SimpleName("Lib")))
 
 		self.assertEqual("ent", symbol.NormalizedIdentifier)
 		self.assertEqual("lib", symbol.Prefix.NormalizedIdentifier)
 
 	def test_ComponentInstantiationSymbol(self):
-		symbol = ComponentInstantiationSymbol("comp")
+		symbol = ComponentInstantiationSymbol(SimpleName("comp"))
 
 		self.assertEqual("comp", symbol.NormalizedIdentifier)
 
 	def test_ConfigurationInstantiationSymbol(self):
-		symbol = ConfigurationInstantiationSymbol("cfg")
+		symbol = ConfigurationInstantiationSymbol(SimpleName("cfg"))
 
 		self.assertEqual("cfg", symbol.NormalizedIdentifier)
 


### PR DESCRIPTION
This release reverts changes made to symbols and names in earlier releases. Both features were merged some versions ago, but as shown in #70, a symbol (semantic) can have multiple name styles (syntax).

# New Features
 
*None*

# Changes

* Reworked `Symbol` classes to be a separate class structure. (Formerly derived from `Name` classes).
* Derived `AllName` from `SelectedName`.
* Updated testcases according to the changes in symbols and names.
* Reworked some more `.format(...)` calls to f-strings.
* Bumped dependencies.

# Bug Fixes

*None*

----------
# Related Issues:

* Closes #70
