### PR TITLE
Add configuration/binding model

### DIFF
--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -1,0 +1,321 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+This module contains parts of an abstract document language model for VHDL.
+
+Configurations: entity aspects, binding indications, component configurations (and the structurally
+identical configuration specifications), and block configurations.
+"""
+from typing import List, Iterable, Union, Optional as Nullable
+
+from pyTooling.Decorators    import export, readonly
+from pyTooling.MetaClasses   import ExtendedType
+
+from pyVHDLModel.Base        import ModelEntity
+from pyVHDLModel.Name        import Name
+from pyVHDLModel.Symbol      import Symbol, EntitySymbol, ArchitectureSymbol, ConfigurationSymbol
+from pyVHDLModel.Symbol      import ComponentInstantiationSymbol
+from pyVHDLModel.Association import GenericAssociationItem, PortAssociationItem
+
+
+@export
+class EntityAspect(ModelEntity):
+	"""
+	Base-class for the three forms an entity aspect can take in a binding indication: an entity
+	(optionally with an architecture), a configuration, or ``open``.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use entity work.sub(behav);
+	      --                ^^^^^^^^^^^^^^^^^^^^^^
+	"""
+
+
+@export
+class EntityAspectEntity(EntityAspect):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use entity work.sub(behav);
+	      --                       ^^^^^^^^  ^^^^^
+	      --                       Entity    Architecture (optional)
+	"""
+
+	_entity:       EntitySymbol
+	_architecture: Nullable[ArchitectureSymbol]
+
+	def __init__(
+		self,
+		entity: EntitySymbol,
+		architecture: Nullable[ArchitectureSymbol] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._entity = entity
+		entity.Parent = self
+
+		self._architecture = architecture
+		if architecture is not None:
+			architecture.Parent = self
+
+	@readonly
+	def Entity(self) -> EntitySymbol:
+		return self._entity
+
+	@readonly
+	def Architecture(self) -> Nullable[ArchitectureSymbol]:
+		return self._architecture
+
+
+@export
+class EntityAspectConfiguration(EntityAspect):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use configuration work.cfg;
+	      --                              ^^^^^^^
+	"""
+
+	_configuration: ConfigurationSymbol
+
+	def __init__(self, configuration: ConfigurationSymbol, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(parent)
+
+		self._configuration = configuration
+		configuration.Parent = self
+
+	@readonly
+	def Configuration(self) -> ConfigurationSymbol:
+		return self._configuration
+
+
+@export
+class EntityAspectOpen(EntityAspect):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use open;
+	"""
+
+
+@export
+class BindingIndication(ModelEntity):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use entity work.sub(behav) generic map (...) port map (...);
+	      --                ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^
+	"""
+
+	_entityAspect:            Nullable[EntityAspect]
+	_genericAssociationItems: List[GenericAssociationItem]
+	_portAssociationItems:    List[PortAssociationItem]
+
+	def __init__(
+		self,
+		entityAspect: Nullable[EntityAspect] = None,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
+		portAssociationItems: Nullable[Iterable[PortAssociationItem]] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._entityAspect = entityAspect
+		if entityAspect is not None:
+			entityAspect.Parent = self
+
+		self._genericAssociationItems = []
+		if genericAssociationItems is not None:
+			for association in genericAssociationItems:
+				self._genericAssociationItems.append(association)
+				association.Parent = self
+
+		self._portAssociationItems = []
+		if portAssociationItems is not None:
+			for association in portAssociationItems:
+				self._portAssociationItems.append(association)
+				association.Parent = self
+
+	@readonly
+	def EntityAspect(self) -> Nullable[EntityAspect]:
+		return self._entityAspect
+
+	@readonly
+	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
+		return self._genericAssociationItems
+
+	@readonly
+	def PortAssociationItems(self) -> List[PortAssociationItem]:
+		return self._portAssociationItems
+
+
+@export
+class AllInstantiationList(ModelEntity):
+	"""
+	Represents the reserved word ``all`` used as an instantiation list.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for all : comp use entity work.sub(behav);
+	      --    ^^^
+	"""
+
+
+@export
+class OthersInstantiationList(ModelEntity):
+	"""
+	Represents the reserved word ``others`` used as an instantiation list.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for others : comp use entity work.sub(behav);
+	      --    ^^^^^^
+	"""
+
+
+InstantiationListUnion = Union[List[Name], AllInstantiationList, OthersInstantiationList]
+
+
+@export
+class ComponentConfiguration(ModelEntity):
+	"""
+	Represents a component configuration (inside a block configuration), or - structurally identical
+	- a configuration specification (declared directly in an architecture's declarative part).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use entity work.sub(behav);
+	      --  ^^   ^^^^
+	      --  |    Component name
+	      --  Instantiation list
+	"""
+
+	_instantiationList:  InstantiationListUnion
+	_componentName:      ComponentInstantiationSymbol
+	_bindingIndication:   Nullable[BindingIndication]
+
+	def __init__(
+		self,
+		instantiationList: InstantiationListUnion,
+		componentName: ComponentInstantiationSymbol,
+		bindingIndication: Nullable[BindingIndication] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		if isinstance(instantiationList, (AllInstantiationList, OthersInstantiationList)):
+			self._instantiationList = instantiationList
+			instantiationList.Parent = self
+		else:
+			self._instantiationList = [label for label in instantiationList]
+			for label in self._instantiationList:
+				label.Parent = self
+
+		self._componentName = componentName
+		componentName.Parent = self
+
+		self._bindingIndication = bindingIndication
+		if bindingIndication is not None:
+			bindingIndication.Parent = self
+
+	@readonly
+	def InstantiationList(self) -> InstantiationListUnion:
+		return self._instantiationList
+
+	@readonly
+	def ComponentName(self) -> ComponentInstantiationSymbol:
+		return self._componentName
+
+	@readonly
+	def BindingIndication(self) -> Nullable[BindingIndication]:
+		return self._bindingIndication
+
+
+@export
+class BlockConfiguration(ModelEntity):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for rtl
+	      --  ^^^ Block specification
+	        for U1 : comp
+	        -- ...
+	        end for;
+	      end for;
+	"""
+
+	_blockSpecification: Symbol
+	_items:               List[Union["BlockConfiguration", ComponentConfiguration]]
+
+	def __init__(
+		self,
+		blockSpecification: Symbol,
+		items: Nullable[Iterable[Union["BlockConfiguration", ComponentConfiguration]]] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._blockSpecification = blockSpecification
+		blockSpecification.Parent = self
+
+		self._items = []
+		if items is not None:
+			for item in items:
+				self._items.append(item)
+				item.Parent = self
+
+	@readonly
+	def BlockSpecification(self) -> Symbol:
+		return self._blockSpecification
+
+	@readonly
+	def Items(self) -> List[Union["BlockConfiguration", ComponentConfiguration]]:
+		return self._items

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -49,6 +49,7 @@ from pyVHDLModel.Symbol     import Symbol, PackageSymbol, EntitySymbol, LibraryR
 from pyVHDLModel.Interface  import GenericInterfaceItemMixin, PortInterfaceItemMixin, WithGenericsMixin, WithPortsMixin
 from pyVHDLModel.Object     import DeferredConstant
 from pyVHDLModel.Concurrent import ConcurrentStatement, ConcurrentStatementsMixin
+from pyVHDLModel.Configuration import BlockConfiguration
 
 
 @export
@@ -769,15 +770,34 @@ class Configuration(PrimaryUnit, DesignUnitWithContextMixin):
 	      end configuration;
 	"""
 
+	_entity:            EntitySymbol
+	_blockConfiguration: BlockConfiguration
+
 	def __init__(
 		self,
 		identifier: str,
+		entity: EntitySymbol,
+		blockConfiguration: BlockConfiguration,
 		contextItems: Nullable[Iterable[Context]] = None,
 		documentation: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(identifier, contextItems, documentation, parent)
 		DesignUnitWithContextMixin.__init__(self)
+
+		self._entity = entity
+		entity.Parent = self
+
+		self._blockConfiguration = blockConfiguration
+		blockConfiguration.Parent = self
+
+	@readonly
+	def Entity(self) -> EntitySymbol:
+		return self._entity
+
+	@readonly
+	def BlockConfiguration(self) -> BlockConfiguration:
+		return self._blockConfiguration
 
 	def __str__(self) -> str:
 		lib = self._parent._identifier if self._parent is not None else "%"

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -247,6 +247,32 @@ class SubprogramReferenceSymbol(Symbol):
 
 
 @export
+class ConfigurationSymbol(Symbol):
+	"""
+	Represents a reference (name) to a configuration declaration, e.g. in an entity aspect of a
+	binding indication.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for U1 : comp use configuration work.cfg;
+	      --                              ^^^^^^^
+	"""
+
+	def __init__(self, name: Name) -> None:
+		super().__init__(name, PossibleReference.Configuration)
+
+	@property
+	def Configuration(self) -> Nullable['Configuration']:
+		return self._reference
+
+	@Configuration.setter
+	def Configuration(self, value: 'Configuration') -> None:
+		self._reference = value
+
+
+@export
 class ContextReferenceSymbol(Symbol):
 	"""
 	Represents a reference (name) to a context.

--- a/tests/unit/Analyze.py
+++ b/tests/unit/Analyze.py
@@ -37,9 +37,10 @@ from pyVHDLModel import Design, Document, VHDLModelException
 from pyVHDLModel.Name import SimpleName, SelectedName, AllName
 from pyVHDLModel.Symbol import LibraryReferenceSymbol, PackageReferenceSymbol, AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol, EntitySymbol, PackageSymbol, EntityInstantiationSymbol
-from pyVHDLModel.Symbol import SimpleSubtypeSymbol
+from pyVHDLModel.Symbol import SimpleSubtypeSymbol, Symbol, PossibleReference
 from pyVHDLModel.DesignUnit import Package, PackageBody, Context, Entity, Architecture, Configuration
 from pyVHDLModel.DesignUnit import LibraryClause, UseClause, ContextReference
+from pyVHDLModel.Configuration import BlockConfiguration
 from pyVHDLModel.Concurrent import EntityInstantiation
 from pyVHDLModel.Object import Variable
 from pyVHDLModel.Exception import NotImplementedWarning
@@ -125,7 +126,12 @@ class VHDLLibrary(TestCase):
 		packageBody = PackageBody(PackageSymbol(SimpleName("pack_1")), parent=None)
 		document._AddDesignUnit(packageBody)
 
-		configuration = Configuration("cfg_1", parent=None)
+		configuration = Configuration(
+			"cfg_1",
+			EntitySymbol(SimpleName("entity_A")),
+			BlockConfiguration(Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)),
+			parent=None
+		)
 		document._AddDesignUnit(configuration)
 
 		design.AddDocument(document, library)

--- a/tests/unit/Configuration.py
+++ b/tests/unit/Configuration.py
@@ -1,0 +1,172 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Configuration."""
+from unittest import TestCase
+
+from pyVHDLModel.Name          import SimpleName, SelectedName
+from pyVHDLModel.Symbol        import EntitySymbol, ArchitectureSymbol, ConfigurationSymbol
+from pyVHDLModel.Symbol        import ComponentInstantiationSymbol, Symbol, PossibleReference
+from pyVHDLModel.Association   import GenericAssociationItem, PortAssociationItem
+from pyVHDLModel.Expression    import IntegerLiteral
+from pyVHDLModel.Configuration import (
+	EntityAspect, EntityAspectEntity, EntityAspectConfiguration, EntityAspectOpen,
+	BindingIndication, AllInstantiationList, OthersInstantiationList, ComponentConfiguration,
+	BlockConfiguration,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class EntityAspects(TestCase):
+	def test_Entity(self) -> None:
+		"""``use entity work.sub(behav);``"""
+		entity = EntitySymbol(SelectedName("sub", SimpleName("work")))
+		architecture = ArchitectureSymbol(SimpleName("behav"))
+		aspect = EntityAspectEntity(entity, architecture)
+
+		self.assertIsInstance(aspect, EntityAspect)
+		self.assertIs(entity, aspect.Entity)
+		self.assertIs(architecture, aspect.Architecture)
+
+	def test_EntityWithoutArchitecture(self) -> None:
+		"""``use entity work.sub;``"""
+		entity = EntitySymbol(SelectedName("sub", SimpleName("work")))
+		aspect = EntityAspectEntity(entity)
+
+		self.assertIs(entity, aspect.Entity)
+		self.assertIsNone(aspect.Architecture)
+
+	def test_Configuration(self) -> None:
+		"""``use configuration work.cfg;``"""
+		configuration = ConfigurationSymbol(SelectedName("cfg", SimpleName("work")))
+		aspect = EntityAspectConfiguration(configuration)
+
+		self.assertIsInstance(aspect, EntityAspect)
+		self.assertIs(configuration, aspect.Configuration)
+
+	def test_Open(self) -> None:
+		"""``use open;``"""
+		aspect = EntityAspectOpen()
+
+		self.assertIsInstance(aspect, EntityAspect)
+
+
+class BindingIndications(TestCase):
+	def test_Full(self) -> None:
+		"""``use entity work.sub(behav) generic map (G => 1) port map (p => s);``"""
+		entity = EntitySymbol(SelectedName("sub", SimpleName("work")))
+		aspect = EntityAspectEntity(entity, ArchitectureSymbol(SimpleName("behav")))
+		generics = [GenericAssociationItem(SimpleName("G"), IntegerLiteral(1))]
+		ports = [PortAssociationItem(SimpleName("p"), SimpleName("s"))]
+
+		binding = BindingIndication(aspect, generics, ports)
+
+		self.assertIs(aspect, binding.EntityAspect)
+		self.assertEqual(1, len(binding.GenericAssociationItems))
+		self.assertEqual(1, len(binding.PortAssociationItems))
+
+	def test_Empty(self) -> None:
+		binding = BindingIndication()
+
+		self.assertIsNone(binding.EntityAspect)
+		self.assertEqual(0, len(binding.GenericAssociationItems))
+		self.assertEqual(0, len(binding.PortAssociationItems))
+
+
+class ComponentConfigurations(TestCase):
+	"""Also covers configuration specifications, which are structurally identical."""
+
+	def test_LabeledInstantiationList(self) -> None:
+		"""``for U1 : comp use entity work.sub(behav);``"""
+		componentName = ComponentInstantiationSymbol(SimpleName("comp"))
+		binding = BindingIndication(EntityAspectEntity(EntitySymbol(SimpleName("sub"))))
+
+		config = ComponentConfiguration([SimpleName("U1")], componentName, binding)
+
+		self.assertEqual(1, len(config.InstantiationList))
+		self.assertIs(componentName, config.ComponentName)
+		self.assertIs(binding, config.BindingIndication)
+
+	def test_All(self) -> None:
+		"""``for all : comp use entity work.sub(behav);``"""
+		allMarker = AllInstantiationList()
+		config = ComponentConfiguration(allMarker, ComponentInstantiationSymbol(SimpleName("comp")))
+
+		self.assertIs(allMarker, config.InstantiationList)
+
+	def test_Others(self) -> None:
+		"""``for others : comp use entity work.sub(behav);``"""
+		othersMarker = OthersInstantiationList()
+		config = ComponentConfiguration(othersMarker, ComponentInstantiationSymbol(SimpleName("comp")))
+
+		self.assertIs(othersMarker, config.InstantiationList)
+
+	def test_WithoutBindingIndication(self) -> None:
+		config = ComponentConfiguration([SimpleName("U1")], ComponentInstantiationSymbol(SimpleName("comp")))
+
+		self.assertIsNone(config.BindingIndication)
+
+
+class BlockConfigurations(TestCase):
+	def test_Empty(self) -> None:
+		"""``for rtl end for;``"""
+		blockSpec = Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)
+		block = BlockConfiguration(blockSpec)
+
+		self.assertIs(blockSpec, block.BlockSpecification)
+		self.assertEqual(0, len(block.Items))
+
+	def test_WithComponentConfiguration(self) -> None:
+		"""``for rtl for U1 : comp use entity work.sub(behav); end for; end for;``"""
+		blockSpec = Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)
+		componentConfig = ComponentConfiguration(
+			[SimpleName("U1")], ComponentInstantiationSymbol(SimpleName("comp"))
+		)
+		block = BlockConfiguration(blockSpec, [componentConfig])
+
+		self.assertEqual(1, len(block.Items))
+		self.assertIs(componentConfig, block.Items[0])
+
+	def test_NestedBlockConfiguration(self) -> None:
+		"""A block configuration may itself contain nested block configurations (e.g. for a generate
+		statement's alternative)."""
+		outerSpec = Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)
+		innerSpec = Symbol(SimpleName("gen_label"), PossibleReference.Architecture | PossibleReference.Label)
+		innerBlock = BlockConfiguration(innerSpec)
+		outerBlock = BlockConfiguration(outerSpec, [innerBlock])
+
+		self.assertEqual(1, len(outerBlock.Items))
+		self.assertIs(innerBlock, outerBlock.Items[0])

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -44,6 +44,8 @@ from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol, ContextReferenc
 from pyVHDLModel.Symbol import ArchitectureSymbol, PackageSymbol, EntityInstantiationSymbol
 from pyVHDLModel.Symbol import ComponentInstantiationSymbol, ConfigurationInstantiationSymbol
 from pyVHDLModel.Symbol import SubprogramReferenceSymbol, ConstrainedScalarSubtypeSymbol
+from pyVHDLModel.Symbol import Symbol, PossibleReference
+from pyVHDLModel.Configuration import BlockConfiguration
 from pyVHDLModel.Expression import IntegerLiteral, FloatingPointLiteral
 from pyVHDLModel.Type          import Subtype, IntegerType, RealType, ArrayType, RecordType
 from pyVHDLModel.DesignUnit    import Package, PackageBody, Context, Entity, Architecture, Configuration
@@ -496,7 +498,12 @@ class SimpleInstance(TestCase):
 		self.assertEqual("ctx_1", context.Identifier)
 
 	def test_Configuration(self) -> None:
-		configuration = Configuration("conf_1", parent=None)
+		configuration = Configuration(
+			"conf_1",
+			EntitySymbol(SimpleName("entity_1")),
+			BlockConfiguration(Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)),
+			parent=None
+		)
 
 		self.assertIsNotNone(configuration)
 		self.assertEqual("conf_1", configuration.Identifier)
@@ -595,7 +602,12 @@ class VHDLDocument(TestCase):
 		path = Path("tests.vhdl")
 		document = Document(path, parent=None)
 
-		configuration = Configuration("cfg_1", parent=None)
+		configuration = Configuration(
+			"cfg_1",
+			EntitySymbol(SimpleName("entity_1")),
+			BlockConfiguration(Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)),
+			parent=None
+		)
 		document._AddConfiguration(configuration)
 
 		self.assertEqual(1, len(document.Configurations))
@@ -622,7 +634,12 @@ class VHDLDocument(TestCase):
 		context = Context("ctx_1", parent=None)
 		document._AddDesignUnit(context)
 
-		configuration = Configuration("cfg_1", parent=None)
+		configuration = Configuration(
+			"cfg_1",
+			EntitySymbol(SimpleName("entity_1")),
+			BlockConfiguration(Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)),
+			parent=None
+		)
 		document._AddDesignUnit(configuration)
 
 		self.assertEqual(1, len(document.Entities))
@@ -671,7 +688,12 @@ class VHDLLibrary(TestCase):
 		document._AddDesignUnit(Package("pack_1", parent=None))
 		document._AddDesignUnit(PackageBody(PackageSymbol(SimpleName("pack_1")), parent=None))
 		document._AddDesignUnit(Context("ctx_1", parent=None))
-		document._AddDesignUnit(Configuration("cfg_1", parent=None))
+		document._AddDesignUnit(Configuration(
+			"cfg_1",
+			EntitySymbol(SimpleName("entity_1")),
+			BlockConfiguration(Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)),
+			parent=None
+		))
 
 		design.AddDocument(document, library)
 


### PR DESCRIPTION
## Summary

Design discussed and agreed on in chat first (including your correction that `EntityAspect` needed
to derive from `ModelEntity`, and the direction on instantiation-list marker classes, the new
`ConfigurationSymbol`, and including configuration specifications in scope), then implemented.

`Configuration` was previously a bare shell (identifier/contextItems/documentation only) - no
entity being configured, no block configuration content at all.

## New: `pyVHDLModel/Configuration.py`

- `EntityAspect` (properly deriving from `ModelEntity`) with its 3-way split mirroring GHDL's IIR:
  `EntityAspectEntity` (entity + optional architecture), `EntityAspectConfiguration`,
  `EntityAspectOpen`.
- `BindingIndication`: optional `EntityAspect`, generic/port association items.
- `AllInstantiationList` / `OthersInstantiationList`: dedicated marker classes for the `for all:`/
  `for others:` forms, mirroring `AllName`/`AllPackageMembersReferenceSymbol` rather than a plain
  enum flag.
- `ComponentConfiguration`: also used for configuration specifications (the in-architecture
  shorthand, `for U1: comp use entity ...;`) - confirmed empirically that GHDL represents both with
  the identical field structure (`Instantiation_List`, `Component_Name`, `Binding_Indication`), so
  one model class serves both.
- `BlockConfiguration`: block specification (a generic `Symbol`, since it can reference either an
  architecture or a nested block/generate label - reusing the same "no single fixed
  `PossibleReference`" pattern introduced for `Alias`) plus nested block/component configuration
  items.

## `Symbol.py`

New `ConfigurationSymbol` (mirrors `PackageReferenceSymbol`), distinct from the existing
`ConfigurationInstantiationSymbol` (which is for a different context - `label : configuration Foo;`
- not `use configuration work.cfg;` inside a binding indication).

## `DesignUnit.py`

`Configuration` now holds the entity being configured and its block configuration.

## Testing

Updated all existing `Configuration(...)` construction call sites in `tests/unit/Analyze.py` and
`tests/unit/Instantiate.py` (breaking change to the constructor - now requires `entity` and
`blockConfiguration`). Added `tests/unit/Configuration.py`.

Full suite: `101 passed` (was 88), no regressions.

## Companion change

pyGHDL.dom PR translating `Configuration_Declaration`/`Block_Configuration`/
`Component_Configuration`/`Configuration_Specification`/`Binding_Indication` using these classes.
