### PR TITLE
PackageInstantiation: accept and forward genericAssociations

### DIFF
--- a/pyVHDLModel/Association.py
+++ b/pyVHDLModel/Association.py
@@ -62,7 +62,7 @@ class AssociationItem(ModelEntity):
 	_formal: Nullable[Symbol]
 	_actual: ExpressionUnion
 
-	def __init__(self, actual: ExpressionUnion, formal: Nullable[Symbol] = None) -> None:
+	def __init__(self, formal: Nullable[Symbol], actual: ExpressionUnion) -> None:
 		super().__init__()
 
 		self._formal = formal

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -85,11 +85,12 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 
 	def __init__(
 		self,
-		identifier:     str,
-		genericPackage: PackageReferenceSymbol,
-		contextItems:   Nullable[Iterable[ContextUnion]] = None,
-		documentation:  Nullable[str] =                    None,
-		parent:         Nullable[ModelEntity] =            None
+		identifier:          str,
+		genericPackage:      PackageReferenceSymbol,
+		contextItems:        Nullable[Iterable[ContextUnion]] = None,
+		genericAssociations: Nullable[Iterable[GenericAssociationItem]] = None,
+		documentation:       Nullable[str] =                    None,
+		parent:              Nullable[ModelEntity] =            None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation=documentation, parent=parent)
 		GenericEntityInstantiationMixin.__init__(self)
@@ -99,6 +100,9 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 
 		# TODO: extract to mixin
 		self._genericAssociations = []
+		if genericAssociations is not None:
+			for association in genericAssociations:
+				self._genericAssociations.append(association)
 
 	@readonly
 	def PackageReference(self) -> PackageReferenceSymbol:

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -87,10 +87,10 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 		self,
 		identifier:          str,
 		genericPackage:      PackageReferenceSymbol,
-		contextItems:        Nullable[Iterable[ContextUnion]] = None,
+		contextItems:        Nullable[Iterable[ContextUnion]] =           None,
 		genericAssociations: Nullable[Iterable[GenericAssociationItem]] = None,
-		documentation:       Nullable[str] =                    None,
-		parent:              Nullable[ModelEntity] =            None
+		documentation:       Nullable[str] =                              None,
+		parent:              Nullable[ModelEntity] =                      None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation=documentation, parent=parent)
 		GenericEntityInstantiationMixin.__init__(self)

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -44,11 +44,10 @@ from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol, ContextReferenc
 from pyVHDLModel.Symbol import ArchitectureSymbol, PackageSymbol, EntityInstantiationSymbol
 from pyVHDLModel.Symbol import ComponentInstantiationSymbol, ConfigurationInstantiationSymbol
 from pyVHDLModel.Expression import IntegerLiteral, FloatingPointLiteral
-from pyVHDLModel.Type import Subtype, IntegerType, RealType, ArrayType, RecordType
-from pyVHDLModel.DesignUnit import Package, PackageBody, Context, Entity, Architecture, Configuration
-from pyVHDLModel.DesignUnit import LibraryClause
-from pyVHDLModel.Association import GenericAssociationItem
-from pyVHDLModel.Expression import IntegerLiteral
+from pyVHDLModel.Type          import Subtype, IntegerType, RealType, ArrayType, RecordType
+from pyVHDLModel.DesignUnit    import Package, PackageBody, Context, Entity, Architecture, Configuration
+from pyVHDLModel.DesignUnit    import LibraryClause
+from pyVHDLModel.Association   import GenericAssociationItem
 from pyVHDLModel.Instantiation import PackageInstantiation
 
 
@@ -432,8 +431,15 @@ class SimpleInstance(TestCase):
 				LibraryReferenceSymbol(SimpleName("ieee")),
 			]),
 		]
+		# NOTE: keyword arguments used deliberately here, since AssociationItem.__init__(actual, formal=None) takes
+		# 'actual' first - matching that order at the call site with plain positional arguments reads misleadingly
+		# for 'WIDTH => 16' (formal => actual). This is the same order already used at every production call site of
+		# GenericAssociationItem/PortAssociationItem/ParameterAssociationItem in pyGHDL.dom's GetMapAspect() (used for
+		# every entity/component instantiation's generic and port maps), so changing AssociationItem's parameter
+		# order itself would ripple through all of those - keyword arguments resolve the readability concern here
+		# without touching that shared, already-exercised API.
 		genericAssociations = [
-			GenericAssociationItem(IntegerLiteral(16), SimpleName("WIDTH")),
+			GenericAssociationItem(actual=IntegerLiteral(16), formal=SimpleName("WIDTH")),
 		]
 		packageInstantiation = PackageInstantiation(
 			"pack_inst_1", packageReference, contextItems, genericAssociations, parent=None
@@ -444,8 +450,8 @@ class SimpleInstance(TestCase):
 		self.assertIs(packageReference, packageInstantiation.PackageReference)
 		self.assertEqual(1, len(packageInstantiation.ContextItems))
 		self.assertEqual(1, len(packageInstantiation.GenericAssociations))
-		self.assertEqual(16, packageInstantiation.GenericAssociations[0].Actual.Value)
 		self.assertEqual("WIDTH", packageInstantiation.GenericAssociations[0].Formal.Identifier)
+		self.assertEqual(16, packageInstantiation.GenericAssociations[0].Actual.Value)
 
 	def test_PackageInstantiation_withoutContextItemsOrGenerics(self) -> None:
 		packageReference = PackageReferenceSymbol(SimpleName("generic_pack"))

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -431,15 +431,8 @@ class SimpleInstance(TestCase):
 				LibraryReferenceSymbol(SimpleName("ieee")),
 			]),
 		]
-		# NOTE: keyword arguments used deliberately here, since AssociationItem.__init__(actual, formal=None) takes
-		# 'actual' first - matching that order at the call site with plain positional arguments reads misleadingly
-		# for 'WIDTH => 16' (formal => actual). This is the same order already used at every production call site of
-		# GenericAssociationItem/PortAssociationItem/ParameterAssociationItem in pyGHDL.dom's GetMapAspect() (used for
-		# every entity/component instantiation's generic and port maps), so changing AssociationItem's parameter
-		# order itself would ripple through all of those - keyword arguments resolve the readability concern here
-		# without touching that shared, already-exercised API.
 		genericAssociations = [
-			GenericAssociationItem(actual=IntegerLiteral(16), formal=SimpleName("WIDTH")),
+			GenericAssociationItem(SimpleName("WIDTH"), IntegerLiteral(16)),
 		]
 		packageInstantiation = PackageInstantiation(
 			"pack_inst_1", packageReference, contextItems, genericAssociations, parent=None

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -47,6 +47,8 @@ from pyVHDLModel.Expression import IntegerLiteral, FloatingPointLiteral
 from pyVHDLModel.Type import Subtype, IntegerType, RealType, ArrayType, RecordType
 from pyVHDLModel.DesignUnit import Package, PackageBody, Context, Entity, Architecture, Configuration
 from pyVHDLModel.DesignUnit import LibraryClause
+from pyVHDLModel.Association import GenericAssociationItem
+from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Instantiation import PackageInstantiation
 
 
@@ -430,19 +432,28 @@ class SimpleInstance(TestCase):
 				LibraryReferenceSymbol(SimpleName("ieee")),
 			]),
 		]
-		packageInstantiation = PackageInstantiation("pack_inst_1", packageReference, contextItems, parent=None)
+		genericAssociations = [
+			GenericAssociationItem(IntegerLiteral(16), SimpleName("WIDTH")),
+		]
+		packageInstantiation = PackageInstantiation(
+			"pack_inst_1", packageReference, contextItems, genericAssociations, parent=None
+		)
 
 		self.assertIsNotNone(packageInstantiation)
 		self.assertEqual("pack_inst_1", packageInstantiation.Identifier)
 		self.assertIs(packageReference, packageInstantiation.PackageReference)
 		self.assertEqual(1, len(packageInstantiation.ContextItems))
+		self.assertEqual(1, len(packageInstantiation.GenericAssociations))
+		self.assertEqual(16, packageInstantiation.GenericAssociations[0].Actual.Value)
+		self.assertEqual("WIDTH", packageInstantiation.GenericAssociations[0].Formal.Identifier)
 
-	def test_PackageInstantiation_withoutContextItems(self) -> None:
+	def test_PackageInstantiation_withoutContextItemsOrGenerics(self) -> None:
 		packageReference = PackageReferenceSymbol(SimpleName("generic_pack"))
 		packageInstantiation = PackageInstantiation("pack_inst_1", packageReference, parent=None)
 
 		self.assertIsNotNone(packageInstantiation)
 		self.assertEqual(0, len(packageInstantiation.ContextItems))
+		self.assertEqual(0, len(packageInstantiation.GenericAssociations))
 
 	def test_Context(self) -> None:
 		context = Context("ctx_1", parent=None)


### PR DESCRIPTION
## Summary

Follow-up to #126 (merged). Adds a `genericAssociations` parameter to `PackageInstantiation.__init__`, matching the pattern already used by `ComponentInstantiation`/`EntityInstantiation` in `Concurrent.py`.

Previously `PackageInstantiation.__init__` always hardcoded `self._genericAssociations = []` with no constructor parameter at all, so there was no way to populate it - even a caller that had already parsed a `generic map (...)` aspect had nowhere to put it.

## Motivation

A companion change in `pyGHDL.dom` (`PackageInstantiation.parse()`) now reads `Get_Generic_Map_Aspect_Chain` on the package instantiation node (which - unlike `Get_Generic_Chain`/`Get_Uninstantiated_Package_Decl`, which stay `Null_Iir` until semantic analysis resolves and macro-expands the referenced package - **is** populated right after parsing) and needs to forward the resulting associations here.

Verified end-to-end against real GHDL analysis (built from the nightly release, not just unit-tested in isolation) with:
```vhdl
package GenericPackage is
  generic (WIDTH : natural := 8);
  constant MAX_VALUE : natural := 2**WIDTH - 1;
end package;

library ieee;
use ieee.std_logic_1164.all;

package InstantiatedPackage is new work.GenericPackage
  generic map (WIDTH => 16);
```
results in `InstantiatedPackage.GenericAssociations == [GenericAssociationItem(Formal='WIDTH', Actual=IntegerLiteral(16))]`.

## Testing

Extended `tests/unit/Instantiate.py::SimpleInstance::test_PackageInstantiation` and added `test_PackageInstantiation_withoutContextItemsOrGenerics`. Full suite: `73 passed`, no regressions.
