### PR TITLE
Add VHDL-2019 mode view classes and split Port/Parameter signal interface items

### DIFF
--- a/doc/LanguageModel/InterfaceItems.rst
+++ b/doc/LanguageModel/InterfaceItems.rst
@@ -10,7 +10,7 @@ Interface items are used in generic, port and parameter declarations.
 
 .. rubric:: Class Hierarchy
 
-.. inheritance-diagram:: pyVHDLModel.SyntaxModel.GenericConstantInterfaceItem pyVHDLModel.SyntaxModel.GenericTypeInterfaceItem pyVHDLModel.SyntaxModel.GenericProcedureInterfaceItem pyVHDLModel.SyntaxModel.GenericFunctionInterfaceItem pyVHDLModel.SyntaxModel.PortSignalInterfaceItem pyVHDLModel.SyntaxModel.ParameterConstantInterfaceItem pyVHDLModel.SyntaxModel.ParameterVariableInterfaceItem pyVHDLModel.SyntaxModel.ParameterSignalInterfaceItem pyVHDLModel.SyntaxModel.ParameterFileInterfaceItem
+.. inheritance-diagram:: pyVHDLModel.SyntaxModel.GenericConstantInterfaceItem pyVHDLModel.SyntaxModel.GenericTypeInterfaceItem pyVHDLModel.SyntaxModel.GenericProcedureInterfaceItem pyVHDLModel.SyntaxModel.GenericFunctionInterfaceItem pyVHDLModel.SyntaxModel.PortSimpleSignalInterfaceItem pyVHDLModel.SyntaxModel.PortViewSignalInterfaceItem pyVHDLModel.SyntaxModel.ParameterConstantInterfaceItem pyVHDLModel.SyntaxModel.ParameterVariableInterfaceItem pyVHDLModel.SyntaxModel.ParameterSimpleSignalInterfaceItem pyVHDLModel.SyntaxModel.ParameterViewSignalInterfaceItem pyVHDLModel.SyntaxModel.ParameterFileInterfaceItem
    :parts: 1
 
 
@@ -136,16 +136,25 @@ Port Interface Item
 PortSignalInterfaceItem
 -----------------------
 
+``PortSignalInterfaceItem`` is now an abstract base-class for :class:`PortSimpleSignalInterfaceItem`
+(``port (p : in bit);``) and :class:`PortViewSignalInterfaceItem` (``port (p : view MyView);``,
+VHDL-2019 mode views) - see below. It is not meant to be instantiated directly.
+
+.. _vhdlmodel-portsimplesignal:
+
+PortSimpleSignalInterfaceItem
+------------------------------
+
 .. todo::
 
    Write documentation.
 
-**Condensed definition of class** :class:`~pyVHDLModel.SyntaxModel.PortSignalInterfaceItem`:
+**Condensed definition of class** :class:`~pyVHDLModel.SyntaxModel.PortSimpleSignalInterfaceItem`:
 
 .. code-block:: Python
 
    @export
-   class PortSignalInterfaceItem(Signal, PortInterfaceItem):
+   class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem):
      # inherited from ModelEntity
      @property
      def Parent(self) -> ModelEntity:
@@ -162,9 +171,41 @@ PortSignalInterfaceItem
      @property
      def DefaultExpression(self) -> BaseExpression:
 
-     # inherited from InterfaceItem
+     # inherited from InterfaceItemWithModeMixin
      @property
      def Mode(self) -> Mode:
+
+
+.. _vhdlmodel-portviewsignal:
+
+PortViewSignalInterfaceItem
+-----------------------------
+
+.. todo::
+
+   Write documentation.
+
+**Condensed definition of class** :class:`~pyVHDLModel.SyntaxModel.PortViewSignalInterfaceItem`:
+
+.. code-block:: Python
+
+   @export
+   class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
+     # inherited from ModelEntity
+     @property
+     def Parent(self) -> ModelEntity:
+
+     # inherited from NamedEntity
+     @property
+     def Name(self) -> str:
+
+     # inherited from Object; aliased as ModeViewIndication (a mode view reference occupies the
+     # same structural position as an ordinary subtype indication)
+     @property
+     def Subtype(self) -> Symbol:
+
+     @property
+     def ModeViewIndication(self) -> ModeViewSymbol:
 
 
 
@@ -252,16 +293,26 @@ ParameterVariableInterfaceItem
 ParameterSignalInterfaceItem
 ----------------------------
 
+``ParameterSignalInterfaceItem`` is now an abstract base-class for
+:class:`ParameterSimpleSignalInterfaceItem` (``procedure p(signal s : in bit);``) and
+:class:`ParameterViewSignalInterfaceItem` (``procedure p(signal s : view MyView);``, VHDL-2019 mode
+views) - see below. It is not meant to be instantiated directly.
+
+.. _vhdlmodel-parametersimplesignal:
+
+ParameterSimpleSignalInterfaceItem
+-----------------------------------
+
 .. todo::
 
    Write documentation.
 
-**Condensed definition of class** :class:`~pyVHDLModel.SyntaxModel.ParameterSignalInterfaceItem`:
+**Condensed definition of class** :class:`~pyVHDLModel.SyntaxModel.ParameterSimpleSignalInterfaceItem`:
 
 .. code-block:: Python
 
    @export
-   class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItem):
+   class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem):
      # inherited from ModelEntity
      @property
      def Parent(self) -> ModelEntity:
@@ -278,9 +329,41 @@ ParameterSignalInterfaceItem
      @property
      def DefaultExpression(self) -> BaseExpression:
 
-     # inherited from InterfaceItem
+     # inherited from InterfaceItemWithModeMixin
      @property
      def Mode(self) -> Mode:
+
+
+.. _vhdlmodel-parameterviewsignal:
+
+ParameterViewSignalInterfaceItem
+-----------------------------------
+
+.. todo::
+
+   Write documentation.
+
+**Condensed definition of class** :class:`~pyVHDLModel.SyntaxModel.ParameterViewSignalInterfaceItem`:
+
+.. code-block:: Python
+
+   @export
+   class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
+     # inherited from ModelEntity
+     @property
+     def Parent(self) -> ModelEntity:
+
+     # inherited from NamedEntity
+     @property
+     def Name(self) -> str:
+
+     # inherited from Object; aliased as ModeViewIndication (a mode view reference occupies the
+     # same structural position as an ordinary subtype indication)
+     @property
+     def Subtype(self) -> Symbol:
+
+     @property
+     def ModeViewIndication(self) -> ModeViewSymbol:
 
 
 

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -278,6 +278,7 @@ class PortSignalInterfaceItem(Signal, InterfaceItemMixin):
 @export
 class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithModeMixin):
 	"""
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
@@ -301,6 +302,7 @@ class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithMo
 @export
 class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
 	"""
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
@@ -309,29 +311,26 @@ class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
 
 	.. note::
 
-	   ``Subtype`` will usually be ``None`` here: at the parse-only level this project operates at, the
-	   element's type is only implied by the referenced mode view's own ``of`` type - there is no separate
-	   subtype indication to read directly off the interface declaration itself.
+	   VHDL's grammar treats a mode view indication as occupying the same structural position as an
+	   ordinary subtype indication (``mode_indication ::= simple_mode_indication | mode_view_indication``).
+	   Accordingly, the mode view reference *is* this object's :attr:`Subtype` (a :class:`Symbol` is a
+	   :class:`Symbol`, whether it names a subtype or a mode view) - :attr:`ModeViewIndication` is just a
+	   more specific, aliased name for the same value, not a separate field. An object's subtype can never
+	   be ``None`` - there is no VHDL syntax that omits it.
 	"""
-
-	_modeViewIndication: ModeViewSymbol
 
 	def __init__(
 		self,
 		identifiers: Iterable[str],
 		modeViewIndication: ModeViewSymbol,
-		subtype: Nullable[Symbol] = None,
 		documentation: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(identifiers, subtype, None, documentation, parent)
-
-		self._modeViewIndication = modeViewIndication
-		modeViewIndication.Parent = self
+		super().__init__(identifiers, modeViewIndication, None, documentation, parent)
 
 	@readonly
 	def ModeViewIndication(self) -> ModeViewSymbol:
-		return self._modeViewIndication
+		return self._subtype
 
 
 @export
@@ -378,6 +377,7 @@ class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin):
 @export
 class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, InterfaceItemWithModeMixin):
 	"""
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
@@ -402,6 +402,7 @@ class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, Interface
 @export
 class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
 	"""
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
@@ -410,28 +411,23 @@ class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
 
 	.. note::
 
-	   ``Subtype`` will usually be ``None`` here - see :class:`PortViewSignalInterfaceItem` for why.
+	   See :class:`PortViewSignalInterfaceItem` for why the mode view reference *is* :attr:`Subtype`
+	   (aliased as :attr:`ModeViewIndication`), rather than a separate, possibly-``None`` field.
 	"""
-
-	_modeViewIndication: ModeViewSymbol
 
 	def __init__(
 		self,
 		identifiers: Iterable[str],
 		modeViewIndication: ModeViewSymbol,
-		subtype: Nullable[Symbol] = None,
 		documentation: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(identifiers, subtype, None, documentation, parent)
+		super().__init__(identifiers, modeViewIndication, None, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)
-
-		self._modeViewIndication = modeViewIndication
-		modeViewIndication.Parent = self
 
 	@readonly
 	def ModeViewIndication(self) -> ModeViewSymbol:
-		return self._modeViewIndication
+		return self._subtype
 
 
 @export

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -91,12 +91,6 @@ class SimpleModeViewElement(ModeViewElement):
 class CompositeModeViewElement(ModeViewElement):
 	"""
 	A mode view element that refers to another (named) mode view for an array or record sub-element.
-
-	GHDL's IIR distinguishes an array- from a record-typed target element (``Array_Mode_View_Element`` /
-	``Record_Mode_View_Element``), but that distinction can only be determined once the target element's
-	type is resolved, which requires semantic analysis. Both are merged into this one class here, since they
-	are otherwise structurally identical (both just carry a reference to another mode view).
-
 	.. admonition:: Example
 
 	   .. code-block:: VHDL

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -39,12 +39,133 @@ from typing                 import Iterable, Optional as Nullable, List, Iterato
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
 
-from pyVHDLModel.Symbol     import Symbol
+from pyVHDLModel.Symbol     import Symbol, SubtypeSymbol, ModeViewSymbol
 from pyVHDLModel.Base       import ModelEntity, DocumentedEntityMixin, NamedEntityMixin, OptionallyNamedEntityMixin
+from pyVHDLModel.Base       import MultipleNamedEntityMixin
 from pyVHDLModel.Base       import ExpressionUnion, Mode
 from pyVHDLModel.Object     import Constant, Signal, Variable, File
 from pyVHDLModel.Subprogram import Procedure, Function
 from pyVHDLModel.Type       import Type
+
+
+@export
+class ModeViewElement(ModelEntity, MultipleNamedEntityMixin):
+	"""
+	Base-class for one element definition inside a mode view declaration (VHDL-2019). An element may name
+	several fields sharing the same specification (e.g. ``a, b : out;``), hence
+	:class:`~pyVHDLModel.Base.MultipleNamedEntityMixin` is inherited.
+	"""
+
+	def __init__(self, identifiers: Iterable[str], parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(parent)
+		MultipleNamedEntityMixin.__init__(self, identifiers)
+
+
+@export
+class SimpleModeViewElement(ModeViewElement):
+	"""
+	A mode view element with a plain (simple) mode.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      view MyView of RecordType is
+	        a, b : out;
+	        --     ^^^
+	      end view;
+	"""
+
+	_mode: Mode
+
+	def __init__(self, identifiers: Iterable[str], mode: Mode, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifiers, parent)
+		self._mode = mode
+
+	@readonly
+	def Mode(self) -> Mode:
+		return self._mode
+
+
+@export
+class CompositeModeViewElement(ModeViewElement):
+	"""
+	A mode view element that refers to another (named) mode view for an array or record sub-element.
+
+	GHDL's IIR distinguishes an array- from a record-typed target element (``Array_Mode_View_Element`` /
+	``Record_Mode_View_Element``), but that distinction can only be determined once the target element's
+	type is resolved, which requires semantic analysis. Both are merged into this one class here, since they
+	are otherwise structurally identical (both just carry a reference to another mode view).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      view OuterView of OuterRecord is
+	        b : view InnerView;
+	        --       ^^^^^^^^^
+	      end view;
+	"""
+
+	_modeViewName: ModeViewSymbol
+
+	def __init__(self, identifiers: Iterable[str], modeViewName: ModeViewSymbol, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifiers, parent)
+
+		self._modeViewName = modeViewName
+		modeViewName.Parent = self
+
+	@readonly
+	def ModeViewName(self) -> ModeViewSymbol:
+		return self._modeViewName
+
+
+@export
+class ModeViewDeclaration(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
+	"""
+	Represents a mode view declaration (VHDL-2019).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      view MyView of RecordType is
+	        a : out;
+	        b : in;
+	      end view;
+	"""
+
+	_subtype:  SubtypeSymbol
+	_elements: List[ModeViewElement]
+
+	def __init__(
+		self,
+		identifier:    str,
+		subtype:       SubtypeSymbol,
+		elements:      Nullable[Iterable[ModeViewElement]] = None,
+		documentation: Nullable[str] =                        None,
+		parent:        Nullable[ModelEntity] =                None
+	) -> None:
+		super().__init__(parent)
+		NamedEntityMixin.__init__(self, identifier)
+		DocumentedEntityMixin.__init__(self, documentation)
+
+		self._subtype = subtype
+		subtype.Parent = self
+
+		self._elements = []
+		if elements is not None:
+			for element in elements:
+				self._elements.append(element)
+				element.Parent = self
+
+	@readonly
+	def Subtype(self) -> SubtypeSymbol:
+		return self._subtype
+
+	@readonly
+	def Elements(self) -> List[ModeViewElement]:
+		return self._elements
 
 
 @export
@@ -146,7 +267,24 @@ class GenericPackageInterfaceItem(InterfacePackage, GenericInterfaceItemMixin):
 
 
 @export
-class PortSignalInterfaceItem(Signal, PortInterfaceItemMixin):
+class PortSignalInterfaceItem(Signal, InterfaceItemMixin):
+	"""
+	Abstract base-class for port signal interface items - either declared with a simple mode
+	(:class:`PortSimpleSignalInterfaceItem`) or with a mode view (:class:`PortViewSignalInterfaceItem`,
+	VHDL-2019).
+	"""
+
+
+@export
+class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithModeMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      port (p : in bit);
+	"""
+
 	def __init__(
 		self,
 		identifiers: Iterable[str],
@@ -157,7 +295,43 @@ class PortSignalInterfaceItem(Signal, PortInterfaceItemMixin):
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
-		PortInterfaceItemMixin.__init__(self, mode)
+		InterfaceItemWithModeMixin.__init__(self, mode)
+
+
+@export
+class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      port (p : view MyView);
+
+	.. note::
+
+	   ``Subtype`` will usually be ``None`` here: at the parse-only level this project operates at, the
+	   element's type is only implied by the referenced mode view's own ``of`` type - there is no separate
+	   subtype indication to read directly off the interface declaration itself.
+	"""
+
+	_modeViewIndication: ModeViewSymbol
+
+	def __init__(
+		self,
+		identifiers: Iterable[str],
+		modeViewIndication: ModeViewSymbol,
+		subtype: Nullable[Symbol] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifiers, subtype, None, documentation, parent)
+
+		self._modeViewIndication = modeViewIndication
+		modeViewIndication.Parent = self
+
+	@readonly
+	def ModeViewIndication(self) -> ModeViewSymbol:
+		return self._modeViewIndication
 
 
 @export
@@ -193,7 +367,24 @@ class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItemMixin, Inte
 
 
 @export
-class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin, InterfaceItemWithModeMixin):
+class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin):
+	"""
+	Abstract base-class for subprogram signal parameters - either declared with a simple mode
+	(:class:`ParameterSimpleSignalInterfaceItem`) or with a mode view
+	(:class:`ParameterViewSignalInterfaceItem`, VHDL-2019).
+	"""
+
+
+@export
+class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, InterfaceItemWithModeMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure proc(signal s : in bit);
+	"""
+
 	def __init__(
 		self,
 		identifiers: Iterable[str],
@@ -206,6 +397,41 @@ class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin, Interfac
 		super().__init__(identifiers, subtype, defaultExpression, documentation, parent)
 		ParameterInterfaceItemMixin.__init__(self)
 		InterfaceItemWithModeMixin.__init__(self, mode)
+
+
+@export
+class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure proc(signal s : view MyView);
+
+	.. note::
+
+	   ``Subtype`` will usually be ``None`` here - see :class:`PortViewSignalInterfaceItem` for why.
+	"""
+
+	_modeViewIndication: ModeViewSymbol
+
+	def __init__(
+		self,
+		identifiers: Iterable[str],
+		modeViewIndication: ModeViewSymbol,
+		subtype: Nullable[Symbol] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifiers, subtype, None, documentation, parent)
+		ParameterInterfaceItemMixin.__init__(self)
+
+		self._modeViewIndication = modeViewIndication
+		modeViewIndication.Parent = self
+
+	@readonly
+	def ModeViewIndication(self) -> ModeViewSymbol:
+		return self._modeViewIndication
 
 
 @export

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -59,22 +59,21 @@ class Obj(ModelEntity, MultipleNamedEntityMixin, DocumentedEntityMixin):
 	:data:`__objectVertex`.
 	"""
 
-	_subtype:      Nullable[Symbol]
+	_subtype:      Symbol
 	_objectVertex: Nullable[Vertex]
 
-	def __init__(self, identifiers: Iterable[str], subtype: Nullable[Symbol], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, identifiers: Iterable[str], subtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		MultipleNamedEntityMixin.__init__(self, identifiers)
 		DocumentedEntityMixin.__init__(self, documentation)
 
 		self._subtype = subtype
-		if subtype is not None:
-			subtype.Parent = self
+		subtype.Parent = self
 
 		self._objectVertex = None
 
 	@readonly
-	def Subtype(self) -> Nullable[Symbol]:
+	def Subtype(self) -> Symbol:
 		return self._subtype
 
 	@readonly

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -59,21 +59,22 @@ class Obj(ModelEntity, MultipleNamedEntityMixin, DocumentedEntityMixin):
 	:data:`__objectVertex`.
 	"""
 
-	_subtype:      Symbol
+	_subtype:      Nullable[Symbol]
 	_objectVertex: Nullable[Vertex]
 
-	def __init__(self, identifiers: Iterable[str], subtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, identifiers: Iterable[str], subtype: Nullable[Symbol], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		MultipleNamedEntityMixin.__init__(self, identifiers)
 		DocumentedEntityMixin.__init__(self, documentation)
 
 		self._subtype = subtype
-		subtype.Parent = self
+		if subtype is not None:
+			subtype.Parent = self
 
 		self._objectVertex = None
 
 	@readonly
-	def Subtype(self) -> Symbol:
+	def Subtype(self) -> Nullable[Symbol]:
 		return self._subtype
 
 	@readonly

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -191,6 +191,36 @@ class PackageReferenceSymbol(Symbol):
 
 
 @export
+class ModeViewSymbol(Symbol):
+	"""
+	Represents a reference (name) to a mode view declaration.
+
+	The internal name will be a :class:`~pyVHDLModel.Name.SimpleName` (or an
+	:class:`~pyVHDLModel.Name.AttributeName` for the ``'converse`` case).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      port (p : view MyView);
+	      --          ^^^^^^
+	      port (p : view MyView'converse);
+	      --          ^^^^^^^^^^^^^^^^^^
+	"""
+
+	def __init__(self, name: Name) -> None:
+		super().__init__(name, PossibleReference.View)
+
+	@property
+	def ModeView(self) -> Nullable['ModeViewDeclaration']:
+		return self._reference
+
+	@ModeView.setter
+	def ModeView(self, value: 'ModeViewDeclaration') -> None:
+		self._reference = value
+
+
+@export
 class ContextReferenceSymbol(Symbol):
 	"""
 	Represents a reference (name) to a context.

--- a/tests/unit/Interface.py
+++ b/tests/unit/Interface.py
@@ -126,7 +126,7 @@ class PortSignalInterfaceItems(TestCase):
 
 		self.assertIsInstance(port, PortSignalInterfaceItem)
 		self.assertIs(modeViewIndication, port.ModeViewIndication)
-		self.assertIsNone(port.Subtype)
+		self.assertIs(modeViewIndication, port.Subtype)
 
 
 class ParameterSignalInterfaceItems(TestCase):
@@ -142,3 +142,4 @@ class ParameterSignalInterfaceItems(TestCase):
 
 		self.assertIsInstance(parameter, ParameterSignalInterfaceItem)
 		self.assertIs(modeViewIndication, parameter.ModeViewIndication)
+		self.assertIs(modeViewIndication, parameter.Subtype)

--- a/tests/unit/Interface.py
+++ b/tests/unit/Interface.py
@@ -1,0 +1,144 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |      __| | ___  _ __ ___                                                        #
+#  | '_ \| | | \ \ / /| |_| | | | | |     / _` |/ _ \| '_ ` _ \                                                       #
+#  | |_) | |_| |\ V / |  _  | |_| | |___ | (_| | (_) | | | | | |                                                       #
+#  | .__/ \__, | \_/  |_| |_|____/|_____(_)__,_|\___/|_| |_| |_|                                                       #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for mode views (VHDL-2019) and the Port/Parameter signal interface item split."""
+from unittest import TestCase
+
+from pyVHDLModel.Base       import Mode
+from pyVHDLModel.Name       import SimpleName
+from pyVHDLModel.Symbol     import SimpleSubtypeSymbol, ModeViewSymbol
+from pyVHDLModel.Interface  import ModeViewDeclaration, SimpleModeViewElement, CompositeModeViewElement
+from pyVHDLModel.Interface  import PortSignalInterfaceItem, PortSimpleSignalInterfaceItem, PortViewSignalInterfaceItem
+from pyVHDLModel.Interface  import ParameterSignalInterfaceItem, ParameterSimpleSignalInterfaceItem, ParameterViewSignalInterfaceItem
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class ModeViewSymbols(TestCase):
+	def test_Unresolved(self) -> None:
+		name = SimpleName("MyView")
+		symbol = ModeViewSymbol(name)
+
+		self.assertIs(name, symbol.Name)
+		self.assertFalse(symbol.IsResolved)
+		self.assertIsNone(symbol.Reference)
+		self.assertIsNone(symbol.ModeView)
+
+	def test_Resolved(self) -> None:
+		symbol = ModeViewSymbol(SimpleName("MyView"))
+		subtype = SimpleSubtypeSymbol(SimpleName("RecordType"))
+		modeView = ModeViewDeclaration("MyView", subtype)
+
+		symbol.ModeView = modeView
+
+		self.assertTrue(symbol.IsResolved)
+		self.assertIs(modeView, symbol.ModeView)
+		self.assertIs(modeView, symbol.Reference)
+
+
+class ModeViewDeclarations(TestCase):
+	def test_SimpleElements(self) -> None:
+		subtype = SimpleSubtypeSymbol(SimpleName("RecordType"))
+		elements = [
+			SimpleModeViewElement(["a"], Mode.Out),
+			SimpleModeViewElement(["b"], Mode.In),
+		]
+		modeView = ModeViewDeclaration("MyView", subtype, elements)
+
+		self.assertEqual("MyView", modeView.Identifier)
+		self.assertIs(subtype, modeView.Subtype)
+		self.assertEqual(2, len(modeView.Elements))
+
+		a, b = modeView.Elements
+		self.assertIsInstance(a, SimpleModeViewElement)
+		self.assertEqual(("a",), a.Identifiers)
+		self.assertEqual(Mode.Out, a.Mode)
+		self.assertIsInstance(b, SimpleModeViewElement)
+		self.assertEqual(("b",), b.Identifiers)
+		self.assertEqual(Mode.In, b.Mode)
+
+	def test_MultipleIdentifiersSharingOneMode(self) -> None:
+		"""``a, b : out;`` - one element definition, multiple target field names."""
+		element = SimpleModeViewElement(["a", "b"], Mode.Out)
+
+		self.assertEqual(("a", "b"), element.Identifiers)
+		self.assertEqual(Mode.Out, element.Mode)
+
+	def test_CompositeElement(self) -> None:
+		"""``b : view InnerView;`` - a nested/hierarchical mode view reference."""
+		subtype = SimpleSubtypeSymbol(SimpleName("OuterRecord"))
+		innerViewSymbol = ModeViewSymbol(SimpleName("InnerView"))
+		elements = [
+			SimpleModeViewElement(["a"], Mode.Out),
+			CompositeModeViewElement(["b"], innerViewSymbol),
+		]
+		modeView = ModeViewDeclaration("OuterView", subtype, elements)
+
+		b = modeView.Elements[1]
+		self.assertIsInstance(b, CompositeModeViewElement)
+		self.assertEqual(("b",), b.Identifiers)
+		self.assertIs(innerViewSymbol, b.ModeViewName)
+
+
+class PortSignalInterfaceItems(TestCase):
+	def test_SimpleMode(self) -> None:
+		port = PortSimpleSignalInterfaceItem(["p"], Mode.In, SimpleSubtypeSymbol(SimpleName("bit")))
+
+		self.assertIsInstance(port, PortSignalInterfaceItem)
+		self.assertEqual(Mode.In, port.Mode)
+		self.assertIsNotNone(port.Subtype)
+
+	def test_ModeView(self) -> None:
+		modeViewIndication = ModeViewSymbol(SimpleName("MyView"))
+		port = PortViewSignalInterfaceItem(["p"], modeViewIndication)
+
+		self.assertIsInstance(port, PortSignalInterfaceItem)
+		self.assertIs(modeViewIndication, port.ModeViewIndication)
+		self.assertIsNone(port.Subtype)
+
+
+class ParameterSignalInterfaceItems(TestCase):
+	def test_SimpleMode(self) -> None:
+		parameter = ParameterSimpleSignalInterfaceItem(["s"], Mode.In, SimpleSubtypeSymbol(SimpleName("bit")))
+
+		self.assertIsInstance(parameter, ParameterSignalInterfaceItem)
+		self.assertEqual(Mode.In, parameter.Mode)
+
+	def test_ModeView(self) -> None:
+		modeViewIndication = ModeViewSymbol(SimpleName("MyView"))
+		parameter = ParameterViewSignalInterfaceItem(["s"], modeViewIndication)
+
+		self.assertIsInstance(parameter, ParameterSignalInterfaceItem)
+		self.assertIs(modeViewIndication, parameter.ModeViewIndication)


### PR DESCRIPTION
## Summary

VHDL-2019 mode views. Design was discussed and agreed on in chat first (including cross-checking the actual grammar rather than relying on memory), then implemented.

### New classes

- `ModeViewSymbol` (`Symbol.py`) - reference to a mode view declaration, mirroring `PackageReferenceSymbol` exactly. Uses `PossibleReference.View`, which - along with `.ViewAttribute` - was already present in the enum.
- `ModeViewDeclaration`, `ModeViewElement`, `SimpleModeViewElement`, `CompositeModeViewElement` (`Interface.py`):
  - `ModeViewElement` uses `MultipleNamedEntityMixin` - mode view elements support comma-separated identifiers sharing one mode (`a, b : out;`), same pattern as `Constant`/`Signal`/`Variable`.
  - `CompositeModeViewElement` merges what GHDL's IIR splits into `Array_Mode_View_Element`/`Record_Mode_View_Element` - verified both are structurally identical (just a reference to another named view); the distinction requires resolving the target field's type, which needs semantic analysis this project doesn't perform.
  - `ModeViewDeclaration.Subtype` is a plain `SubtypeSymbol`, so `of MyArrayType(0 to 7)` (constrained array-of-views) is already supported for free via the existing `ConstrainedArraySubtypeSymbol` - no new work needed there.

### Port/Parameter interface item split

Split `PortSignalInterfaceItem` and `ParameterSignalInterfaceItem` into abstract bases with two concrete forms each (`*SimpleSignalInterfaceItem` / `*ViewSignalInterfaceItem`), since mode views apply to signal-class ports and signal-class subprogram parameters, but not to generics.

Cross-checked against the actual VHDL grammar (not just memory/LRM prose) before finalizing this: `interface_object_declaration` is one production shared across generic/port/parameter lists - the generics-can't-be-signals restriction is semantic (LRM prose), not encoded in the grammar itself. This explains why GHDL's parser (grammar-level only, no full semantic pass) accepts view-typed generics/parameters syntactically without them being legal VHDL - confirmed empirically against real GHDL, then reconciled against the grammar and confirmed as correct by the model owner directly. `GenericSignalInterfaceItem` does not exist and is out of scope here.

### One small supporting change

`Obj.__init__` (`Object.py`) now tolerates `subtype=None` (`Nullable[Symbol]`, additive, not breaking). A view-typed port has no separate subtype indication of its own at the parse-only level this project operates at - verified against real GHDL: `Get_Subtype_Indication` on `Interface_View_Declaration` is `Null_Iir` before semantic analysis resolves the referenced view. The type is only implied by the mode view.

## Testing

Added `tests/unit/Interface.py`. Full suite: `82 passed` (was 73), no regressions.

## Companion change

pyGHDL.dom will need a matching PR to actually translate `Mode_View_Declaration`/`Interface_View_Declaration` using these classes, plus `Design`'s `--std=19` support (already merged) to reach this code path at all.
