### PR TITLE
Rename genericAssociations/portAssociations/parameterMappings to *AssociationItems for consistency

### DIFF
--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -103,17 +103,17 @@ class Statement(ModelEntity, LabeledEntityMixin):
 @export
 class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
 	_procedure:         Symbol  # TODO: implement a ProcedureSymbol
-	_parameterMappings: List[ParameterAssociationItem]
+	_parameterAssociationItems: List[ParameterAssociationItem]
 
-	def __init__(self, procedureName: Symbol, parameterMappings: Nullable[Iterable[ParameterAssociationItem]] = None) -> None:
+	def __init__(self, procedureName: Symbol, parameterAssociationItems: Nullable[Iterable[ParameterAssociationItem]] = None) -> None:
 		self._procedure = procedureName
 		procedureName.Parent = self
 
 		# TODO: extract to mixin
-		self._parameterMappings = []
-		if parameterMappings is not None:
-			for parameterMapping in parameterMappings:
-				self._parameterMappings.append(parameterMapping)
+		self._parameterAssociationItems = []
+		if parameterAssociationItems is not None:
+			for parameterMapping in parameterAssociationItems:
+				self._parameterAssociationItems.append(parameterMapping)
 				parameterMapping.Parent = self
 
 	@readonly
@@ -121,8 +121,8 @@ class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
 		return self._procedure
 
 	@property
-	def ParameterMappings(self) -> List[ParameterAssociationItem]:
-		return self._parameterMappings
+	def ParameterAssociationItems(self) -> List[ParameterAssociationItem]:
+		return self._parameterAssociationItems
 
 
 @export

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -102,7 +102,7 @@ class Statement(ModelEntity, LabeledEntityMixin):
 
 @export
 class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
-	_procedure:         Symbol  # TODO: implement a ProcedureSymbol
+	_procedure:                 Symbol  # TODO: implement a ProcedureSymbol
 	_parameterAssociationItems: List[ParameterAssociationItem]
 
 	def __init__(self, procedureName: Symbol, parameterAssociationItems: Nullable[Iterable[ParameterAssociationItem]] = None) -> None:

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -131,13 +131,13 @@ class Instantiation(ConcurrentStatement):
 	"""
 
 	_genericAssociationItems: List[AssociationItem]
-	_portAssociationItems: List[AssociationItem]
+	_portAssociationItems:    List[AssociationItem]
 
 	def __init__(
 		self,
 		label: str,
 		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
-		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems:    Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
@@ -184,7 +184,7 @@ class ComponentInstantiation(Instantiation):
 		label: str,
 		componentSymbol: ComponentInstantiationSymbol,
 		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
-		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems:    Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, genericAssociationItems, portAssociationItems, parent)
@@ -218,7 +218,7 @@ class EntityInstantiation(Instantiation):
 		entitySymbol: EntityInstantiationSymbol,
 		architectureSymbol: Nullable[ArchitectureSymbol] = None,
 		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
-		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems:    Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, genericAssociationItems, portAssociationItems, parent)
@@ -258,7 +258,7 @@ class ConfigurationInstantiation(Instantiation):
 		label: str,
 		configurationSymbol: ConfigurationInstantiationSymbol,
 		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
-		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems:    Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, genericAssociationItems, portAssociationItems, parent)

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -130,39 +130,39 @@ class Instantiation(ConcurrentStatement):
 	A base-class for all (component) instantiations.
 	"""
 
-	_genericAssociations: List[AssociationItem]
-	_portAssociations: List[AssociationItem]
+	_genericAssociationItems: List[AssociationItem]
+	_portAssociationItems: List[AssociationItem]
 
 	def __init__(
 		self,
 		label: str,
-		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
-		portAssociations: Nullable[Iterable[AssociationItem]] = None,
+		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 
 		# TODO: extract to mixin
-		self._genericAssociations = []
-		if genericAssociations is not None:
-			for association in genericAssociations:
-				self._genericAssociations.append(association)
+		self._genericAssociationItems = []
+		if genericAssociationItems is not None:
+			for association in genericAssociationItems:
+				self._genericAssociationItems.append(association)
 				association.Parent = self
 
 		# TODO: extract to mixin
-		self._portAssociations = []
-		if portAssociations is not None:
-			for association in portAssociations:
-				self._portAssociations.append(association)
+		self._portAssociationItems = []
+		if portAssociationItems is not None:
+			for association in portAssociationItems:
+				self._portAssociationItems.append(association)
 				association.Parent = self
 
 	@readonly
-	def GenericAssociations(self) -> List[AssociationItem]:
-		return self._genericAssociations
+	def GenericAssociationItems(self) -> List[AssociationItem]:
+		return self._genericAssociationItems
 
 	@property
-	def PortAssociations(self) -> List[AssociationItem]:
-		return self._portAssociations
+	def PortAssociationItems(self) -> List[AssociationItem]:
+		return self._portAssociationItems
 
 
 @export
@@ -183,11 +183,11 @@ class ComponentInstantiation(Instantiation):
 		self,
 		label: str,
 		componentSymbol: ComponentInstantiationSymbol,
-		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
-		portAssociations: Nullable[Iterable[AssociationItem]] = None,
+		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(label, genericAssociations, portAssociations, parent)
+		super().__init__(label, genericAssociationItems, portAssociationItems, parent)
 
 		self._component = componentSymbol
 		componentSymbol.Parent = self
@@ -217,11 +217,11 @@ class EntityInstantiation(Instantiation):
 		label: str,
 		entitySymbol: EntityInstantiationSymbol,
 		architectureSymbol: Nullable[ArchitectureSymbol] = None,
-		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
-		portAssociations: Nullable[Iterable[AssociationItem]] = None,
+		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(label, genericAssociations, portAssociations, parent)
+		super().__init__(label, genericAssociationItems, portAssociationItems, parent)
 
 		self._entity = entitySymbol
 		entitySymbol.Parent = self
@@ -257,11 +257,11 @@ class ConfigurationInstantiation(Instantiation):
 		self,
 		label: str,
 		configurationSymbol: ConfigurationInstantiationSymbol,
-		genericAssociations: Nullable[Iterable[AssociationItem]] = None,
-		portAssociations: Nullable[Iterable[AssociationItem]] = None,
+		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
+		portAssociationItems: Nullable[Iterable[AssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(label, genericAssociations, portAssociations, parent)
+		super().__init__(label, genericAssociationItems, portAssociationItems, parent)
 
 		self._configuration = configurationSymbol
 		configurationSymbol.Parent = self
@@ -322,11 +322,11 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 		self,
 		label: str,
 		procedureName: Name,
-		parameterMappings: Nullable[Iterable[ParameterAssociationItem]] = None,
+		parameterAssociationItems: Nullable[Iterable[ParameterAssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
-		ProcedureCallMixin.__init__(self, procedureName, parameterMappings)
+		ProcedureCallMixin.__init__(self, procedureName, parameterAssociationItems)
 
 
 @export

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -81,14 +81,14 @@ class FunctionInstantiation(Function, SubprogramInstantiationMixin):
 @export
 class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a PackageBase class is needed to share members.
 	_packageReference: PackageReferenceSymbol
-	_genericAssociations: List[GenericAssociationItem]
+	_genericAssociationItems: List[GenericAssociationItem]
 
 	def __init__(
 		self,
 		identifier:          str,
 		genericPackage:      PackageReferenceSymbol,
 		contextItems:        Nullable[Iterable[ContextUnion]] =           None,
-		genericAssociations: Nullable[Iterable[GenericAssociationItem]] = None,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
 		documentation:       Nullable[str] =                              None,
 		parent:              Nullable[ModelEntity] =                      None
 	) -> None:
@@ -99,18 +99,18 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 		self._packageReference.Parent = self
 
 		# TODO: extract to mixin
-		self._genericAssociations = []
-		if genericAssociations is not None:
-			for association in genericAssociations:
-				self._genericAssociations.append(association)
+		self._genericAssociationItems = []
+		if genericAssociationItems is not None:
+			for association in genericAssociationItems:
+				self._genericAssociationItems.append(association)
 
 	@readonly
 	def PackageReference(self) -> PackageReferenceSymbol:
 		return self._packageReference
 
 	@readonly
-	def GenericAssociations(self) -> List[GenericAssociationItem]:
-		return self._genericAssociations
+	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
+		return self._genericAssociationItems
 
 	def Instantiate(self):
 		genericPackage: Package = self._packageReference.Package

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -103,6 +103,7 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 		if genericAssociationItems is not None:
 			for association in genericAssociationItems:
 				self._genericAssociationItems.append(association)
+				association.Parent = self
 
 	@readonly
 	def PackageReference(self) -> PackageReferenceSymbol:

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -79,12 +79,12 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 	def __init__(
 		self,
 		procedureName: Symbol,
-		parameterMappings: Nullable[Iterable[ParameterAssociationItem]] = None,
+		parameterAssociationItems: Nullable[Iterable[ParameterAssociationItem]] = None,
 		label: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
-		ProcedureCallMixin.__init__(self, procedureName, parameterMappings)
+		ProcedureCallMixin.__init__(self, procedureName, parameterAssociationItems)
 
 
 @export

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -431,20 +431,20 @@ class SimpleInstance(TestCase):
 				LibraryReferenceSymbol(SimpleName("ieee")),
 			]),
 		]
-		genericAssociations = [
+		genericAssociationItems = [
 			GenericAssociationItem(SimpleName("WIDTH"), IntegerLiteral(16)),
 		]
 		packageInstantiation = PackageInstantiation(
-			"pack_inst_1", packageReference, contextItems, genericAssociations, parent=None
+			"pack_inst_1", packageReference, contextItems, genericAssociationItems, parent=None
 		)
 
 		self.assertIsNotNone(packageInstantiation)
 		self.assertEqual("pack_inst_1", packageInstantiation.Identifier)
 		self.assertIs(packageReference, packageInstantiation.PackageReference)
 		self.assertEqual(1, len(packageInstantiation.ContextItems))
-		self.assertEqual(1, len(packageInstantiation.GenericAssociations))
-		self.assertEqual("WIDTH", packageInstantiation.GenericAssociations[0].Formal.Identifier)
-		self.assertEqual(16, packageInstantiation.GenericAssociations[0].Actual.Value)
+		self.assertEqual(1, len(packageInstantiation.GenericAssociationItems))
+		self.assertEqual("WIDTH", packageInstantiation.GenericAssociationItems[0].Formal.Identifier)
+		self.assertEqual(16, packageInstantiation.GenericAssociationItems[0].Actual.Value)
 
 	def test_PackageInstantiation_withoutContextItemsOrGenerics(self) -> None:
 		packageReference = PackageReferenceSymbol(SimpleName("generic_pack"))
@@ -452,7 +452,7 @@ class SimpleInstance(TestCase):
 
 		self.assertIsNotNone(packageInstantiation)
 		self.assertEqual(0, len(packageInstantiation.ContextItems))
-		self.assertEqual(0, len(packageInstantiation.GenericAssociations))
+		self.assertEqual(0, len(packageInstantiation.GenericAssociationItems))
 
 	def test_Context(self) -> None:
 		context = Context("ctx_1", parent=None)


### PR DESCRIPTION
## Summary

Follow-up naming consistency pass, triggered by review discussion on #127: the class held in every one of these lists is `GenericAssociationItem`/`PortAssociationItem`/`ParameterAssociationItem`, so the parameter/property name should be the plural of the class name - matching `genericItems` (plural of the class held there, `GenericInterfaceItemMixin`) and mirroring `PackageInstantiation.genericAssociationItems` (introduced in #127).

| Old name | New name | Where |
|---|---|---|
| `genericAssociations` / `GenericAssociations` | `genericAssociationItems` / `GenericAssociationItems` | `Concurrent.py`: `Instantiation`, `ComponentInstantiation`, `EntityInstantiation`, `ConfigurationInstantiation`; `Instantiation.py`: `PackageInstantiation` |
| `portAssociations` / `PortAssociations` | `portAssociationItems` / `PortAssociationItems` | same four `Concurrent.py` classes |
| `parameterMappings` / `ParameterMappings` | `parameterAssociationItems` / `ParameterAssociationItems` | `Common.py`: `ProcedureCallMixin`; `Concurrent.py`: `ConcurrentProcedureCall`; `Sequential.py`: `ProcedureCallStatement` |

`parameterMappings` was the odd one out (different word, not just missing "Items") - I checked whether it might be intentionally different, since VHDL's LRM never calls a procedure call's actual parameter part a "map" (unlike generic/port map aspects, which the LRM does call a "map"), but was asked to rename it too for full cross-codebase consistency with pyGHDL.dom, so it's included here.

This is a breaking rename for any external code constructing these classes directly with keyword arguments or reading `.GenericAssociations`/`.PortAssociations`/`.ParameterMappings` - a companion PR in `pyGHDL.dom` (which is the only consumer I'm aware of) updates all matching call sites: https://github.com/paebbels/GHDL/pull/5

## Testing

Updated `tests/unit/Instantiate.py`. Full suite: `73 passed`, no regressions. Also re-verified end-to-end against real GHDL analysis via the companion pyGHDL.dom change - including a new manual check of `ParameterAssociationItems` on a real procedure-call statement (`log("hello", 3)`), which wasn't covered by any existing fixture.
