### PR TITLE
Fix Function.ReturnType crash and Subprogram genericItems/parameterItems constructor gap

### DIFF
--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -80,17 +80,17 @@ class FunctionInstantiation(Function, SubprogramInstantiationMixin):
 
 @export
 class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a PackageBase class is needed to share members.
-	_packageReference: PackageReferenceSymbol
+	_packageReference:        PackageReferenceSymbol
 	_genericAssociationItems: List[GenericAssociationItem]
 
 	def __init__(
 		self,
-		identifier:          str,
-		genericPackage:      PackageReferenceSymbol,
-		contextItems:        Nullable[Iterable[ContextUnion]] =           None,
+		identifier:              str,
+		genericPackage:          PackageReferenceSymbol,
+		contextItems:            Nullable[Iterable[ContextUnion]] =           None,
 		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
-		documentation:       Nullable[str] =                              None,
-		parent:              Nullable[ModelEntity] =                      None
+		documentation:           Nullable[str] =                              None,
+		parent:                  Nullable[ModelEntity] =                      None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation=documentation, parent=parent)
 		GenericEntityInstantiationMixin.__init__(self)

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -436,8 +436,8 @@ class ReturnStatement(SequentialStatement):
 	def __init__(
 		self,
 		returnValue: Nullable[ExpressionUnion] = None,
-		label: Nullable[str] = None,
-		parent: Nullable[ModelEntity] = None
+		label:       Nullable[str] =             None,
+		parent:      Nullable[ModelEntity] =     None
 	) -> None:
 		super().__init__(label, parent)
 

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -430,17 +430,23 @@ class NullStatement(SequentialStatement):
 
 
 @export
-class ReturnStatement(SequentialStatement, ConditionalMixin):
-	_returnValue: ExpressionUnion
+class ReturnStatement(SequentialStatement):
+	_returnValue: Nullable[ExpressionUnion]
 
-	def __init__(self, returnValue: Nullable[ExpressionUnion] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(parent)
-		ConditionalMixin.__init__(self, returnValue)
+	def __init__(
+		self,
+		returnValue: Nullable[ExpressionUnion] = None,
+		label: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(label, parent)
 
-		# TODO: return value?
+		self._returnValue = returnValue
+		if returnValue is not None:
+			returnValue.Parent = self
 
-	@property
-	def ReturnValue(self) -> ExpressionUnion:
+	@readonly
+	def ReturnValue(self) -> Nullable[ExpressionUnion]:
 		return self._returnValue
 
 

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -55,14 +55,14 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	def __init__(
 		self,
-		identifier: str,
-		isPure: bool,
-		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		identifier:     str,
+		isPure:         bool,
+		genericItems:   Nullable[Iterable['GenericInterfaceItemMixin']] =   None,
 		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
-		declaredItems: Nullable[Iterable] = None,
-		statements: Nullable[Iterable[SequentialStatement]] = None,
-		documentation: Nullable[str] = None,
-		parent: Nullable[ModelEntity] = None
+		declaredItems:  Nullable[Iterable] =                                None,
+		statements:     Nullable[Iterable[SequentialStatement]] =           None,
+		documentation:  Nullable[str] =                                     None,
+		parent:         Nullable[ModelEntity] =                             None
 	) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
@@ -119,13 +119,13 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 class Procedure(Subprogram):
 	def __init__(
 		self,
-		identifier: str,
-		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		identifier:     str,
+		genericItems:   Nullable[Iterable['GenericInterfaceItemMixin']] =   None,
 		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
-		declaredItems: Nullable[Iterable] = None,
-		statements: Nullable[Iterable[SequentialStatement]] = None,
-		documentation: Nullable[str] = None,
-		parent: Nullable[ModelEntity] = None
+		declaredItems:  Nullable[Iterable] =                                None,
+		statements:     Nullable[Iterable[SequentialStatement]] =           None,
+		documentation:  Nullable[str] =                                     None,
+		parent:         Nullable[ModelEntity] =                             None
 	) -> None:
 		super().__init__(identifier, False, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 
@@ -136,15 +136,15 @@ class Function(Subprogram):
 
 	def __init__(
 		self,
-		identifier: str,
-		returnType: SubtypeSymbol,
-		isPure: bool = True,
-		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		identifier:     str,
+		returnType:     SubtypeSymbol,
+		isPure:         bool =                                              True,
+		genericItems:   Nullable[Iterable['GenericInterfaceItemMixin']] =   None,
 		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
-		declaredItems: Nullable[Iterable] = None,
-		statements: Nullable[Iterable[SequentialStatement]] = None,
-		documentation: Nullable[str] = None,
-		parent: Nullable[ModelEntity] = None
+		declaredItems:  Nullable[Iterable] =                                None,
+		statements:     Nullable[Iterable[SequentialStatement]] =           None,
+		documentation:  Nullable[str] =                                     None,
+		parent:         Nullable[ModelEntity] =                             None
 	) -> None:
 		super().__init__(identifier, isPure, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 
@@ -175,14 +175,14 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 class ProcedureMethod(Procedure, MethodMixin):
 	def __init__(
 		self,
-		identifier: str,
-		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		identifier:     str,
+		genericItems:   Nullable[Iterable['GenericInterfaceItemMixin']] =   None,
 		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
-		declaredItems: Nullable[Iterable] = None,
-		statements: Nullable[Iterable[SequentialStatement]] = None,
-		documentation: Nullable[str] = None,
-		protectedType: Nullable[ProtectedType] = None,
-		parent: Nullable[ModelEntity] = None
+		declaredItems:  Nullable[Iterable] =                                None,
+		statements:     Nullable[Iterable[SequentialStatement]] =           None,
+		documentation:  Nullable[str] =                                     None,
+		protectedType:  Nullable[ProtectedType] =                           None,
+		parent:         Nullable[ModelEntity] =                             None
 	) -> None:
 		super().__init__(identifier, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 		MethodMixin.__init__(self, protectedType)
@@ -192,16 +192,16 @@ class ProcedureMethod(Procedure, MethodMixin):
 class FunctionMethod(Function, MethodMixin):
 	def __init__(
 		self,
-		identifier: str,
-		returnType: SubtypeSymbol,
-		isPure: bool = True,
-		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		identifier:     str,
+		returnType:     SubtypeSymbol,
+		isPure:         bool =                                              True,
+		genericItems:   Nullable[Iterable['GenericInterfaceItemMixin']] =   None,
 		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
-		declaredItems: Nullable[Iterable] = None,
-		statements: Nullable[Iterable[SequentialStatement]] = None,
-		documentation: Nullable[str] = None,
-		protectedType: Nullable[ProtectedType] = None,
-		parent: Nullable[ModelEntity] = None
+		declaredItems:  Nullable[Iterable] =                                None,
+		statements:     Nullable[Iterable[SequentialStatement]] =           None,
+		documentation:  Nullable[str] =                                     None,
+		protectedType:  Nullable[ProtectedType] =                           None,
+		parent:         Nullable[ModelEntity] =                             None
 	) -> None:
 		super().__init__(identifier, returnType, isPure, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 		MethodMixin.__init__(self, protectedType)

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -34,41 +34,72 @@ This module contains parts of an abstract document language model for VHDL.
 
 Subprograms are procedures, functions and methods.
 """
-from typing                 import List, Optional as Nullable
+from typing                 import List, Iterable, Optional as Nullable
 
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
 
 from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, DocumentedEntityMixin
-from pyVHDLModel.Type       import Subtype, ProtectedType
+from pyVHDLModel.Symbol     import SubtypeSymbol
+from pyVHDLModel.Type       import ProtectedType
 from pyVHDLModel.Sequential import SequentialStatement
 
 
 @export
 class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
-	_genericItems:   List['GenericInterfaceItem']
-	_parameterItems: List['ParameterInterfaceItem']
+	_genericItems:   List['GenericInterfaceItemMixin']
+	_parameterItems: List['ParameterInterfaceItemMixin']
 	_declaredItems:  List
-	_statements:     List['SequentialStatement']
+	_statements:     List[SequentialStatement]
 	_isPure:         bool
 
-	def __init__(self, identifier: str, isPure: bool, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(
+		self,
+		identifier: str,
+		isPure: bool,
+		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable[SequentialStatement]] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
 
-		self._genericItems =    []  # TODO: convert to dict
-		self._parameterItems =  []  # TODO: convert to dict
-		self._declaredItems =   []  # TODO: use mixin class
-		self._statements =      []  # TODO: use mixin class
-		self._isPure =          isPure
+		self._genericItems = []  # TODO: convert to dict
+		if genericItems is not None:
+			for item in genericItems:
+				self._genericItems.append(item)
+				item.Parent = self
+
+		self._parameterItems = []  # TODO: convert to dict
+		if parameterItems is not None:
+			for item in parameterItems:
+				self._parameterItems.append(item)
+				item.Parent = self
+
+		self._declaredItems = []  # TODO: use mixin class
+		if declaredItems is not None:
+			for item in declaredItems:
+				self._declaredItems.append(item)
+				item.Parent = self
+
+		self._statements = []  # TODO: use mixin class
+		if statements is not None:
+			for item in statements:
+				self._statements.append(item)
+				item.Parent = self
+
+		self._isPure = isPure
 
 	@readonly
-	def GenericItems(self) -> List['GenericInterfaceItem']:
+	def GenericItems(self) -> List['GenericInterfaceItemMixin']:
 		return self._genericItems
 
 	@readonly
-	def ParameterItems(self) -> List['ParameterInterfaceItem']:
+	def ParameterItems(self) -> List['ParameterInterfaceItemMixin']:
 		return self._parameterItems
 
 	@readonly
@@ -76,7 +107,7 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		return self._declaredItems
 
 	@readonly
-	def Statements(self) -> List['SequentialStatement']:
+	def Statements(self) -> List[SequentialStatement]:
 		return self._statements
 
 	@readonly
@@ -86,21 +117,42 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 @export
 class Procedure(Subprogram):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, False, documentation, parent)
+	def __init__(
+		self,
+		identifier: str,
+		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable[SequentialStatement]] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifier, False, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 
 
 @export
 class Function(Subprogram):
-	_returnType: Subtype
+	_returnType: SubtypeSymbol
 
-	def __init__(self, identifier: str, isPure: bool = True, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, isPure, documentation, parent)
+	def __init__(
+		self,
+		identifier: str,
+		returnType: SubtypeSymbol,
+		isPure: bool = True,
+		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable[SequentialStatement]] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifier, isPure, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 
-		# FIXME: return type is missing
+		self._returnType = returnType
+		returnType.Parent = self
 
 	@readonly
-	def ReturnType(self) -> Subtype:
+	def ReturnType(self) -> SubtypeSymbol:
 		return self._returnType
 
 
@@ -121,13 +173,35 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class ProcedureMethod(Procedure, MethodMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, protectedType: Nullable[ProtectedType] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, documentation, parent)
+	def __init__(
+		self,
+		identifier: str,
+		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable[SequentialStatement]] = None,
+		documentation: Nullable[str] = None,
+		protectedType: Nullable[ProtectedType] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifier, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 		MethodMixin.__init__(self, protectedType)
 
 
 @export
 class FunctionMethod(Function, MethodMixin):
-	def __init__(self, identifier: str, isPure: bool = True, documentation: Nullable[str] = None, protectedType: Nullable[ProtectedType] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, isPure, documentation, parent)
+	def __init__(
+		self,
+		identifier: str,
+		returnType: SubtypeSymbol,
+		isPure: bool = True,
+		genericItems: Nullable[Iterable['GenericInterfaceItemMixin']] = None,
+		parameterItems: Nullable[Iterable['ParameterInterfaceItemMixin']] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable[SequentialStatement]] = None,
+		documentation: Nullable[str] = None,
+		protectedType: Nullable[ProtectedType] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifier, returnType, isPure, genericItems, parameterItems, declaredItems, statements, documentation, parent)
 		MethodMixin.__init__(self, protectedType)

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -256,9 +256,8 @@ class VHDLVersion(Enum):
 
 	def __hash__(self) -> int:
 		"""
-		Compute a hash value from the underlying version number, so ``VHDLVersion`` members can be used as
-		dict keys / set members again (overriding ``__eq__`` implicitly disables the default ``__hash__``).
-
+		Return the hash of the VHDL version using the underlying version number.
+		
 		.. note::
 
 		   ``Any`` compares equal to every other member (see :meth:`__eq__`), which no hash value can satisfy
@@ -266,7 +265,7 @@ class VHDLVersion(Enum):
 		   hashes by ``self.value``, which is internally consistent for all comparisons *except* those
 		   involving ``Any`` - avoid using ``Any`` as a dict key or set member.
 
-		:returns: Hash value of the underlying version number.
+		:returns: Hash value of the underlying VHDL version number.
 		"""
 		return hash(self.value)
 

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -254,6 +254,22 @@ class VHDLVersion(Enum):
 		else:
 			raise TypeError("Second operand is not of type 'VHDLVersion'.")
 
+	def __hash__(self) -> int:
+		"""
+		Compute a hash value from the underlying version number, so ``VHDLVersion`` members can be used as
+		dict keys / set members again (overriding ``__eq__`` implicitly disables the default ``__hash__``).
+
+		.. note::
+
+		   ``Any`` compares equal to every other member (see :meth:`__eq__`), which no hash value can satisfy
+		   simultaneously for all members without collapsing every member to the same hash. This implementation
+		   hashes by ``self.value``, which is internally consistent for all comparisons *except* those
+		   involving ``Any`` - avoid using ``Any`` as a dict key or set member.
+
+		:returns: Hash value of the underlying version number.
+		"""
+		return hash(self.value)
+
 	@readonly
 	def IsVHDL(self) -> bool:
 		"""


### PR DESCRIPTION
## Summary

Found while auditing pyGHDL.dom for untranslated/silently-broken constructs. `Function.ReturnType`
crashes on every instance, reproducibly:

```python
>>> from pyVHDLModel.Subprogram import Function
>>> Function("my_func").ReturnType
AttributeError: 'Function' object has no attribute '_returnType'
```

`Function.__init__` declares `_returnType: Subtype` as a type annotation and has a `ReturnType`
readonly property reading `self._returnType` - but never assigns it, and doesn't even accept a
`returnType` parameter.

Same root problem, one level up: `Subprogram.__init__` (shared base of `Function`/`Procedure`)
doesn't accept `genericItems`/`parameterItems`/`declaredItems`/`statements` at all - it
unconditionally sets all four to `[]`.

**How pyGHDL.dom currently copes**: reaches directly into `self._returnType`/`self._genericItems`/
`self._parameterItems` after calling `super().__init__()`, bypassing the constructor - marked
`# TODO: move to model` in that codebase, i.e. already flagged as a workaround for a gap here.

## Changes

- `Subprogram.__init__` now accepts `genericItems`/`parameterItems`/`declaredItems`/`statements`,
  wiring `.Parent` correctly on each item (previously never done at all, since the lists were
  always empty).
- `Function.__init__` now accepts and stores `returnType` (required - every function has one).
- `Procedure`/`ProcedureMethod`/`FunctionMethod` forward the new parameters through.
- `ReturnType`'s type hint was `pyVHDLModel.Type.Subtype`, but every real caller actually passes a
  `Symbol` (a reference to the return type, not an owned type definition) - retyped as
  `SubtypeSymbol` to match actual usage.

One thing worth a second opinion: `Subprogram` reimplements generic/parameter item storage instead
of composing `WithGenericsMixin`/`WithParametersMixin` (which already do this correctly elsewhere,
including `.Parent` wiring). I kept `Subprogram`'s own storage for this fix to keep the change
narrowly scoped to "make the constructor work correctly" rather than also restructuring the class
hierarchy - but composing those mixins instead might be the more consistent long-term shape. Happy
to redo it that way if you'd rather.

## Companion change

pyGHDL.dom's `Function`/`Procedure` now use the fixed constructor instead of the private-field
workaround, and additionally now read `IsPure` from `Get_Pure_Flag` (previously never read at all -
every function silently defaulted to `IsPure=True` regardless of `impure`). Verified end-to-end
against real GHDL analysis:

```vhdl
function double(x : integer) return integer is ... end function;
impure function get_random return integer is ... end function;
```
→ `double.IsPure == True`, `get_random.IsPure == False`, both `.ReturnType` populated correctly
(previously would have crashed on `.ReturnType` access).

## Testing

Full suite: `73 passed`, no regressions. This branch is stacked on `naming/genericAssociationItems`
(#128, still open) since I'm actively working across both, to avoid reintroducing the old
`genericAssociations` naming - please merge/rebase order as you see fit.
