### PR TITLE
v0.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ on such a model, while supporting multiple frontends.
 
 * High-level API for [GHDL's](https://GitHub.com/ghdl/ghdl) `libghdl` offered via `pyghdl`.
 * Code Document-Object-Model (Code-DOM) in [pyVHDLParser](https://GitHub.com/Paebbels/pyVHDLParser).
+* [PyHDLio](https://github.com/amb5l/PyHDLio) based on an ANTLR4 grammar.
 * [pyVHDLModelTreesitter](https://gitlab.com/dawalters/pyVHDLModelTreesitter) based on [tree-sitter-vhdl](https://github.com/jpt13653903/tree-sitter-vhdl).
 
 ## pyVHDLModel Consumers

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Sourcecode on GitHub](https://img.shields.io/badge/VHDL-pyVHDLModel-29b6f6?longCache=true&style=flat-square&logo=GitHub&labelColor=0277bd)](https://github.com/vhdl/pyVHDLModel)
 [![Sourcecode License](https://img.shields.io/pypi/l/pyVHDLModel?longCache=true&style=flat-square&logo=Apache&label=code)](LICENSE.md)
 [![Documentation](https://img.shields.io/website?longCache=true&style=flat-square&label=vhdl.github.io%2FpyVHDLModel&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Fvhdl.github.io%2FpyVHDLModel%2Findex.html)](https://vhdl.github.io/pyVHDLModel/)
-[![Documentation License](https://img.shields.io/badge/doc-CC--BY%204.0-green?longCache=true&style=flat-square&logo=CreativeCommons&logoColor=fff)](LICENSE.md)
+[![Documentation License](https://img.shields.io/badge/doc-CC--BY%204.0-green?longCache=true&style=flat-square&logo=CreativeCommons&logoColor=fff)](doc/Doc-License.rst)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-4db797?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef)](https://gitter.im/hdl/community)  
 [![PyPI](https://img.shields.io/pypi/v/pyVHDLModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)](https://pypi.org/project/pyVHDLModel/)
 ![PyPI - Status](https://img.shields.io/pypi/status/pyVHDLModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)
@@ -90,7 +90,7 @@ for entity in document.Entities.values():
 
 # License
 
-This Python package (source code) licensed under [Apache License 2.0](LICENSE.md).  
+This Python package (source code) is licensed under [Apache License 2.0](LICENSE.md).  
 The accompanying documentation is licensed under [Creative Commons - Attribution 4.0 (CC-BY 4.0)](doc/Doc-License.rst).
 
 -------------------------

--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -55,7 +55,7 @@ the mandatory dependencies too.
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `pytest-cov <https://GitHub.com/pytest-dev/pytest-cov>`__           | ≥7.1        | `MIT <https://GitHub.com/pytest-dev/pytest-cov/blob/master/LICENSE>`__                 | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
-| `Coverage <https://GitHub.com/nedbat/coveragepy>`__                 | ≥7.13       | `Apache License, 2.0 <https://GitHub.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__ | *Not yet evaluated.* |
+| `Coverage <https://GitHub.com/nedbat/coveragepy>`__                 | ≥7.14       | `Apache License, 2.0 <https://GitHub.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__ | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `mypy <https://GitHub.com/python/mypy>`__                           | ≥1.19       | `MIT <https://GitHub.com/python/mypy/blob/master/LICENSE>`__                           | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,7 @@
 
 .. only:: html
 
-   |  |SHIELD:svg:pyVHDLModel-github| |SHIELD:svg:pyVHDLModel-src-license| |SHIELD:svg:pyVHDLModel-ghp-doc| |SHIELD:svg:pyVHDLModel-doc-license| |SHIELD:svg:pyVHDLModel-gitter|
+   |  |SHIELD:svg:pyVHDLModel-github| |SHIELD:svg:pyVHDLModel-src-license| |SHIELD:svg:pyVHDLModel-ghp-doc| |SHIELD:svg:pyVHDLModel-doc-license|
    |  |SHIELD:svg:pyVHDLModel-pypi-tag| |SHIELD:svg:pyVHDLModel-pypi-status| |SHIELD:svg:pyVHDLModel-pypi-python|
    |  |SHIELD:svg:pyVHDLModel-gha-test| |SHIELD:svg:pyVHDLModel-lib-status| |SHIELD:svg:pyVHDLModel-codacy-quality| |SHIELD:svg:pyVHDLModel-codacy-coverage| |SHIELD:svg:pyVHDLModel-codecov-coverage|
 
@@ -23,7 +23,7 @@
 
 .. only:: latex
 
-   |SHIELD:png:pyVHDLModel-github| |SHIELD:png:pyVHDLModel-src-license| |SHIELD:png:pyVHDLModel-ghp-doc| |SHIELD:png:pyVHDLModel-doc-license| |SHIELD:svg:pyVHDLModel-gitter|
+   |SHIELD:png:pyVHDLModel-github| |SHIELD:png:pyVHDLModel-src-license| |SHIELD:png:pyVHDLModel-ghp-doc| |SHIELD:png:pyVHDLModel-doc-license|
    |SHIELD:png:pyVHDLModel-pypi-tag| |SHIELD:png:pyVHDLModel-pypi-status| |SHIELD:png:pyVHDLModel-pypi-python|
    |SHIELD:png:pyVHDLModel-gha-test| |SHIELD:png:pyVHDLModel-lib-status| |SHIELD:png:pyVHDLModel-codacy-quality| |SHIELD:png:pyVHDLModel-codacy-coverage| |SHIELD:png:pyVHDLModel-codecov-coverage|
 
@@ -56,6 +56,8 @@ Use Cases
 
 * High-level API for `GHDL's <https://GitHub.com/ghdl/ghdl>`__ `libghdl` offered via `pyGHDL <https://ghdl.github.io/ghdl/pyGHDL/pyGHDL.html>`__.
 * Code Document-Object-Model (Code-DOM) in `pyVHDLParser <https://paebbels.github.io/pyVHDLParser/>`__.
+* `PyHDLio <https://github.com/amb5l/PyHDLio>`__ based on an ANTLR4 grammar.
+* `pyVHDLModelTreesitter <https://gitlab.com/dawalters/pyVHDLModelTreesitter>`__ based on `tree-sitter-vhdl <https://github.com/jpt13653903/tree-sitter-vhdl>`__.
 
 
 .. _NEWS:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -239,15 +239,8 @@ Contributors
 License
 *******
 
-.. only:: html
-
-   This Python package (source code) is licensed under `Apache License 2.0 <Code-License.html>`__. |br|
-   The accompanying documentation is licensed under `Creative Commons - Attribution 4.0 (CC-BY 4.0) <Doc-License.html>`__.
-
-.. only:: latex
-
-   This Python package (source code) is licensed under **Apache License 2.0**. |br|
-   The accompanying documentation is licensed under **Creative Commons - Attribution 4.0 (CC-BY 4.0)**.
+This Python package (source code) is licensed under :ref:`Apache License 2.0 <CODELICENSE>`. |br|
+The accompanying documentation is licensed under :ref:`Creative Commons - Attribution 4.0 (CC-BY 4.0) <DOCLICENSE>`.
 
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,6 +65,58 @@ News
 
 .. only:: html
 
+   April 2026 - Generic, Port, and Parameter Groups
+   ================================================
+
+.. only:: latex
+
+   .. rubric:: Generic, Port, and Parameter Groups
+
+* Link components in architectures and components nested in concurrent statements.
+* Added grouping of generics, ports and parameters.
+
+
+.. only:: html
+
+   Nov. 2025 - Raise Warnings
+   ==========================
+
+.. only:: latex
+
+   .. rubric:: Raise Warnings
+
+* Handle bit-string literals
+* Raise Warnings instead of Exceptions.
+
+
+.. only:: html
+
+   Feb. 2025 - Blackboxes
+   ======================
+
+.. only:: latex
+
+   .. rubric:: Blackboxes
+
+* Support handling of blackboxes for component instantiations.
+* Added dummy packages for Synopsys and Mentor Graphics "IEEE" packages.
+
+
+.. only:: html
+
+   Sept. 2024 - Unary Operators
+   ============================
+
+.. only:: latex
+
+   .. rubric:: Unary Operators
+
+* Added more unary operators.
+* Added more doc-strings
+
+
+.. only:: html
+
    Jan. 2023 - Dependency, Hierarchy, Compile Order Analysis
    =========================================================
 
@@ -80,6 +132,7 @@ News
 
 * Transformation from single module to >15 modules.
 * Improved code coverage and test cases.
+
 
 .. only:: html
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,5 +13,5 @@ sphinxcontrib-mermaid ~= 2.0
 autoapi >= 2.0.1
 sphinx_design ~= 0.7.0
 sphinx-copybutton >= 0.5.2
-sphinx_autodoc_typehints ~= 3.10
-sphinx_reports ~= 0.10.0
+sphinx_autodoc_typehints ~= 3.11
+sphinx_reports ~= 0.11.0

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -137,13 +137,13 @@ class ModelEntity(metaclass=ExtendedType, slots=True):
 @export
 class NamedEntityMixin(metaclass=ExtendedType, mixin=True):
 	"""
-	A ``NamedEntityMixin`` is a mixin class for all VHDL entities that have identifiers.
+	A ``NamedEntityMixin`` is a mixin class for all VHDL entities that have an identifier.
 
 	Protected variables :attr:`_identifier` and :attr:`_normalizedIdentifier` are available to derived classes as well as
 	two readonly properties :attr:`Identifier` and :attr:`NormalizedIdentifier` for public access.
 	"""
 
-	_identifier: str            #: The identifier of a model entity.
+	_identifier:           str  #: The identifier of a model entity.
 	_normalizedIdentifier: str  #: The normalized (lower case) identifier of a model entity.
 
 	def __init__(self, identifier: str) -> None:
@@ -401,7 +401,7 @@ class Range(ModelEntity):
 	_rightBound: ExpressionUnion
 	_direction:  Direction
 
-	def __init__(self, leftBound: ExpressionUnion, rightBound: ExpressionUnion, direction: Direction, parent: ModelEntity = None) -> None:
+	def __init__(self, leftBound: ExpressionUnion, rightBound: ExpressionUnion, direction: Direction, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._leftBound = leftBound
@@ -433,7 +433,7 @@ class WaveformElement(ModelEntity):
 	_expression: ExpressionUnion
 	_after: ExpressionUnion
 
-	def __init__(self, expression: ExpressionUnion, after: Nullable[ExpressionUnion] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, expression: ExpressionUnion, after: Nullable[ExpressionUnion] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._expression = expression

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -175,6 +175,46 @@ class NamedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
+class OptionallyNamedEntityMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A ``OptionallyNamedEntityMixin`` is a mixin class for all VHDL entities that have an optional identifier.
+
+	Protected variables :attr:`_identifier` and :attr:`_normalizedIdentifier` are available to derived classes as well as
+	two readonly properties :attr:`Identifier` and :attr:`NormalizedIdentifier` for public access.
+	"""
+
+	_identifier:           Nullable[str]  #: The identifier of a model entity.
+	_normalizedIdentifier: Nullable[str]  #: The normalized (lower case) identifier of a model entity.
+
+	def __init__(self, identifier: Nullable[str]) -> None:
+		"""
+		Initializes a named entity.
+
+		:param identifier: Identifier (name) of the model entity.
+		"""
+		self._identifier = identifier
+		self._normalizedIdentifier = identifier.lower() if identifier is not None else None
+
+	@readonly
+	def Identifier(self) -> Nullable[str]:
+		"""
+		Returns a model entity's identifier (name).
+
+		:returns: Name of a model entity.
+		"""
+		return self._identifier
+
+	@readonly
+	def NormalizedIdentifier(self) -> Nullable[str]:
+		"""
+		Returns a model entity's normalized identifier (lower case name).
+
+		:returns: Normalized name of a model entity.
+		"""
+		return self._normalizedIdentifier
+
+
+@export
 class MultipleNamedEntityMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A ``MultipleNamedEntityMixin`` is a mixin class for all VHDL entities that declare multiple instances at once by

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -138,7 +138,7 @@ class Instantiation(ConcurrentStatement):
 		label: str,
 		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
 		portAssociations: Nullable[Iterable[AssociationItem]] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 
@@ -185,7 +185,7 @@ class ComponentInstantiation(Instantiation):
 		componentSymbol: ComponentInstantiationSymbol,
 		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
 		portAssociations: Nullable[Iterable[AssociationItem]] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, genericAssociations, portAssociations, parent)
 
@@ -219,7 +219,7 @@ class EntityInstantiation(Instantiation):
 		architectureSymbol: Nullable[ArchitectureSymbol] = None,
 		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
 		portAssociations: Nullable[Iterable[AssociationItem]] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, genericAssociations, portAssociations, parent)
 
@@ -259,7 +259,7 @@ class ConfigurationInstantiation(Instantiation):
 		configurationSymbol: ConfigurationInstantiationSymbol,
 		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
 		portAssociations: Nullable[Iterable[AssociationItem]] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, genericAssociations, portAssociations, parent)
 
@@ -296,7 +296,7 @@ class ProcessStatement(ConcurrentStatement, SequentialDeclarationsMixin, Sequent
 		statements: Nullable[Iterable[SequentialStatement]] = None,
 		sensitivityList: Nullable[Iterable[Name]] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		SequentialDeclarationsMixin.__init__(self, declaredItems)
@@ -323,7 +323,7 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 		label: str,
 		procedureName: Name,
 		parameterMappings: Nullable[Iterable[ParameterAssociationItem]] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		ProcedureCallMixin.__init__(self, procedureName, parameterMappings)
@@ -341,7 +341,7 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 		statements:    Iterable['ConcurrentStatement'] = None,
 		documentation: Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		BlockStatementMixin.__init__(self)
@@ -386,7 +386,7 @@ class GenerateBranch(ModelEntity, ConcurrentDeclarationRegionMixin, ConcurrentSt
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
 		allowBlackbox:    Nullable[bool] = None,
-		parent:           ModelEntity = None
+		parent:           Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
@@ -434,7 +434,7 @@ class IfGenerateBranch(GenerateBranch, IfBranchMixin):
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
 		allowBlackbox:    Nullable[bool] = None,
-		parent:           ModelEntity = None
+		parent:           Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(declaredItems, statements, alternativeLabel, allowBlackbox, parent)
 		IfBranchMixin.__init__(self, condition)
@@ -467,7 +467,7 @@ class ElsifGenerateBranch(GenerateBranch, ElsifBranchMixin):
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
 		allowBlackbox:    Nullable[bool] = None,
-		parent:           ModelEntity = None
+		parent:           Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(declaredItems, statements, alternativeLabel, allowBlackbox, parent)
 		ElsifBranchMixin.__init__(self, condition)
@@ -499,7 +499,7 @@ class ElseGenerateBranch(GenerateBranch, ElseBranchMixin):
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
 		allowBlackbox:    Nullable[bool] = None,
-		parent:           ModelEntity = None
+		parent:           Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(declaredItems, statements, alternativeLabel, allowBlackbox, parent)
 		ElseBranchMixin.__init__(self)
@@ -523,7 +523,7 @@ class GenerateStatement(ConcurrentStatement, AllowBlackboxMixin):
 		self,
 		label:         Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		AllowBlackboxMixin.__init__(self, allowBlackbox)
@@ -575,7 +575,7 @@ class IfGenerateStatement(GenerateStatement):
 		elsifBranches: Nullable[Iterable[ElsifGenerateBranch]] = None,
 		elseBranch:    Nullable[ElseGenerateBranch] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, allowBlackbox, parent)
 
@@ -630,7 +630,7 @@ class ConcurrentChoice(BaseChoice):
 class IndexedGenerateChoice(ConcurrentChoice):
 	_expression: ExpressionUnion
 
-	def __init__(self, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._expression = expression
@@ -648,7 +648,7 @@ class IndexedGenerateChoice(ConcurrentChoice):
 class RangedGenerateChoice(ConcurrentChoice):
 	_range: 'Range'
 
-	def __init__(self, rng: 'Range', parent: ModelEntity = None) -> None:
+	def __init__(self, rng: 'Range', parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._range = rng
@@ -670,7 +670,7 @@ class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMi
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
 		allowBlackbox:    Nullable[bool] = None,
-		parent:           ModelEntity = None
+		parent:           Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
 		LabeledEntityMixin.__init__(self, alternativeLabel)
@@ -690,7 +690,7 @@ class GenerateCase(ConcurrentCase):
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
 		allowBlackbox:    Nullable[bool] = None,
-		parent:           ModelEntity = None
+		parent:           Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(declaredItems, statements, alternativeLabel, allowBlackbox, parent)
 
@@ -744,7 +744,7 @@ class CaseGenerateStatement(GenerateStatement):
 		expression:    ExpressionUnion,
 		cases:         Iterable[ConcurrentCase],
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, allowBlackbox, parent)
 
@@ -800,7 +800,7 @@ class ForGenerateStatement(GenerateStatement, ConcurrentDeclarationRegionMixin, 
 		declaredItems: Nullable[Iterable] = None,
 		statements:    Nullable[Iterable[ConcurrentStatement]] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, allowBlackbox, parent)
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
@@ -842,7 +842,7 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 	   * :class:`~pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment`
 	   * :class:`~pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment`
 	"""
-	def __init__(self, label: str, target: Name, parent: ModelEntity = None) -> None:
+	def __init__(self, label: str, target: Name, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
 
@@ -851,7 +851,7 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment):
 	_waveform: List[WaveformElement]
 
-	def __init__(self, label: str, target: Name, waveform: Iterable[WaveformElement], parent: ModelEntity = None) -> None:
+	def __init__(self, label: str, target: Name, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
 
 		# TODO: extract to mixin
@@ -868,13 +868,13 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment):
 
 @export
 class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
-	def __init__(self, label: str, target: Name, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, label: str, target: Name, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
 
 
 @export
 class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment):
-	def __init__(self, label: str, target: Name, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, label: str, target: Name, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
 
 
@@ -886,7 +886,7 @@ class ConcurrentAssertStatement(ConcurrentStatement, AssertStatementMixin):
 		message: ExpressionUnion,
 		severity: Nullable[ExpressionUnion] = None,
 		label: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		AssertStatementMixin.__init__(self, condition, message, severity)

--- a/pyVHDLModel/Declaration.py
+++ b/pyVHDLModel/Declaration.py
@@ -103,7 +103,7 @@ class Attribute(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		identifier: str,
 		subtype: Symbol,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
@@ -141,7 +141,7 @@ class AttributeSpecification(ModelEntity, DocumentedEntityMixin):
 		entityClass: EntityClass,
 		expression: ExpressionUnion,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
 		DocumentedEntityMixin.__init__(self, documentation)
@@ -179,7 +179,7 @@ class AttributeSpecification(ModelEntity, DocumentedEntityMixin):
 # TODO: move somewhere else
 @export
 class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
 		Initializes underlying ``BaseType``.
 

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -46,7 +46,7 @@ from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, DocumentedEnti
 from pyVHDLModel.Namespace  import Namespace
 from pyVHDLModel.Regions    import ConcurrentDeclarationRegionMixin
 from pyVHDLModel.Symbol     import Symbol, PackageSymbol, EntitySymbol, LibraryReferenceSymbol
-from pyVHDLModel.Interface  import GenericInterfaceItemMixin, PortInterfaceItemMixin
+from pyVHDLModel.Interface  import GenericInterfaceItemMixin, PortInterfaceItemMixin, WithGenericsMixin, WithPortsMixin
 from pyVHDLModel.Object     import DeferredConstant
 from pyVHDLModel.Concurrent import ConcurrentStatement, ConcurrentStatementsMixin
 
@@ -414,7 +414,7 @@ class Context(PrimaryUnit):
 
 
 @export
-class Package(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegionMixin, AllowBlackboxMixin):
+class Package(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, ConcurrentDeclarationRegionMixin, AllowBlackboxMixin):
 	"""
 	Represents a package declaration.
 
@@ -428,8 +428,6 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegi
 	"""
 
 	_packageBody:       Nullable["PackageBody"]
-
-	_genericItems:      List[GenericInterfaceItemMixin]
 
 	_deferredConstants: Dict[str, DeferredConstant]
 	_components:        Dict[str, 'Component']
@@ -457,17 +455,11 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegi
 		"""
 		super().__init__(identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)
+		WithGenericsMixin.__init__(self, genericItems)
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
 		AllowBlackboxMixin.__init__(self, allowBlackbox)
 
 		self._packageBody = None
-
-		# TODO: extract to mixin
-		self._genericItems = []  # TODO: convert to dict
-		if genericItems is not None:
-			for generic in genericItems:
-				self._genericItems.append(generic)
-				generic._parent = self
 
 		self._deferredConstants = {}
 		self._components = {}
@@ -475,10 +467,6 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegi
 	@property
 	def PackageBody(self) -> Nullable["PackageBody"]:
 		return self._packageBody
-
-	@property
-	def GenericItems(self) -> List[GenericInterfaceItemMixin]:
-		return self._genericItems
 
 	@property
 	def DeclaredItems(self) -> List:
@@ -566,7 +554,7 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarati
 
 
 @export
-class Entity(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin):
+class Entity(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, WithPortsMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin):
 	"""
 	Represents an entity declaration.
 
@@ -578,9 +566,6 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegio
 	        -- ...
 	      end entity;
 	"""
-
-	_genericItems:  List[GenericInterfaceItemMixin]
-	_portItems:     List[PortInterfaceItemMixin]
 
 	_architectures: Dict[str, 'Architecture']
 
@@ -598,35 +583,13 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegio
 	) -> None:
 		super().__init__(identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)
+		WithGenericsMixin.__init__(self, genericItems)
+		WithPortsMixin.__init__(self, portItems)
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
 		ConcurrentStatementsMixin.__init__(self, statements)
 		AllowBlackboxMixin.__init__(self, allowBlackbox)
 
-		# TODO: extract to mixin
-		self._genericItems = []
-		if genericItems is not None:
-			for item in genericItems:
-				self._genericItems.append(item)
-				item._parent = self
-
-		# TODO: extract to mixin
-		self._portItems = []
-		if portItems is not None:
-			for item in portItems:
-				self._portItems.append(item)
-				item._parent = self
-
 		self._architectures = {}
-
-	# TODO: extract to mixin for generics
-	@property
-	def GenericItems(self) -> List[GenericInterfaceItemMixin]:
-		return self._genericItems
-
-	# TODO: extract to mixin for ports
-	@property
-	def PortItems(self) -> List[PortInterfaceItemMixin]:
-		return self._portItems
 
 	@property
 	def Architectures(self) -> Dict[str, 'Architecture']:

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -65,7 +65,7 @@ class Reference(ModelEntity):
 
 	_symbols:       List[Symbol]
 
-	def __init__(self, symbols: Iterable[Symbol], parent: ModelEntity = None) -> None:
+	def __init__(self, symbols: Iterable[Symbol], parent: Nullable[ModelEntity] = None) -> None:
 		"""
 		Initializes a reference by taking a list of symbols and a parent reference.
 
@@ -187,7 +187,7 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	_namespace:           'Namespace'
 
-	def __init__(self, identifier: str, contextItems: Nullable[Iterable[ContextUnion]] = None, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, contextItems: Nullable[Iterable[ContextUnion]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
 		Initializes a design unit.
 
@@ -373,7 +373,7 @@ class Context(PrimaryUnit):
 
 	_references:        List[ContextUnion]
 
-	def __init__(self, identifier: str, references: Nullable[Iterable[ContextUnion]] = None, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, references: Nullable[Iterable[ContextUnion]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, None, documentation, parent)
 
 		self._references = []
@@ -442,7 +442,7 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegi
 		declaredItems: Nullable[Iterable] = None,
 		documentation: Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		"""
 		Initialize a package.
@@ -534,7 +534,7 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarati
 		contextItems: Nullable[Iterable[ContextUnion]] = None,
 		declaredItems: Nullable[Iterable] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(packageSymbol.Name.Identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)
@@ -594,7 +594,7 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegio
 		statements:    Nullable[Iterable[ConcurrentStatement]] = None,
 		documentation: Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)
@@ -672,7 +672,7 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarat
 		statements:    Iterable['ConcurrentStatement'] = None,
 		documentation: Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)
@@ -728,7 +728,7 @@ class Component(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, AllowBlack
 		portItems:     Nullable[Iterable[PortInterfaceItemMixin]] = None,
 		documentation: Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
@@ -811,7 +811,7 @@ class Configuration(PrimaryUnit, DesignUnitWithContextMixin):
 		identifier: str,
 		contextItems: Nullable[Iterable[Context]] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -73,7 +73,7 @@ class NullLiteral(Literal):
 class EnumerationLiteral(Literal):
 	_value: str
 
-	def __init__(self, value: str, parent: ModelEntity = None) -> None:
+	def __init__(self, value: str, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._value = value
@@ -298,7 +298,7 @@ class UnaryExpression(BaseExpression):
 	_FORMAT:  Tuple[str, str]
 	_operand: ExpressionUnion
 
-	def __init__(self, operand: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, operand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._operand = operand
@@ -380,7 +380,7 @@ class BinaryExpression(BaseExpression):
 	_leftOperand:  ExpressionUnion
 	_rightOperand: ExpressionUnion
 
-	def __init__(self, leftOperand: ExpressionUnion, rightOperand: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, leftOperand: ExpressionUnion, rightOperand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._leftOperand = leftOperand
@@ -638,7 +638,7 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 	_operand:  ExpressionUnion
 	_subtype:  Symbol
 
-	def __init__(self, subtype: Symbol, operand: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, subtype: Symbol, operand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._operand = operand
@@ -668,7 +668,7 @@ class TernaryExpression(BaseExpression):
 	_secondOperand: ExpressionUnion
 	_thirdOperand:  ExpressionUnion
 
-	def __init__(self, parent: ModelEntity = None) -> None:
+	def __init__(self, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		# FIXME: parameters and initializers are missing !!
@@ -716,7 +716,7 @@ class Allocation(BaseExpression):
 class SubtypeAllocation(Allocation):
 	_subtype: Symbol
 
-	def __init__(self, subtype: Symbol, parent: ModelEntity = None) -> None:
+	def __init__(self, subtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._subtype = subtype
@@ -734,7 +734,7 @@ class SubtypeAllocation(Allocation):
 class QualifiedExpressionAllocation(Allocation):
 	_qualifiedExpression: QualifiedExpression
 
-	def __init__(self, qualifiedExpression: QualifiedExpression, parent: ModelEntity = None) -> None:
+	def __init__(self, qualifiedExpression: QualifiedExpression, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._qualifiedExpression = qualifiedExpression
@@ -754,7 +754,7 @@ class AggregateElement(ModelEntity):
 
 	_expression: ExpressionUnion
 
-	def __init__(self, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._expression = expression
@@ -775,7 +775,7 @@ class SimpleAggregateElement(AggregateElement):
 class IndexedAggregateElement(AggregateElement):
 	_index: int
 
-	def __init__(self, index: ExpressionUnion, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, index: ExpressionUnion, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(expression, parent)
 
 		self._index = index
@@ -792,7 +792,7 @@ class IndexedAggregateElement(AggregateElement):
 class RangedAggregateElement(AggregateElement):
 	_range: Range
 
-	def __init__(self, rng: Range, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, rng: Range, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(expression, parent)
 
 		self._range = rng
@@ -810,7 +810,7 @@ class RangedAggregateElement(AggregateElement):
 class NamedAggregateElement(AggregateElement):
 	_name: Symbol
 
-	def __init__(self, name: Symbol, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, name: Symbol, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(expression, parent)
 
 		self._name = name
@@ -839,7 +839,7 @@ class OthersAggregateElement(AggregateElement):
 class Aggregate(BaseExpression):
 	_elements: List[AggregateElement]
 
-	def __init__(self, elements: Iterable[AggregateElement], parent: ModelEntity = None) -> None:
+	def __init__(self, elements: Iterable[AggregateElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._elements = []

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -82,7 +82,7 @@ class PackageInstantiation(PrimaryUnit, GenericInstantiationMixin):
 	_packageReference: PackageReferenceSymbol
 	_genericAssociations: List[GenericAssociationItem]
 
-	def __init__(self, identifier: str, uninstantiatedPackage: PackageReferenceSymbol, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, uninstantiatedPackage: PackageReferenceSymbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericEntityInstantiationMixin.__init__(self)
 

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -96,7 +96,7 @@ class GenericConstantInterfaceItem(Constant, GenericInterfaceItemMixin, Interfac
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
@@ -105,7 +105,7 @@ class GenericConstantInterfaceItem(Constant, GenericInterfaceItemMixin, Interfac
 
 @export
 class GenericTypeInterfaceItem(Type, GenericInterfaceItemMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
 
@@ -117,21 +117,21 @@ class GenericSubprogramInterfaceItem(GenericInterfaceItemMixin):
 
 @export
 class GenericProcedureInterfaceItem(Procedure, GenericInterfaceItemMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
 
 
 @export
 class GenericFunctionInterfaceItem(Function, GenericInterfaceItemMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
 
 
 @export
 class InterfacePackage(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
@@ -139,7 +139,7 @@ class InterfacePackage(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 @export
 class GenericPackageInterfaceItem(InterfacePackage, GenericInterfaceItemMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
 
@@ -153,7 +153,7 @@ class PortSignalInterfaceItem(Signal, PortInterfaceItemMixin):
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
 		PortInterfaceItemMixin.__init__(self, mode)
@@ -168,7 +168,7 @@ class ParameterConstantInterfaceItem(Constant, ParameterInterfaceItemMixin, Inte
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)
@@ -184,7 +184,7 @@ class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItemMixin, Inte
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)
@@ -200,7 +200,7 @@ class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin, Interfac
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)
@@ -214,7 +214,7 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
 		identifiers: Iterable[str],
 		subtype: Symbol,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -222,6 +222,75 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
 
 
 @export
+class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
+	_genericItems: List[GenericInterfaceItemMixin]
+
+	def __init__(
+		self,
+		genericItems: Nullable[Iterable[GenericInterfaceItemMixin]] = None,
+ 	) -> None:
+		self._genericItems = []
+		if genericItems is not None:
+			for item in genericItems:
+				self._genericItems.append(item)
+				item._parent = self
+
+	@property
+	def GenericItems(self) -> List[GenericInterfaceItemMixin]:
+		return self._genericItems
+
+	@property
+	def GenericCount(self) -> int:
+		return len(self._genericItems)
+
+
+@export
+class WithPortsMixin(metaclass=ExtendedType, mixin=True):
+	_portItems: List[PortInterfaceItemMixin]
+
+	def __init__(
+		self,
+		portItems: Nullable[Iterable[PortInterfaceItemMixin]] = None,
+	) -> None:
+		self._portItems = []
+		if portItems is not None:
+			for item in portItems:
+				self._portItems.append(item)
+				item._parent = self
+
+	@property
+	def PortItems(self) -> List[PortInterfaceItemMixin]:
+		return self._portItems
+
+	@property
+	def PortCount(self) -> int:
+		return len(self._portItems)
+
+
+@export
+class WithParametersMixin(metaclass=ExtendedType, mixin=True):
+	_parameterItems: List[ParameterInterfaceItemMixin]
+
+	def __init__(
+		self,
+		parameterItems: Nullable[Iterable[ParameterInterfaceItemMixin]] = None,
+	) -> None:
+		self._parameterItems = []
+		if parameterItems is not None:
+			for item in parameterItems:
+				self._parameterItems.append(item)
+				item._parent = self
+
+	@property
+	def ParameterItems(self) -> List[ParameterInterfaceItemMixin]:
+		return self._parameterItems
+
+	@property
+	def ParameterCount(self) -> int:
+		return len(self._parameterItems)
+
+
+@export
 class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin):
 	def __init__(
 		self,

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -291,26 +291,29 @@ class WithParametersMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
-class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin):
+class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin, DocumentedEntityMixin):
 	def __init__(
 		self,
 		name:   Nullable[str] = None,
+		documentation: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		"""Initialize a PortGroup with a list of ports and optional name."""
 		super().__init__(parent)
 		OptionallyNamedEntityMixin.__init__(self, name)
+		DocumentedEntityMixin.__init__(self, documentation)
 
 
 @export
 class GenericGroup(InterfaceGroup):
 	def __init__(
 		self,
-		genericItems: Iterable[GenericInterfaceItemMixin],
-		name:         Nullable[str] = None,
-		parent:       Nullable[ModelEntity] = None
+		genericItems:  Iterable[GenericInterfaceItemMixin],
+		name:          Nullable[str] = None,
+		documentation: Nullable[str] = None,
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(name, parent)
+		super().__init__(name, documentation, parent)
 		WithGenericsMixin.__init__(self, genericItems)
 
 	def __len__(self) -> int:
@@ -327,11 +330,12 @@ class GenericGroup(InterfaceGroup):
 class PortGroup(InterfaceGroup, WithPortsMixin):
 	def __init__(
 		self,
-		portItems: Iterable[PortInterfaceItemMixin],
-		name:      Nullable[str] = None,
-		parent:    Nullable[ModelEntity] = None
+		portItems:     Iterable[PortInterfaceItemMixin],
+		name:          Nullable[str] = None,
+		documentation: Nullable[str] = None,
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(name, parent)
+		super().__init__(name, documentation, parent)
 		WithPortsMixin.__init__(self, portItems)
 
 	def __len__(self) -> int:
@@ -350,9 +354,10 @@ class ParameterGroup(InterfaceGroup):
 		self,
 		parameterItems: Iterable[ParameterInterfaceItemMixin],
 		name:           Nullable[str] = None,
+		documentation:  Nullable[str] = None,
 		parent:         Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(name, parent)
+		super().__init__(name, documentation, parent)
 		WithParametersMixin.__init__(self, parameterItems)
 
 	def __len__(self) -> int:

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -34,13 +34,14 @@ This module contains parts of an abstract document language model for VHDL.
 
 Interface items are used in generic, port and parameter declarations.
 """
-from typing                 import Iterable, Optional as Nullable
+from typing                 import Iterable, Optional as Nullable, List
 
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
 
 from pyVHDLModel.Symbol     import Symbol
-from pyVHDLModel.Base       import ModelEntity, DocumentedEntityMixin, ExpressionUnion, Mode, NamedEntityMixin
+from pyVHDLModel.Base       import ModelEntity, DocumentedEntityMixin, NamedEntityMixin, OptionallyNamedEntityMixin
+from pyVHDLModel.Base       import ExpressionUnion, Mode
 from pyVHDLModel.Object     import Constant, Signal, Variable, File
 from pyVHDLModel.Subprogram import Procedure, Function
 from pyVHDLModel.Type       import Type
@@ -218,3 +219,76 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)
+
+
+@export
+class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin):
+	def __init__(
+		self,
+		name:   Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		"""Initialize a PortGroup with a list of ports and optional name."""
+		super().__init__(parent)
+		OptionallyNamedEntityMixin.__init__(self, name)
+
+
+@export
+class GenericGroup(InterfaceGroup):
+	pass
+
+
+@export
+class PortGroup(InterfaceGroup):
+	"""A ``PortGroup`` is a group of ports."""
+
+	_portItems: List[PortInterfaceItemMixin]
+
+	def __init__(
+		self,
+		portItems: Iterable[PortInterfaceItemMixin],
+		name:      Nullable[str] = None,
+		parent:    Nullable[ModelEntity] = None
+	) -> None:
+		"""Initialize a PortGroup with a list of ports and optional name."""
+		super().__init__(name, parent)
+
+		self._portItems = list(portItems)
+
+		if not self._portItems:
+			raise ValueError("PortGroup cannot be empty")
+		for port in self._portItems:
+			if not isinstance(port, PortInterfaceItemMixin):
+				raise TypeError(f"All ports must be PortInterfaceItemMixin instances, got {type(port)}")
+			port._group = self
+
+	@property
+	def PortItems(self) -> List[PortInterfaceItemMixin]:
+		"""Get the list of port items in this group."""
+		return self._portItems
+
+	@property
+	def Count(self) -> int:
+		"""Get the number of ports in this group."""
+		return len(self._portItems)
+
+	def __len__(self) -> int:
+		"""Return the number of ports in this group."""
+		return len(self._portItems)
+
+	def __iter__(self):
+		"""Iterate over ports in this group."""
+		return iter(self._portItems)
+
+	def __str__(self) -> str:
+		"""String representation of the port group."""
+		port_names = [str(port) for port in self._portItems]
+		name_part = f"'{self._name}' " if self._name is not None else ""
+		return f"PortGroup({name_part}{len(self._portItems)} ports: {', '.join(port_names)})"
+
+	__repr__ = __str__
+
+
+@export
+class ParameterGroup(InterfaceGroup):
+	pass

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -34,7 +34,7 @@ This module contains parts of an abstract document language model for VHDL.
 
 Interface items are used in generic, port and parameter declarations.
 """
-from typing                 import Iterable, Optional as Nullable, List
+from typing                 import Iterable, Optional as Nullable, List, Iterator
 
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
@@ -304,60 +304,62 @@ class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin):
 
 @export
 class GenericGroup(InterfaceGroup):
-	pass
+	def __init__(
+		self,
+		genericItems: Iterable[GenericInterfaceItemMixin],
+		name:         Nullable[str] = None,
+		parent:       Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(name, parent)
+		WithGenericsMixin.__init__(self, genericItems)
+
+	def __len__(self) -> int:
+		return len(self._genericItems)
+
+	def __iter__(self) -> Iterator[GenericInterfaceItemMixin]:
+		return iter(self._genericItems)
+
+	def __str__(self) -> str:
+		return f"GenericGroup {self._identifier} ({len(self._genericItems)}) - generics: {', '.join(p._identifier for p in self._genericItems)})"
 
 
 @export
-class PortGroup(InterfaceGroup):
-	"""A ``PortGroup`` is a group of ports."""
-
-	_portItems: List[PortInterfaceItemMixin]
-
+class PortGroup(InterfaceGroup, WithPortsMixin):
 	def __init__(
 		self,
 		portItems: Iterable[PortInterfaceItemMixin],
 		name:      Nullable[str] = None,
 		parent:    Nullable[ModelEntity] = None
 	) -> None:
-		"""Initialize a PortGroup with a list of ports and optional name."""
 		super().__init__(name, parent)
-
-		self._portItems = list(portItems)
-
-		if not self._portItems:
-			raise ValueError("PortGroup cannot be empty")
-		for port in self._portItems:
-			if not isinstance(port, PortInterfaceItemMixin):
-				raise TypeError(f"All ports must be PortInterfaceItemMixin instances, got {type(port)}")
-			port._group = self
-
-	@property
-	def PortItems(self) -> List[PortInterfaceItemMixin]:
-		"""Get the list of port items in this group."""
-		return self._portItems
-
-	@property
-	def Count(self) -> int:
-		"""Get the number of ports in this group."""
-		return len(self._portItems)
+		WithPortsMixin.__init__(self, portItems)
 
 	def __len__(self) -> int:
-		"""Return the number of ports in this group."""
 		return len(self._portItems)
 
-	def __iter__(self):
-		"""Iterate over ports in this group."""
+	def __iter__(self) -> Iterator[PortInterfaceItemMixin]:
 		return iter(self._portItems)
 
 	def __str__(self) -> str:
-		"""String representation of the port group."""
-		port_names = [str(port) for port in self._portItems]
-		name_part = f"'{self._name}' " if self._name is not None else ""
-		return f"PortGroup({name_part}{len(self._portItems)} ports: {', '.join(port_names)})"
-
-	__repr__ = __str__
+		return f"PortGroup: {self._identifier} ({len(self._portItems)}) - ports: {', '.join(p._identifier for p in self._portItems)})"
 
 
 @export
 class ParameterGroup(InterfaceGroup):
-	pass
+	def __init__(
+		self,
+		parameterItems: Iterable[ParameterInterfaceItemMixin],
+		name:           Nullable[str] = None,
+		parent:         Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(name, parent)
+		WithParametersMixin.__init__(self, parameterItems)
+
+	def __len__(self) -> int:
+		return len(self._parameterItems)
+
+	def __iter__(self) -> Iterator[ParameterInterfaceItemMixin]:
+		return iter(self._parameterItems)
+
+	def __str__(self) -> str:
+		return f"ParameterGroup {self._identifier} ({len(self._parameterItems)}) - parameters: {', '.join(p._identifier for p in self._parameterItems)})"

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -52,7 +52,7 @@ class Name(ModelEntity):
 	_root: Nullable['Name']     # TODO: seams to be unused. There is no reverse linking, or?
 	_prefix: Nullable['Name']
 
-	def __init__(self, identifier: str, prefix: Nullable["Name"] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, prefix: Nullable["Name"] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._identifier = identifier
@@ -136,7 +136,7 @@ class SimpleName(Name):
 class ParenthesisName(Name):
 	_associations: List
 
-	def __init__(self, prefix: Name, associations: Iterable, parent: ModelEntity = None) -> None:
+	def __init__(self, prefix: Name, associations: Iterable, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__("", prefix, parent)
 
 		self._associations = []
@@ -156,7 +156,7 @@ class ParenthesisName(Name):
 class IndexedName(Name):
 	_indices: List[ExpressionUnion]
 
-	def __init__(self, prefix: Name, indices: Iterable[ExpressionUnion], parent: ModelEntity = None) -> None:
+	def __init__(self, prefix: Name, indices: Iterable[ExpressionUnion], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__("", prefix, parent)
 
 		self._indices = []
@@ -187,7 +187,7 @@ class SelectedName(Name):
 	referenced by the selected name via the :attr:`~pyVHDLModel.Name.Prefix` property.
 	"""
 
-	def __init__(self, identifier: str, prefix: Name, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, prefix: Name, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, prefix, parent)
 
 	def __str__(self) -> str:
@@ -196,7 +196,7 @@ class SelectedName(Name):
 
 @export
 class AttributeName(Name):
-	def __init__(self, identifier: str, prefix: Name, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, prefix: Name, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, prefix, parent)
 
 	def __str__(self) -> str:
@@ -210,7 +210,7 @@ class AllName(SelectedName):
 
 	Most likely this name is used in use-statements.
 	"""
-	def __init__(self, prefix: Name, parent: ModelEntity = None) -> None:
+	def __init__(self, prefix: Name, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__("all", prefix, parent)  # TODO: the case of 'ALL' is not preserved
 
 
@@ -221,7 +221,7 @@ class OpenName(Name):
 
 	Most likely this name is used in port associations.
 	"""
-	def __init__(self, parent: ModelEntity = None) -> None:
+	def __init__(self, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__("open", parent)  # TODO: the case of 'OPEN' is not preserved
 
 	def __str__(self) -> str:

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -62,7 +62,7 @@ class Obj(ModelEntity, MultipleNamedEntityMixin, DocumentedEntityMixin):
 	_subtype:      Symbol
 	_objectVertex: Nullable[Vertex]
 
-	def __init__(self, identifiers: Iterable[str], subtype: Symbol, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifiers: Iterable[str], subtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		MultipleNamedEntityMixin.__init__(self, identifiers)
 		DocumentedEntityMixin.__init__(self, documentation)
@@ -136,7 +136,7 @@ class Constant(BaseConstant, WithDefaultExpressionMixin):
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 		WithDefaultExpressionMixin.__init__(self, defaultExpression)
@@ -163,7 +163,7 @@ class DeferredConstant(BaseConstant):
 		identifiers: Iterable[str],
 		subtype: Symbol,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 
@@ -195,7 +195,7 @@ class Variable(Obj, WithDefaultExpressionMixin):
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 		WithDefaultExpressionMixin.__init__(self, defaultExpression)
@@ -231,7 +231,7 @@ class Signal(Obj, WithDefaultExpressionMixin):
 		subtype: Symbol,
 		defaultExpression: Nullable[ExpressionUnion] = None,
 		documentation: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 		WithDefaultExpressionMixin.__init__(self, defaultExpression)

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -81,7 +81,7 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 		procedureName: Symbol,
 		parameterMappings: Nullable[Iterable[ParameterAssociationItem]] = None,
 		label: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		ProcedureCallMixin.__init__(self, procedureName, parameterMappings)
@@ -89,7 +89,7 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 
 @export
 class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
-	def __init__(self, target: Symbol, label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, target: Symbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
 
@@ -98,7 +98,7 @@ class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
 class SequentialSimpleSignalAssignment(SequentialSignalAssignment):
 	_waveform: List[WaveformElement]
 
-	def __init__(self, target: Symbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, target: Symbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(target, label, parent)
 
 		# TODO: extract to mixin
@@ -120,14 +120,14 @@ class SequentialSimpleSignalAssignment(SequentialSignalAssignment):
 
 @export
 class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin):
-	def __init__(self, target: Symbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, target: Symbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		VariableAssignmentMixin.__init__(self, target, expression)
 
 
 @export
 class SequentialReportStatement(SequentialStatement, ReportStatementMixin):
-	def __init__(self, message: ExpressionUnion, severity: Nullable[ExpressionUnion] = None, label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, message: ExpressionUnion, severity: Nullable[ExpressionUnion] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		ReportStatementMixin.__init__(self, message, severity)
 
@@ -140,7 +140,7 @@ class SequentialAssertStatement(SequentialStatement, AssertStatementMixin):
 		message: Nullable[ExpressionUnion] = None,
 		severity: Nullable[ExpressionUnion] = None,
 		label: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		AssertStatementMixin.__init__(self, condition, message, severity)
@@ -155,28 +155,28 @@ class CompoundStatement(SequentialStatement):
 class Branch(ModelEntity, SequentialStatementsMixin):
 	"""A ``Branch`` is a base-class for all branches in a if statement."""
 
-	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		SequentialStatementsMixin.__init__(self, statements)
 
 
 @export
 class IfBranch(Branch, IfBranchMixin):
-	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 		IfBranchMixin.__init__(self, condition)
 
 
 @export
 class ElsifBranch(Branch, ElsifBranchMixin):
-	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 		ElsifBranchMixin.__init__(self, condition)
 
 
 @export
 class ElseBranch(Branch, ElseBranchMixin):
-	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 		ElseBranchMixin.__init__(self)
 
@@ -193,7 +193,7 @@ class IfStatement(CompoundStatement):
 		elsifBranches: Nullable[Iterable[ElsifBranch]] = None,
 		elseBranch: Nullable[ElseBranch] = None,
 		label: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 
@@ -249,7 +249,7 @@ class SequentialChoice(BaseChoice):
 class IndexedChoice(SequentialChoice):
 	_expression: ExpressionUnion
 
-	def __init__(self, expression: ExpressionUnion, parent: ModelEntity = None) -> None:
+	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._expression = expression
@@ -267,7 +267,7 @@ class IndexedChoice(SequentialChoice):
 class RangedChoice(SequentialChoice):
 	_range: 'Range'
 
-	def __init__(self, rng: 'Range', parent: ModelEntity = None) -> None:
+	def __init__(self, rng: 'Range', parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 
 		self._range = rng
@@ -285,7 +285,7 @@ class RangedChoice(SequentialChoice):
 class SequentialCase(BaseCase, SequentialStatementsMixin):
 	_choices: List
 
-	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		SequentialStatementsMixin.__init__(self, statements)
 
@@ -298,7 +298,7 @@ class SequentialCase(BaseCase, SequentialStatementsMixin):
 
 @export
 class Case(SequentialCase):
-	def __init__(self, choices: Iterable[SequentialChoice], statements: Nullable[Iterable[SequentialStatement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, choices: Iterable[SequentialChoice], statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 
 		self._choices = []
@@ -326,7 +326,7 @@ class CaseStatement(CompoundStatement):
 	_expression: ExpressionUnion
 	_cases:      List[SequentialCase]
 
-	def __init__(self, expression: ExpressionUnion, cases: Iterable[SequentialCase], label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, expression: ExpressionUnion, cases: Iterable[SequentialCase], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 
 		self._expression = expression
@@ -351,7 +351,7 @@ class CaseStatement(CompoundStatement):
 class LoopStatement(CompoundStatement, SequentialStatementsMixin):
 	"""A ``LoopStatement`` is a base-class for all loop statements."""
 
-	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SequentialStatementsMixin.__init__(self, statements)
 
@@ -366,7 +366,7 @@ class ForLoopStatement(LoopStatement):
 	_loopIndex: str
 	_range:     Range
 
-	def __init__(self, loopIndex: str, rng: Range, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, loopIndex: str, rng: Range, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, label, parent)
 
 		self._loopIndex = loopIndex
@@ -390,7 +390,7 @@ class WhileLoopStatement(LoopStatement, ConditionalMixin):
 		condition: ExpressionUnion,
 		statements: Nullable[Iterable[SequentialStatement]] = None,
 		label: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(statements, label, parent)
 		ConditionalMixin.__init__(self, condition)
@@ -402,7 +402,7 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 
 	_loopReference: LoopStatement
 
-	def __init__(self, condition: Nullable[ExpressionUnion] = None, loopLabel: Nullable[str] = None, parent: ModelEntity = None) -> None:  # TODO: is this label (currently str) a Name or a Label class?
+	def __init__(self, condition: Nullable[ExpressionUnion] = None, loopLabel: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:  # TODO: is this label (currently str) a Name or a Label class?
 		super().__init__(parent)
 		ConditionalMixin.__init__(self, condition)
 
@@ -433,7 +433,7 @@ class NullStatement(SequentialStatement):
 class ReturnStatement(SequentialStatement, ConditionalMixin):
 	_returnValue: ExpressionUnion
 
-	def __init__(self, returnValue: Nullable[ExpressionUnion] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, returnValue: Nullable[ExpressionUnion] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		ConditionalMixin.__init__(self, returnValue)
 
@@ -455,7 +455,7 @@ class WaitStatement(SequentialStatement, ConditionalMixin):
 		condition: Nullable[ExpressionUnion] = None,
 		timeout: Nullable[ExpressionUnion] = None,
 		label: Nullable[str] = None,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		ConditionalMixin.__init__(self, condition)

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -52,7 +52,7 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	_statements:     List['SequentialStatement']
 	_isPure:         bool
 
-	def __init__(self, identifier: str, isPure: bool, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, isPure: bool, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
@@ -86,7 +86,7 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 @export
 class Procedure(Subprogram):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, False, documentation, parent)
 
 
@@ -94,7 +94,7 @@ class Procedure(Subprogram):
 class Function(Subprogram):
 	_returnType: Subtype
 
-	def __init__(self, identifier: str, isPure: bool = True, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, isPure: bool = True, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, isPure, documentation, parent)
 
 		# FIXME: return type is missing
@@ -121,13 +121,13 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class ProcedureMethod(Procedure, MethodMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, protectedType: Nullable[ProtectedType] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, protectedType: Nullable[ProtectedType] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		MethodMixin.__init__(self, protectedType)
 
 
 @export
 class FunctionMethod(Function, MethodMixin):
-	def __init__(self, identifier: str, isPure: bool = True, documentation: Nullable[str] = None, protectedType: Nullable[ProtectedType] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, isPure: bool = True, documentation: Nullable[str] = None, protectedType: Nullable[ProtectedType] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, isPure, documentation, parent)
 		MethodMixin.__init__(self, protectedType)

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -52,7 +52,7 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	_objectVertex: Vertex
 
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
 		Initializes underlying ``BaseType``.
 
@@ -88,7 +88,7 @@ class Subtype(BaseType):
 	_range:              Range
 	_resolutionFunction: 'Function'
 
-	def __init__(self, identifier: str, symbol: Symbol, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, symbol: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._type = symbol
@@ -129,7 +129,7 @@ class RangedScalarType(ScalarType):
 	_leftBound:  ExpressionUnion
 	_rightBound: ExpressionUnion
 
-	def __init__(self, identifier: str, rng: Union[Range, Name], parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, rng: Union[Range, Name], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 		self._range = rng
 
@@ -158,7 +158,7 @@ class DiscreteTypeMixin(metaclass=ExtendedType, mixin=True):
 class EnumeratedType(ScalarType, DiscreteTypeMixin):
 	_literals: List[EnumerationLiteral]
 
-	def __init__(self, identifier: str, literals: Iterable[EnumerationLiteral], parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, literals: Iterable[EnumerationLiteral], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._literals = []
@@ -177,7 +177,7 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 
 @export
 class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
-	def __init__(self, identifier: str, rng: Union[Range, Name], parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, rng: Union[Range, Name], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, parent)
 
 	def __str__(self) -> str:
@@ -186,7 +186,7 @@ class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
 
 @export
 class RealType(RangedScalarType, NumericTypeMixin):
-	def __init__(self, identifier: str, rng: Union[Range, Name], parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, rng: Union[Range, Name], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, parent)
 
 	def __str__(self) -> str:
@@ -204,7 +204,7 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 		rng: Union[Range, Name],
 		primaryUnit: str,
 		units: Iterable[Tuple[str, PhysicalIntegerLiteral]],
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifier, rng, parent)
 
@@ -242,7 +242,7 @@ class ArrayType(CompositeType):
 		identifier: str,
 		indices: Iterable,
 		elementSubtype: Symbol,
-		parent: ModelEntity = None
+		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifier, parent)
 
@@ -270,7 +270,7 @@ class ArrayType(CompositeType):
 class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 	_subtype: Symbol
 
-	def __init__(self, identifiers: Iterable[str], subtype: Symbol, parent: ModelEntity = None) -> None:
+	def __init__(self, identifiers: Iterable[str], subtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		MultipleNamedEntityMixin.__init__(self, identifiers)
 
@@ -289,7 +289,7 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 class RecordType(CompositeType):
 	_elements: List[RecordTypeElement]
 
-	def __init__(self, identifier: str, elements: Nullable[Iterable[RecordTypeElement]] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, elements: Nullable[Iterable[RecordTypeElement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._elements = []  # TODO: convert to dict
@@ -310,7 +310,7 @@ class RecordType(CompositeType):
 class ProtectedType(FullType):
 	_methods: List[Union['Procedure', 'Function']]
 
-	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._methods = []
@@ -328,7 +328,7 @@ class ProtectedType(FullType):
 class ProtectedTypeBody(FullType):
 	_methods: List[Union['Procedure', 'Function']]
 
-	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._methods = []
@@ -347,7 +347,7 @@ class ProtectedTypeBody(FullType):
 class AccessType(FullType):
 	_designatedSubtype: Symbol
 
-	def __init__(self, identifier: str, designatedSubtype: Symbol, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, designatedSubtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._designatedSubtype = designatedSubtype
@@ -365,7 +365,7 @@ class AccessType(FullType):
 class FileType(FullType):
 	_designatedSubtype: Symbol
 
-	def __init__(self, identifier: str, designatedSubtype: Symbol, parent: ModelEntity = None) -> None:
+	def __init__(self, identifier: str, designatedSubtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, parent)
 
 		self._designatedSubtype = designatedSubtype

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -301,11 +301,26 @@ class VHDLVersion(Enum):
 
 @export
 class IEEEFlavor(Flag):
-	Unknown = 0
-	IEEE = 1
-	Synopsys = 2
-	MentorGraphics = 4
-	WithVITAL = 32      # VITAL = VHDL Initiative Towards ASIC Libraries
+	"""
+	The ``IEEE`` VHDL library as a fixed set of predefined VHDL packages according to IEEE Std. 1076.
+
+	Nonetheless, some vendors decided to sneak in additional packages into the ``IEEE`` namespace. |br|
+	Supported flavors are:
+
+	* ``Synopsys``
+	* ``MentorGraphics``
+
+	In addition, IEEE Std. 1076.X extensions can be loaded. |br|
+	Supported extensions are:
+
+	* ``WithVITAL`` - IEEE Std. 1076.4
+
+	"""
+	Unknown = 0         #: Unknown IEEE flavor
+	IEEE = 1            #: IEEE Std. 1076 compliant list of IEEE packages.
+	Synopsys = 2        #: Additional packages created by Synopsys are visible within the IEEE library.
+	MentorGraphics = 4  #: Additional packages created by Mentor Graphics are visible within the IEEE library.
+	WithVITAL = 32      #: Additionally load IEEE Std 1076.4 VITAL packages. (VITAL = VHDL Initiative Towards ASIC Libraries)
 
 
 @export

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -433,16 +433,16 @@ class ObjectGraphVertexKind(Flag):
 	"""
 	A ``ObjectGraphVertexKind`` is an enumeration and represents the kind of vertex in the object graph.
 	"""
-	Type = auto()
-	Subtype = auto()
+	Type =             auto()
+	Subtype =          auto()
 
-	Constant = auto()
+	Constant =         auto()
 	DeferredConstant = auto()
-	Variable = auto()
-	Signal = auto()
-	File = auto()
+	Variable =         auto()
+	Signal =           auto()
+	File =             auto()
 
-	Alias = auto()
+	Alias =            auto()
 
 
 @export
@@ -452,7 +452,7 @@ class ObjectGraphEdgeKind(Flag):
 	A ``ObjectGraphEdgeKind`` is an enumeration and represents the kind of edge in the object graph.
 	"""
 	BaseType = auto()
-	Subtype = auto()
+	Subtype =  auto()
 
 	ReferenceInExpression = auto()
 
@@ -1601,7 +1601,11 @@ class Design(ModelEntity, AllowBlackboxMixin):
 			for packageReference in designUnit.PackageReferences:
 				# A use clause can have multiple comma-separated references
 				for packageMemberSymbol in packageReference.Symbols:
-					packageName = packageMemberSymbol.Name.Prefix
+					if isinstance(packageMemberSymbol, PackageReferenceSymbol):
+						packageName = packageMemberSymbol.Name
+					elif isinstance(packageMemberSymbol, (AllPackageMembersReferenceSymbol, PackageMemberReferenceSymbol)):
+						packageName = packageMemberSymbol.Name.Prefix
+
 					libraryName = packageName.Prefix
 
 					libraryIdentifier = libraryName.NormalizedIdentifier
@@ -1633,7 +1637,10 @@ class Design(ModelEntity, AllowBlackboxMixin):
 					dependency["kind"] = DependencyGraphEdgeKind.UseClause
 
 					# TODO: update the namespace with visible members
-					if isinstance(packageMemberSymbol, AllPackageMembersReferenceSymbol):
+					if isinstance(packageMemberSymbol, PackageReferenceSymbol):
+						designUnit._namespace._elements[packageIdentifier] = package
+
+					elif isinstance(packageMemberSymbol, AllPackageMembersReferenceSymbol):
 						WarningCollector.Raise(NotImplementedWarning(f"Handling of 'myLib.myPackage.all'. Exception: components are handled."))
 
 						for componentIdentifier, component in package._components.items():
@@ -1643,7 +1650,9 @@ class Design(ModelEntity, AllowBlackboxMixin):
 						WarningCollector.Raise(NotImplementedWarning(f"Handling of 'myLib.myPackage.mySymbol'."))
 
 					else:
-						raise VHDLModelException()  # TODO: missing exception message
+						ex = VHDLModelException(f"Unknown package reference symbol type.")
+						ex.add_note(f"Got type '{getFullyQualifiedName(packageMemberSymbol)}'.")
+						raise ex
 
 	def LinkContextReferences(self) -> None:
 		"""
@@ -2356,6 +2365,8 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 		for package in self._packages.values():
 			if isinstance(package, Package):
 				package.IndexDeclaredItems()
+			elif isinstance(package, PackageInstantiation):
+				pass
 
 	def IndexPackageBodies(self) -> None:
 		"""

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -48,7 +48,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2016-2026, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.34.0"
+__version__ =   "0.35.0"
 
 
 from enum                      import unique, Enum, Flag, auto
@@ -1360,6 +1360,60 @@ class Design(ModelEntity, AllowBlackboxMixin):
 			library.LinkPackageBodies()
 
 	def LinkLibraryReferences(self) -> None:
+		"""
+		Link all library references (library clause) to the matching VHDL library.
+
+		.. rubric:: Algorithm
+
+		1. Iterate all design units with contexts:
+
+		   * If the design unit is a primary unit:
+
+		     1. Iterate all library identifiers in ``DEFAULT_LIBRARIES`` (``std``):
+
+		        * Get the referenced library by name from the design.
+		        * Add an entry in the design unit's ``_referencedLibraries`` dictionary referencing the referenced library.
+		        * Add an empty dictionary in the design unit's ``_referencedPackages`` dictionary.
+		        * Add an empty dictionary in the design unit's ``_referencedContexts`` dictionary.
+		        * Add an edge in the dependency graph from design unit to the referenced library.
+
+		     2. Get the design unit's library:
+
+		        * Add an entry in the design unit's ``_referencedLibraries`` dictionary referencing the referenced library.
+		        * Add an empty dictionary in the design unit's ``_referencedPackages`` dictionary.
+		        * Add an empty dictionary in the design unit's ``_referencedContexts`` dictionary.
+		        * Add an edge in the dependency graph from design unit to the referenced library.
+
+		   * If the design unit is a secondary unit:
+
+		     * If design unit is an architecture, get the corresponding entity's referenced libraries.
+		     * If design unit is a package body, get the corresponding package's referenced libraries.
+		     * Otherwise, raise an exception
+
+		     For every referenced library create new dictionary entries in the design unit's ``_referencedLibraries``.
+
+		2. Iterate every library reference (library clause) in the design unit:
+
+		   * Iterate every library symbol within the library reference:
+
+		     * Get the library identifier from the symbol.
+		     * Continue the inner loop, if identifier is ``work``.
+		     * Get the referenced library from the design or raise an exception.
+		     * Update the library symbol's target with the referenced library.
+		     * Add an entry in the design unit's ``_referencedLibraries`` dictionary referencing the referenced library.
+		     * Add an empty dictionary in the design unit's ``_referencedPackages`` dictionary.
+		     * Add an empty dictionary in the design unit's ``_referencedContexts`` dictionary.
+		     * Add an edge in the dependency graph from design unit to the referenced library.
+
+		.. seealso::
+
+		   :meth:`LinkPackageReferences`
+		     Link *use clause*.
+		   :meth:`LinkContextReferences`
+		     Link *context clause*.
+		   :meth:`AnalyzeDependencies`
+		     Analyze dependencies and link relations.
+		"""
 		DEFAULT_LIBRARIES = ("std",)
 
 		for designUnit in self.IterateDesignUnits(DesignUnitKind.WithContext):
@@ -1376,10 +1430,10 @@ class Design(ModelEntity, AllowBlackboxMixin):
 					dependency = designUnit._dependencyVertex.EdgeToVertex(referencedLibrary._dependencyVertex)
 					dependency["kind"] = DependencyGraphEdgeKind.LibraryClause
 
+				# TODO: this could create a duplicate linking, if primary unit is put into library 'std'
 				workingLibrary: Library = designUnit.Library
 				libraryIdentifier = workingLibrary.NormalizedIdentifier
-				referencedLibrary = self._libraries[libraryIdentifier]
-
+				referencedLibrary = self._libraries[libraryIdentifier]   # TODO: isn't this the same as the workingLibrary from 2 lines before?
 
 				designUnit._referencedLibraries[libraryIdentifier] = referencedLibrary
 				designUnit._referencedPackages[libraryIdentifier] = {}
@@ -1395,10 +1449,10 @@ class Design(ModelEntity, AllowBlackboxMixin):
 				elif isinstance(designUnit, PackageBody):
 					referencedLibraries = designUnit.Package.Package._referencedLibraries
 				else:
-					raise VHDLModelException()
+					raise VHDLModelException()  # FIXME: exception message
 
 				for libraryIdentifier, library in referencedLibraries.items():
-					designUnit._referencedLibraries[libraryIdentifier] = library
+					designUnit._referencedLibraries[libraryIdentifier] = library   # TODO: Could we use the .update() method
 
 			for libraryReference in designUnit._libraryReferences:
 				# A library clause can have multiple comma-separated references
@@ -1424,6 +1478,79 @@ class Design(ModelEntity, AllowBlackboxMixin):
 					dependency["kind"] = DependencyGraphEdgeKind.LibraryClause
 
 	def LinkPackageReferences(self) -> None:
+		"""
+		Link all package references (use clause) to the matching packages.
+
+		.. rubric:: Algorithm
+
+		1. Iterate all design units with contexts:
+
+		   * If the design unit is a primary unit:
+
+		     * If primary unit isn't package ``std.standard``:
+
+		       1. Iterate all library, packages tuples in ``DEFAULT_PACKAGES`` (``std``: [``standard``]):
+
+		          * Raise an exception, if library isn't listed in design unit's ``_referencedLibraries``.
+		          * For every package in packages:
+
+		            * Get the referenced package by library name and package name from the design.
+		            * Add an entry in the design unit's ``_referencedPackages`` dictionary referencing the referenced package.
+		            * Add an edge in the dependency graph from design unit to the referenced package.
+
+		   * If the design unit is a secondary unit:
+
+		     * If design unit is an architecture, get the corresponding entity's referenced packages.
+		     * If design unit is a package body, get the corresponding package's referenced packages.
+		     * Otherwise, raise an exception
+
+		     For every referenced package create new dictionary entries in the design unit's ``_referencedPackages``.
+
+		2. Iterate every package reference (use clause) in the design unit:
+
+		   * Iterate every package symbol within the package reference:
+
+		     1. Get the library identifier from the symbol.
+		     2. Get the package identifier from the symbol.
+		     3. Resolve library:
+
+		        * If library name is ``work``, get library from design unit.
+		        * If library name is not in design unit's ``_referencedLibraries``, raise an exception.
+		        * Otherwise, lookup library by name in design.
+
+		     4. Resolve package:
+
+		        * Lookup package by name in library.
+
+		     5. Update design unit:
+
+		        * Update the package symbol's target with the referenced package.
+		        * Add an entry in the design unit's ``_referencedPackages`` dictionary referencing the referenced package.
+		        * Add an edge in the dependency graph from design unit to the referenced package.
+
+		     6. Import public package members.
+
+		        * If package symbol is a ``AllPackageMembersReferenceSymbol``:
+
+		          * Iterate all components within the referenced package and add entries for each component in the design unit's ``_namespace``.
+
+		          .. todo:: Other elements are not implemented.
+
+		        * If package symbol is a ``PackageMemberReferenceSymbol``
+
+		          .. todo:: Not implemented.
+
+		        * Otherwise, raise an exception.
+
+		.. seealso::
+
+		   :meth:`LinkLibraryReferences`
+		     Link *library clause*.
+		   :meth:`LinkContextReferences`
+		     Link *context clause*.
+		   :meth:`AnalyzeDependencies`
+		     Analyze dependencies and link relations.
+		"""
 		DEFAULT_PACKAGES = (
 			("std", ("standard",)),
 		)
@@ -1431,15 +1558,14 @@ class Design(ModelEntity, AllowBlackboxMixin):
 		for designUnit in self.IterateDesignUnits(DesignUnitKind.WithContext):
 			# All primary units supporting a context, have at least one package implicitly referenced
 			if isinstance(designUnit, PrimaryUnit):
-				if designUnit.Library.NormalizedIdentifier != "std" and \
-					designUnit.NormalizedIdentifier != "standard":
-					for lib in DEFAULT_PACKAGES:
-						if lib[0] not in designUnit._referencedLibraries:
-							raise VHDLModelException()
-						for pack in lib[1]:
-							referencedPackage = self._libraries[lib[0]]._packages[pack]
-							designUnit._referencedPackages[lib[0]][pack] = referencedPackage
-							# TODO: catch KeyError on self._libraries[lib[0]]._packages[pack]
+				if not (designUnit.Library.NormalizedIdentifier == "std" and designUnit.NormalizedIdentifier == "standard"):
+					for lib, packages in DEFAULT_PACKAGES:
+						if lib not in designUnit._referencedLibraries:
+							raise VHDLModelException()  # TODO: missing exception message
+						for package in packages:
+							referencedPackage = self._libraries[lib]._packages[package]
+							designUnit._referencedPackages[lib][package] = referencedPackage
+							# TODO: catch KeyError on self._libraries[lib[0]]._packages[package]
 							# TODO: warn duplicate package reference
 
 							dependency = designUnit._dependencyVertex.EdgeToVertex(referencedPackage._dependencyVertex)
@@ -1452,7 +1578,7 @@ class Design(ModelEntity, AllowBlackboxMixin):
 				elif isinstance(designUnit, PackageBody):
 					referencedPackages = designUnit.Package.Package._referencedPackages
 				else:
-					raise VHDLModelException()
+					raise VHDLModelException()  # FIXME: exception message
 
 				for packageIdentifier, package in referencedPackages.items():
 					designUnit._referencedPackages[packageIdentifier] = package
@@ -1502,9 +1628,63 @@ class Design(ModelEntity, AllowBlackboxMixin):
 						WarningCollector.Raise(NotImplementedWarning(f"Handling of 'myLib.myPackage.mySymbol'."))
 
 					else:
-						raise VHDLModelException()
+						raise VHDLModelException()  # TODO: missing exception message
 
 	def LinkContextReferences(self) -> None:
+		"""
+		Link all context references (context clause) to the matching context.
+
+		.. rubric:: Algorithm
+
+		1. Iterate all design units:
+
+		   * Iterate all context references in the design unit:
+
+		     * Iterate each context symbol within the context reference.
+
+		       1. Get the library identifier from the symbol.
+		       2. Get the context identifier from the symbol.
+		       3. Resolve library:
+
+		          * If library name is ``work``, get library from design unit.
+		          * If library name is not in design unit's ``_referencedLibraries``, raise an exception.
+		          * Otherwise, lookup library by name in design.
+
+		       4. Resolve context:
+
+		          * Lookup context by name in library.
+
+		       5. Update design unit:
+
+		          * Update the context symbol's target with the referenced context.
+		          * Add an entry in the design unit's ``_referencedContexts`` dictionary referencing the referenced context.
+		          * Add an edge in the dependency graph from design unit to the referenced context.
+
+		2. Iterate all context vertices in the dependency graph (``_dependencyGraph``) in topological order:
+
+		   * Get the context from the context vertex.
+		   * Iterate all predecessor vertices (design unit vertices) of the context vertex:
+
+		     1. Get the design unit from design unit vertex.
+		     2. Iterate referenced libraries of the context:
+
+		        * Add an entry in the design unit's ``_referencedLibraries`` dictionary referencing the referenced library.
+		        * Add an empty dictionary in the design unit's ``_referencedPackages`` dictionary.
+
+		     3. Iterate referenced packages of the context:
+
+		        * Raise an exception if package name is already listed in ``_referencedPackages``.
+		        * Add an entry in the design unit's ``_referencedPackages`` dictionary referencing the referenced package.
+
+		.. seealso::
+
+		   :meth:`LinkLibraryReferences`
+		     Link *library clause*.
+		   :meth:`LinkPackageReferences`
+		     Link *use clause*.
+		   :meth:`AnalyzeDependencies`
+		     Analyze dependencies and link relations.
+		"""
 		for designUnit in self.IterateDesignUnits():
 			for contextReference in designUnit._contextReferences:
 				# A context reference can have multiple comma-separated references
@@ -1537,24 +1717,23 @@ class Design(ModelEntity, AllowBlackboxMixin):
 					dependency = designUnit._dependencyVertex.EdgeToVertex(referencedContext._dependencyVertex, edgeValue=contextReference)
 					dependency["kind"] = DependencyGraphEdgeKind.ContextReference
 
-		for vertex in self._dependencyGraph.IterateTopologically():
-			if vertex["kind"] is DependencyGraphVertexKind.Context:
-				context: Context = vertex.Value
-				for designUnitVertex in vertex.IteratePredecessorVertices():
-					designUnit: DesignUnit = designUnitVertex.Value
-					for libraryIdentifier, library in context._referencedLibraries.items():
-						# if libraryIdentifier in designUnit._referencedLibraries:
-						# 	raise VHDLModelException(f"Referenced library '{library.Identifier}' already exists in references for design unit '{designUnit.Identifier}'.")
+		for vertex in self._dependencyGraph.IterateTopologically(predicate=lambda v: v["kind"] is DependencyGraphVertexKind.Context):
+			context: Context = vertex.Value
+			for designUnitVertex in vertex.IteratePredecessorVertices():  # TODO: should this be filtered to exclude non-contexts?
+				designUnit: DesignUnit = designUnitVertex.Value
+				for libraryIdentifier, library in context._referencedLibraries.items():
+					# if libraryIdentifier in designUnit._referencedLibraries:
+					# 	raise VHDLModelException(f"Referenced library '{library.Identifier}' already exists in references for design unit '{designUnit.Identifier}'.")
 
-						designUnit._referencedLibraries[libraryIdentifier] = library
-						designUnit._referencedPackages[libraryIdentifier] = {}
+					designUnit._referencedLibraries[libraryIdentifier] = library
+					designUnit._referencedPackages[libraryIdentifier] = {}
 
-					for libraryIdentifier, packages in context._referencedPackages.items():
-						for packageIdentifier, package in packages.items():
-							if packageIdentifier in designUnit._referencedPackages:
-								raise VHDLModelException(f"Referenced package '{package.Identifier}' already exists in references for design unit '{designUnit.Identifier}'.")
+				for libraryIdentifier, packages in context._referencedPackages.items():
+					for packageIdentifier, package in packages.items():
+						if packageIdentifier in designUnit._referencedPackages:
+							raise VHDLModelException(f"Referenced package '{package.Identifier}' already exists in references for design unit '{designUnit.Identifier}'.")
 
-							designUnit._referencedPackages[libraryIdentifier][packageIdentifier] = package
+						designUnit._referencedPackages[libraryIdentifier][packageIdentifier] = package
 
 	def LinkComponents(self) -> None:
 		"""

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -1939,7 +1939,7 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 		self,
 		identifier:    str,
 		allowBlackbox: Nullable[bool] = None,
-		parent:        ModelEntity = None
+		parent:        Nullable[ModelEntity] = None
 	) -> None:
 		"""
 		Initialize a VHDL library.
@@ -2266,7 +2266,7 @@ class Document(ModelEntity, DocumentedEntityMixin):
 	_dependencyVertex:       Vertex[None, None, None, 'Document', None, None, None, None, None, None, None, None, None, None, None, None, None]  #: Reference to the vertex in the dependency graph representing the document. |br| This reference is set by :meth:`~pyVHDLModel.Design.CreateCompileOrderGraph`.
 	_compileOrderVertex:     Vertex[None, None, None, 'Document', None, None, None, None, None, None, None, None, None, None, None, None, None]  #: Reference to the vertex in the compile-order graph representing the document. |br| This reference is set by :meth:`~pyVHDLModel.Design.CreateCompileOrderGraph`.
 
-	def __init__(self, path: Path, documentation: Nullable[str] = None, parent: ModelEntity = None) -> None:
+	def __init__(self, path: Path, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		DocumentedEntityMixin.__init__(self, documentation)
 

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,7 +1,7 @@
 -r ../../requirements.txt
 
 # Coverage collection
-Coverage ~= 7.13
+Coverage ~= 7.14
 
 # Test Runner
 pytest ~= 9.0


### PR DESCRIPTION
# New Features

* New `OptionallyNamedEntityMixin` class.
* New `WithGenericsMixin`, `WithPortsMixin` and `WithParametersMixin` mixin classes.
* New `InterfaceGroup`, `GenericGroup`, `PortGroup`, `ParameterGroup` classes.


# Changes

* Bumped dependencies.
* Use pyTooling's predicate feature in `Graph.IterateTopologically()`
* Refactored classes with generics, ports and parameters.


# Bug Fixes

* Fixed type hints for `parent` parameter in many methods to be `Nullable[...]`
* When creating the dependency graph, handle `PackageReferenceSymbol` vs. `AllPackageMembersReferenceSymbol` and `PackageMemberReferenceSymbol`.


# Documentation

* Updated News section.
* Added more adopters.
* Removed icon to Gitter
* Documented algorithms:
  * `Design.LinkLibraryReferences`
  * `Design.LinkpackageReferences`
  * `Design.LinkContextReferences`
* Added more doc-strings:
  * `IEEEFlavor`
* Fixed link to documentation license.


----------
# Related Issues and Pull-Requests

* #98 (unfortunately closed by GitHubs auto branch cleanup feature, due to deleted `dev` branch)
