### PR TITLE
Fix ConstrainedScalarSubtypeSymbol: range constraint had nowhere to go

### DIFF
--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -507,12 +507,12 @@ class SimpleSubtypeSymbol(SubtypeSymbol):
 
 
 @export
-class Constraint:
+class Constraint(metaclass=ExtendedType, mixin=True):
 	pass
 
 
 @export
-class ScalarConstraint(Constraint):
+class ScalarConstraint(Constraint, mixin=True):
 	_constraint: Nullable[Range]
 
 	def __init__(self, constraint: Nullable[Range]) -> None:
@@ -548,7 +548,7 @@ class ConstrainedScalarSubtypeSymbol(SubtypeSymbol, ScalarConstraint):
 
 
 @export
-class ArrayConstraint(Constraint):
+class ArrayConstraint(Constraint, mixin=True):
 	_constraints: List[Range]
 
 	def __init__(self, constraints: Iterable[Range]) -> None:
@@ -560,7 +560,7 @@ class ArrayConstraint(Constraint):
 
 
 @export
-class RecordConstraint(Constraint):
+class RecordConstraint(Constraint, mixin=True):
 	_constraints: Dict[RecordElementSymbol, Range]
 
 	def __init__(self, constraints: Mapping[RecordElementSymbol, Range]) -> None:

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -507,13 +507,44 @@ class SimpleSubtypeSymbol(SubtypeSymbol):
 
 
 @export
-class ConstrainedScalarSubtypeSymbol(SubtypeSymbol):
+class Constraint:
 	pass
 
 
 @export
-class Constraint:
-	pass
+class ScalarConstraint(Constraint):
+	_constraint: Nullable[Range]
+
+	def __init__(self, constraint: Nullable[Range]) -> None:
+		self._constraint = constraint
+
+	@readonly
+	def Constraint(self) -> Nullable[Range]:
+		"""
+		The scalar type's range constraint.
+
+		``None`` only when the range constraint is written as an attribute name (e.g.
+		``subtype s is t'range;``) rather than a literal range - reading a range out of an attribute
+		name is not yet implemented, not because the source omits a constraint (it never does for a
+		constrained scalar subtype).
+		"""
+		return self._constraint
+
+
+@export
+class ConstrainedScalarSubtypeSymbol(SubtypeSymbol, ScalarConstraint):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      signal s : integer range 0 to 15;
+	      --         ^^^^^^^^^^^^^^^^^^^^^^
+	"""
+
+	def __init__(self, name: Name, constraint: Nullable[Range] = None) -> None:
+		super().__init__(name)
+		ScalarConstraint.__init__(self, constraint)
 
 
 @export

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -43,7 +43,7 @@ from pyVHDLModel.Symbol import LibraryReferenceSymbol, PackageReferenceSymbol, P
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol, ContextReferenceSymbol, EntitySymbol
 from pyVHDLModel.Symbol import ArchitectureSymbol, PackageSymbol, EntityInstantiationSymbol
 from pyVHDLModel.Symbol import ComponentInstantiationSymbol, ConfigurationInstantiationSymbol
-from pyVHDLModel.Symbol import SubprogramReferenceSymbol
+from pyVHDLModel.Symbol import SubprogramReferenceSymbol, ConstrainedScalarSubtypeSymbol
 from pyVHDLModel.Expression import IntegerLiteral, FloatingPointLiteral
 from pyVHDLModel.Type          import Subtype, IntegerType, RealType, ArrayType, RecordType
 from pyVHDLModel.DesignUnit    import Package, PackageBody, Context, Entity, Architecture, Configuration
@@ -351,6 +351,19 @@ class Symbols(TestCase):
 		symbol = ConfigurationInstantiationSymbol(SimpleName("cfg"))
 
 		self.assertEqual("cfg", symbol.Name.NormalizedIdentifier)
+
+	def test_ConstrainedScalarSubtypeSymbol(self) -> None:
+		"""``signal s : integer range 0 to 15;`` - previously the range constraint was read by
+		pyGHDL.dom but had nowhere to go, since this class was a bare stub."""
+		rng = Range(IntegerLiteral(0), IntegerLiteral(15), Direction.To)
+		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"), rng)
+
+		self.assertIs(rng, symbol.Constraint)
+
+	def test_ConstrainedScalarSubtypeSymbol_withoutConstraint(self) -> None:
+		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"))
+
+		self.assertIsNone(symbol.Constraint)
 
 
 class SimpleInstance(TestCase):


### PR DESCRIPTION
## Summary

`signal s : integer range 0 to 15;` parses fine, but `ConstrainedScalarSubtypeSymbol` was a bare
stub (`class ConstrainedScalarSubtypeSymbol(SubtypeSymbol): pass`) - no fields, no constructor
parameter for a range at all. pyGHDL.dom's `ConstrainedScalarSubtypeSymbol.__init__` took an
`rng: Range` parameter but never forwarded it
(`super().__init__(subtypeName)  # , rng)  # XXX: hacked`), and its `.parse()` classmethod was a
bare `pass`.

## Changes

Added `ScalarConstraint` (mirroring `ArrayConstraint`/`RecordConstraint`'s established pattern for
consistency, even though - like those two - it's not reused elsewhere) and gave
`ConstrainedScalarSubtypeSymbol` a real constructor, storing the range via
`ScalarConstraint.Constraint`.

`Constraint` is `Nullable` - not because the source syntax ever omits a range constraint for a
constrained scalar subtype (it never does), but because pyGHDL.dom doesn't yet extract a range from
an `AttributeName`-based constraint (e.g. `subtype s is t'range;`) - a pre-existing, separately-
tracked TODO in that function, not something addressed here.

## Testing

Added tests to `tests/unit/Instantiate.py`. Full suite: `88 passed` (was 86), no regressions.

## Companion change

pyGHDL.dom PR forwarding the range constraint properly using this fix.
