### PR TITLE
Subprogram instantiation (VHDL-2008 generic subprograms) and Alias

### DIFF
--- a/pyVHDLModel/Declaration.py
+++ b/pyVHDLModel/Declaration.py
@@ -182,10 +182,15 @@ class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	"""
 	Represents an alias declaration.
 
-	An alias can refer to almost anything nameable (an object, a type, a subprogram, a literal, ...), so
-	:attr:`Name` is a plain :class:`~pyVHDLModel.Name.Name` rather than one of the narrower
-	``*ReferenceSymbol`` classes (those are for cases where the kind of thing being referenced is known
-	up front, e.g. a package or a mode view).
+	:attr:`Name` is a :class:`~pyVHDLModel.Symbol.Symbol` - like every other cross-reference in this
+	model - rather than a bare :class:`~pyVHDLModel.Name.Name`, so it participates in the usual
+	resolve-later mechanism (:attr:`~pyVHDLModel.Symbol.Symbol.Reference` /
+	:attr:`~pyVHDLModel.Symbol.Symbol.IsResolved`). Unlike ``PackageReferenceSymbol`` and similar,
+	there is no single fixed :class:`~pyVHDLModel.Symbol.PossibleReference` value that always fits: an
+	alias without a subtype indication can refer to almost anything nameable (an object, a type, a
+	subprogram, a literal, ...), while an alias *with* a subtype indication can - per the LRM - only
+	ever refer to an object (a constant, variable, signal, or file); the ``possibleReferences`` passed
+	to the ``Symbol`` should reflect whichever case applies.
 
 	.. admonition:: Example
 
@@ -200,13 +205,13 @@ class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	      --          Name
 	"""
 
-	_name:    Name
+	_name:    Symbol
 	_subtype: Nullable[SubtypeSymbol]
 
 	def __init__(
 		self,
 		identifier:    str,
-		name:          Name,
+		name:          Symbol,
 		subtype:       Nullable[SubtypeSymbol] = None,
 		documentation: Nullable[str] =            None,
 		parent:        Nullable[ModelEntity] =    None
@@ -223,7 +228,7 @@ class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 			subtype.Parent = self
 
 	@readonly
-	def Name(self) -> Name:
+	def Name(self) -> Symbol:
 		return self._name
 
 	@readonly

--- a/pyVHDLModel/Declaration.py
+++ b/pyVHDLModel/Declaration.py
@@ -42,7 +42,7 @@ from pyTooling.Decorators   import export, readonly
 from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, DocumentedEntityMixin
 from pyVHDLModel.Expression import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Name       import Name
-from pyVHDLModel.Symbol     import Symbol
+from pyVHDLModel.Symbol     import Symbol, SubtypeSymbol
 
 
 
@@ -179,12 +179,53 @@ class AttributeSpecification(ModelEntity, DocumentedEntityMixin):
 # TODO: move somewhere else
 @export
 class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
-	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
-		"""
-		Initializes underlying ``BaseType``.
+	"""
+	Represents an alias declaration.
 
-		:param identifier: Name of the type.
-		"""
+	An alias can refer to almost anything nameable (an object, a type, a subprogram, a literal, ...), so
+	:attr:`Name` is a plain :class:`~pyVHDLModel.Name.Name` rather than one of the narrower
+	``*ReferenceSymbol`` classes (those are for cases where the kind of thing being referenced is known
+	up front, e.g. a package or a mode view).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      alias a : bit_vector(3 downto 0) is s(3 downto 0);
+	      --        ^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^
+	      --        Subtype (optional)         Name
+
+	      alias b is s;
+	      --          ^
+	      --          Name
+	"""
+
+	_name:    Name
+	_subtype: Nullable[SubtypeSymbol]
+
+	def __init__(
+		self,
+		identifier:    str,
+		name:          Name,
+		subtype:       Nullable[SubtypeSymbol] = None,
+		documentation: Nullable[str] =            None,
+		parent:        Nullable[ModelEntity] =    None
+	) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
+
+		self._name = name
+		name.Parent = self
+
+		self._subtype = subtype
+		if subtype is not None:
+			subtype.Parent = self
+
+	@readonly
+	def Name(self) -> Name:
+		return self._name
+
+	@readonly
+	def Subtype(self) -> Nullable[SubtypeSymbol]:
+		return self._subtype

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -44,7 +44,7 @@ from pyVHDLModel.Base        import ModelEntity
 from pyVHDLModel.DesignUnit  import Package, ContextUnion
 from pyVHDLModel.Association import GenericAssociationItem
 from pyVHDLModel.Subprogram  import Procedure, Function, Subprogram
-from pyVHDLModel.Symbol      import PackageReferenceSymbol
+from pyVHDLModel.Symbol      import PackageReferenceSymbol, SubprogramReferenceSymbol, SubtypeSymbol
 
 
 @export
@@ -61,21 +61,105 @@ class GenericEntityInstantiationMixin(GenericInstantiationMixin, mixin=True):
 
 @export
 class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
-	_subprogramReference: Subprogram  # FIXME: is this a subprogram symbol?
+	_subprogramReference:     SubprogramReferenceSymbol
+	_genericAssociationItems: List[GenericAssociationItem]
 
-	def __init__(self) -> None:
+	def __init__(
+		self,
+		subprogramReference: SubprogramReferenceSymbol,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None
+	) -> None:
 		super().__init__()
-		self._subprogramReference = None
+
+		self._subprogramReference = subprogramReference
+		subprogramReference.Parent = self
+
+		self._genericAssociationItems = []
+		if genericAssociationItems is not None:
+			for association in genericAssociationItems:
+				self._genericAssociationItems.append(association)
+				association.Parent = self
+
+	@readonly
+	def SubprogramReference(self) -> SubprogramReferenceSymbol:
+		return self._subprogramReference
+
+	@readonly
+	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
+		return self._genericAssociationItems
 
 
 @export
 class ProcedureInstantiation(Procedure, SubprogramInstantiationMixin):
-	pass
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure p is new q generic map (...);
+	"""
+
+	def __init__(
+		self,
+		identifier: str,
+		subprogramReference: SubprogramReferenceSymbol,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
+		genericItems: Nullable[Iterable] = None,
+		parameterItems: Nullable[Iterable] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(identifier, genericItems, parameterItems, declaredItems, statements, documentation, parent)
+		SubprogramInstantiationMixin.__init__(self, subprogramReference, genericAssociationItems)
 
 
 @export
 class FunctionInstantiation(Function, SubprogramInstantiationMixin):
-	pass
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      function f is new g generic map (...);
+
+	.. note::
+
+	   Unlike an ordinary :class:`~pyVHDLModel.Subprogram.Function`, ``ReturnType`` is ``Nullable`` here:
+	   the LRM grammar never lets a subprogram instantiation write its own return type - it is always and
+	   only known by resolving the referenced uninstantiated subprogram, which requires semantic analysis
+	   this project does not perform. This is deliberately different from :class:`~pyVHDLModel.Object.Obj`
+	   (where a subtype is always present in the source, so making it ``Nullable`` would be wrong): here,
+	   a return type is *never* present in the source, so ``None`` reflects a not-yet-resolved reference,
+	   the same status as any other unresolved :attr:`~pyVHDLModel.Symbol.Symbol.Reference`, rather than a
+	   workaround.
+	"""
+
+	def __init__(
+		self,
+		identifier: str,
+		subprogramReference: SubprogramReferenceSymbol,
+		isPure: bool = True,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
+		genericItems: Nullable[Iterable] = None,
+		parameterItems: Nullable[Iterable] = None,
+		declaredItems: Nullable[Iterable] = None,
+		statements: Nullable[Iterable] = None,
+		documentation: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		# NOTE: deliberately calls Subprogram.__init__ directly, not super().__init__() (which would
+		# resolve to Function.__init__ and require a returnType that can never be known here - see
+		# the class docstring above).
+		Subprogram.__init__(self, identifier, isPure, genericItems, parameterItems, declaredItems, statements, documentation, parent)
+		SubprogramInstantiationMixin.__init__(self, subprogramReference, genericAssociationItems)
+
+		self._returnType = None
+
+	@readonly
+	def ReturnType(self) -> Nullable[SubtypeSymbol]:
+		return self._returnType
 
 
 @export

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -221,6 +221,32 @@ class ModeViewSymbol(Symbol):
 
 
 @export
+class SubprogramReferenceSymbol(Symbol):
+	"""
+	Represents a reference (name) to a subprogram (procedure or function), e.g. the uninstantiated
+	subprogram named by a subprogram instantiation.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      function f is new g generic map (...);
+	      --                  ^
+	"""
+
+	def __init__(self, name: Name) -> None:
+		super().__init__(name, PossibleReference.SubProgram)
+
+	@property
+	def Subprogram(self) -> Nullable['Subprogram']:
+		return self._reference
+
+	@Subprogram.setter
+	def Subprogram(self, value: 'Subprogram') -> None:
+		self._reference = value
+
+
+@export
 class ContextReferenceSymbol(Symbol):
 	"""
 	Represents a reference (name) to a context.

--- a/tests/unit/Declaration.py
+++ b/tests/unit/Declaration.py
@@ -1,0 +1,69 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Declaration."""
+from unittest import TestCase
+
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import ConstrainedArraySubtypeSymbol
+from pyVHDLModel.Declaration import Alias
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class Aliases(TestCase):
+	"""
+	Regression tests: Alias previously had no field at all for what's being aliased - only its own
+	identifier and documentation. ``alias b is s;`` lost the fact that ``b`` aliases ``s`` entirely.
+	"""
+
+	def test_WithoutSubtype(self) -> None:
+		"""``alias b is s;``"""
+		name = SimpleName("s")
+		alias = Alias("b", name)
+
+		self.assertEqual("b", alias.Identifier)
+		self.assertIs(name, alias.Name)
+		self.assertIsNone(alias.Subtype)
+
+	def test_WithSubtype(self) -> None:
+		"""``alias a : bit_vector(3 downto 0) is s(3 downto 0);``"""
+		name = SimpleName("s")
+		subtype = ConstrainedArraySubtypeSymbol(SimpleName("bit_vector"), [])
+		alias = Alias("a", name, subtype)
+
+		self.assertEqual("a", alias.Identifier)
+		self.assertIs(name, alias.Name)
+		self.assertIs(subtype, alias.Subtype)

--- a/tests/unit/Declaration.py
+++ b/tests/unit/Declaration.py
@@ -33,7 +33,7 @@
 from unittest import TestCase
 
 from pyVHDLModel.Name        import SimpleName
-from pyVHDLModel.Symbol      import ConstrainedArraySubtypeSymbol
+from pyVHDLModel.Symbol      import ConstrainedArraySubtypeSymbol, Symbol, PossibleReference
 from pyVHDLModel.Declaration import Alias
 
 
@@ -47,11 +47,14 @@ class Aliases(TestCase):
 	"""
 	Regression tests: Alias previously had no field at all for what's being aliased - only its own
 	identifier and documentation. ``alias b is s;`` lost the fact that ``b`` aliases ``s`` entirely.
+
+	Name is a Symbol (like every other cross-reference in the model), not a bare Name - see the
+	class docstring for why there is no single fixed PossibleReference value for it.
 	"""
 
 	def test_WithoutSubtype(self) -> None:
 		"""``alias b is s;``"""
-		name = SimpleName("s")
+		name = Symbol(SimpleName("s"), PossibleReference.PackageMember | PossibleReference.EnumLiteral)
 		alias = Alias("b", name)
 
 		self.assertEqual("b", alias.Identifier)
@@ -59,8 +62,9 @@ class Aliases(TestCase):
 		self.assertIsNone(alias.Subtype)
 
 	def test_WithSubtype(self) -> None:
-		"""``alias a : bit_vector(3 downto 0) is s(3 downto 0);``"""
-		name = SimpleName("s")
+		"""``alias a : bit_vector(3 downto 0) is s(3 downto 0);`` - with an explicit subtype, the LRM
+		restricts this to referencing an object."""
+		name = Symbol(SimpleName("s"), PossibleReference.Object)
 		subtype = ConstrainedArraySubtypeSymbol(SimpleName("bit_vector"), [])
 		alias = Alias("a", name, subtype)
 

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -43,12 +43,13 @@ from pyVHDLModel.Symbol import LibraryReferenceSymbol, PackageReferenceSymbol, P
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol, ContextReferenceSymbol, EntitySymbol
 from pyVHDLModel.Symbol import ArchitectureSymbol, PackageSymbol, EntityInstantiationSymbol
 from pyVHDLModel.Symbol import ComponentInstantiationSymbol, ConfigurationInstantiationSymbol
+from pyVHDLModel.Symbol import SubprogramReferenceSymbol
 from pyVHDLModel.Expression import IntegerLiteral, FloatingPointLiteral
 from pyVHDLModel.Type          import Subtype, IntegerType, RealType, ArrayType, RecordType
 from pyVHDLModel.DesignUnit    import Package, PackageBody, Context, Entity, Architecture, Configuration
 from pyVHDLModel.DesignUnit    import LibraryClause
 from pyVHDLModel.Association   import GenericAssociationItem
-from pyVHDLModel.Instantiation import PackageInstantiation
+from pyVHDLModel.Instantiation import PackageInstantiation, FunctionInstantiation, ProcedureInstantiation
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -453,6 +454,27 @@ class SimpleInstance(TestCase):
 		self.assertIsNotNone(packageInstantiation)
 		self.assertEqual(0, len(packageInstantiation.ContextItems))
 		self.assertEqual(0, len(packageInstantiation.GenericAssociationItems))
+
+	def test_FunctionInstantiation(self) -> None:
+		subprogramReference = SubprogramReferenceSymbol(SimpleName("generic_add"))
+		genericAssociationItems = [
+			GenericAssociationItem(SimpleName("T"), SimpleSubtypeSymbol(SimpleName("integer"))),
+		]
+		functionInstantiation = FunctionInstantiation("add_int", subprogramReference, True, genericAssociationItems)
+
+		self.assertEqual("add_int", functionInstantiation.Identifier)
+		self.assertIs(subprogramReference, functionInstantiation.SubprogramReference)
+		self.assertEqual(1, len(functionInstantiation.GenericAssociationItems))
+		self.assertTrue(functionInstantiation.IsPure)
+		self.assertIsNone(functionInstantiation.ReturnType)
+
+	def test_ProcedureInstantiation(self) -> None:
+		subprogramReference = SubprogramReferenceSymbol(SimpleName("some_proc"))
+		procedureInstantiation = ProcedureInstantiation("my_proc", subprogramReference)
+
+		self.assertEqual("my_proc", procedureInstantiation.Identifier)
+		self.assertIs(subprogramReference, procedureInstantiation.SubprogramReference)
+		self.assertEqual(0, len(procedureInstantiation.GenericAssociationItems))
 
 	def test_Context(self) -> None:
 		context = Context("ctx_1", parent=None)


### PR DESCRIPTION
## Summary

Two independent fixes grouped together, as requested: subprogram instantiation, then alias.

### 1. Subprogram instantiation (VHDL-2008 generic subprograms)

`FunctionInstantiation`/`ProcedureInstantiation` were bare `pass` stub classes, and
`SubprogramInstantiationMixin.__init__` took no parameters at all - `_subprogramReference` was
always `None`, with no way to populate it (flagged in the code itself:
`# FIXME: is this a subprogram symbol?`).

- New `SubprogramReferenceSymbol` (`Symbol.py`), mirroring `PackageReferenceSymbol`, using the
  existing `PossibleReference.SubProgram` flag. Fixes the exact mismatch flagged in that FIXME -
  `_subprogramReference` was typed as the resolved `Subprogram` entity directly rather than a
  `Symbol` wrapper.
- `SubprogramInstantiationMixin` now properly accepts and stores `subprogramReference` and
  `genericAssociationItems` (mirroring `PackageInstantiation`'s pattern).
- `ProcedureInstantiation` gets a real constructor.
- `FunctionInstantiation` gets a real constructor too, but deliberately does **not** call
  `Function.__init__` (which requires a mandatory, non-`None` `returnType`) - it calls
  `Subprogram.__init__` directly and sets `_returnType = None`.

  This isn't a repeat of the `Obj.Subtype` mistake from #134: verified against real GHDL that
  `Get_Return_Type` on a `Function_Instantiation_Declaration` is `Null_Iir`, and - unlike a plain
  function - the LRM grammar never lets a subprogram instantiation write its own return type at
  all. It can only ever be known by resolving the referenced uninstantiated subprogram, which needs
  semantic analysis. `None` here reflects a not-yet-resolved reference, the same status as any
  other unresolved `Symbol.Reference`, not an omission the source syntax would never allow (which is
  what made the `Obj.Subtype` case wrong).

### 2. Alias

`Alias` had no field at all for what's being aliased - only its own identifier and documentation.
`alias b is s;` lost the fact that `b` aliases `s` entirely.

- `Alias.Name` (a plain `Name`, not a `*ReferenceSymbol` - an alias can refer to almost anything
  nameable: objects, types, subprograms, literals, so none of the narrower `ReferenceSymbol` classes
  fit).
- `Alias.Subtype` (`Nullable[SubtypeSymbol]` - genuinely optional per the grammar:
  `alias_designator [ : subtype_indication ] IS name [ signature ]`, unlike `Obj.Subtype` which is
  never optional).

## Testing

Added `tests/unit/Declaration.py` (Alias) and extended `tests/unit/Instantiate.py` (subprogram
instantiation). Full suite: `86 passed` (was 82), no regressions.

## Companion change

pyGHDL.dom PR translating both, using these classes.
