### PR TITLE
Add conditional/selected/force/release assignment statements

### DIFF
--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -35,7 +35,7 @@ This module contains parts of an abstract document language model for VHDL.
 Base-classes for the VHDL language model.
 """
 from enum                  import unique, Enum
-from typing                import Type, Tuple, Iterable, Optional as Nullable, Union, cast
+from typing                import Type, Tuple, List, Iterable, Optional as Nullable, Union, cast
 
 from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType
@@ -459,6 +459,24 @@ class BaseCase(ModelEntity):
 	"""
 	A ``Case`` is a base-class for all cases.
 	"""
+
+
+@export
+class ChoicesMixin(metaclass=ExtendedType, mixin=True):
+	"""A mixin-class for all statements/entities holding a list of :class:`BaseChoice`."""
+
+	_choices: List[BaseChoice]
+
+	def __init__(self, choices: Nullable[Iterable[BaseChoice]] = None) -> None:
+		self._choices = []
+		if choices is not None:
+			for choice in choices:
+				self._choices.append(choice)
+				choice.Parent = self
+
+	@readonly
+	def Choices(self) -> List[BaseChoice]:
+		return self._choices
 
 
 @export

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -357,3 +357,44 @@ class OthersSelectedExpression(BaseCase, ExpressionMixin):
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		ExpressionMixin.__init__(self, expression)
+
+
+@export
+class SelectedWaveformsMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for all statements holding a list of :class:`SelectedWaveform`/
+	:class:`OthersSelectedWaveform` (both the concurrent and sequential forms of a selected signal
+	assignment).
+	"""
+
+	_selectedWaveforms: List[Union[SelectedWaveform, OthersSelectedWaveform]]
+
+	def __init__(self, selectedWaveforms: Iterable[Union[SelectedWaveform, OthersSelectedWaveform]]) -> None:
+		self._selectedWaveforms = []
+		for selectedWaveform in selectedWaveforms:
+			self._selectedWaveforms.append(selectedWaveform)
+			selectedWaveform.Parent = self
+
+	@readonly
+	def SelectedWaveforms(self) -> List[Union[SelectedWaveform, OthersSelectedWaveform]]:
+		return self._selectedWaveforms
+
+
+@export
+class SelectedExpressionsMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for all statements holding a list of :class:`SelectedExpression`/
+	:class:`OthersSelectedExpression`.
+	"""
+
+	_selectedExpressions: List[Union[SelectedExpression, OthersSelectedExpression]]
+
+	def __init__(self, selectedExpressions: Iterable[Union[SelectedExpression, OthersSelectedExpression]]) -> None:
+		self._selectedExpressions = []
+		for selectedExpression in selectedExpressions:
+			self._selectedExpressions.append(selectedExpression)
+			selectedExpression.Parent = self
+
+	@readonly
+	def SelectedExpressions(self) -> List[Union[SelectedExpression, OthersSelectedExpression]]:
+		return self._selectedExpressions

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -41,7 +41,7 @@ from pyTooling.MetaClasses   import ExtendedType
 
 from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, BaseCase, BaseChoice, WaveformElement
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
-from pyVHDLModel.Symbol      import Symbol
+from pyVHDLModel.Symbol      import Symbol, SignalSymbol, VariableSymbol
 from pyVHDLModel.Association import ParameterAssociationItem
 
 
@@ -144,6 +144,10 @@ class AssignmentMixin(metaclass=ExtendedType, mixin=True):
 class SignalAssignmentMixin(AssignmentMixin, mixin=True):
 	"""A mixin-class for all signal assignment statements."""
 
+	@property
+	def Target(self) -> SignalSymbol:
+		return self._target
+
 
 @export
 class VariableAssignmentMixin(AssignmentMixin, mixin=True):
@@ -152,11 +156,15 @@ class VariableAssignmentMixin(AssignmentMixin, mixin=True):
 	# FIXME: move to sequential?
 	_expression: ExpressionUnion
 
-	def __init__(self, target: Symbol, expression: ExpressionUnion) -> None:
+	def __init__(self, target: VariableSymbol, expression: ExpressionUnion) -> None:
 		super().__init__(target)
 
 		self._expression = expression
 		expression.Parent = self
+
+	@property
+	def Target(self) -> VariableSymbol:
+		return self._target
 
 	@property
 	def Expression(self) -> ExpressionUnion:
@@ -245,6 +253,26 @@ class ConditionalExpression(ModelEntity):
 	@readonly
 	def Condition(self) -> Nullable[ExpressionUnion]:
 		return self._condition
+
+
+@export
+class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for all statements holding a list of :class:`ConditionalWaveform` (both the
+	concurrent and sequential forms of a conditional signal assignment).
+	"""
+
+	_conditionalWaveforms: List[ConditionalWaveform]
+
+	def __init__(self, conditionalWaveforms: Iterable[ConditionalWaveform]) -> None:
+		self._conditionalWaveforms = []
+		for conditionalWaveform in conditionalWaveforms:
+			self._conditionalWaveforms.append(conditionalWaveform)
+			conditionalWaveform.Parent = self
+
+	@readonly
+	def ConditionalWaveforms(self) -> List[ConditionalWaveform]:
+		return self._conditionalWaveforms
 
 
 @export

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -39,7 +39,7 @@ from typing                  import List, Iterable, Union, Optional as Nullable
 from pyTooling.Decorators    import export, readonly
 from pyTooling.MetaClasses   import ExtendedType
 
-from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, BaseCase, BaseChoice, WaveformElement, ConditionalMixin
+from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, BaseCase, BaseChoice, WaveformElement, ConditionalMixin, ChoicesMixin
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Symbol      import Symbol, SignalSymbol, VariableSymbol
 from pyVHDLModel.Association import ParameterAssociationItem
@@ -274,7 +274,7 @@ class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
-class SelectedWaveform(BaseCase, WaveformMixin):
+class SelectedWaveform(BaseCase, WaveformMixin, ChoicesMixin):
 	"""
 	One alternative of a selected (waveform) signal assignment.
 
@@ -286,8 +286,6 @@ class SelectedWaveform(BaseCase, WaveformMixin):
 	      --                    ^^^^^^^^      <- this alternative: Choices=[0], Waveform=['1']
 	"""
 
-	_choices: List[BaseChoice]
-
 	def __init__(
 		self,
 		choices: Iterable[BaseChoice],
@@ -296,15 +294,7 @@ class SelectedWaveform(BaseCase, WaveformMixin):
 	) -> None:
 		super().__init__(parent)
 		WaveformMixin.__init__(self, waveform)
-
-		self._choices = []
-		for choice in choices:
-			self._choices.append(choice)
-			choice.Parent = self
-
-	@readonly
-	def Choices(self) -> List[BaseChoice]:
-		return self._choices
+		ChoicesMixin.__init__(self, choices)
 
 
 @export
@@ -317,7 +307,7 @@ class OthersSelectedWaveform(BaseCase, WaveformMixin):
 
 
 @export
-class SelectedExpression(BaseCase, ExpressionMixin):
+class SelectedExpression(BaseCase, ExpressionMixin, ChoicesMixin):
 	"""
 	One alternative of a selected (variable) assignment.
 
@@ -329,8 +319,6 @@ class SelectedExpression(BaseCase, ExpressionMixin):
 	      --                   ^^^^^^^^      <- this alternative: Choices=[0], Expression='1'
 	"""
 
-	_choices: List[BaseChoice]
-
 	def __init__(
 		self,
 		choices: Iterable[BaseChoice],
@@ -339,15 +327,7 @@ class SelectedExpression(BaseCase, ExpressionMixin):
 	) -> None:
 		super().__init__(parent)
 		ExpressionMixin.__init__(self, expression)
-
-		self._choices = []
-		for choice in choices:
-			self._choices.append(choice)
-			choice.Parent = self
-
-	@readonly
-	def Choices(self) -> List[BaseChoice]:
-		return self._choices
+		ChoicesMixin.__init__(self, choices)
 
 
 @export

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -39,7 +39,7 @@ from typing                  import List, Iterable, Union, Optional as Nullable
 from pyTooling.Decorators    import export, readonly
 from pyTooling.MetaClasses   import ExtendedType
 
-from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin
+from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, BaseCase, BaseChoice, WaveformElement
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Symbol      import Symbol
 from pyVHDLModel.Association import ParameterAssociationItem
@@ -159,5 +159,209 @@ class VariableAssignmentMixin(AssignmentMixin, mixin=True):
 		expression.Parent = self
 
 	@property
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+
+@export
+class ConditionalWaveform(ModelEntity):
+	"""
+	One branch of a conditional (waveform) signal assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= '1' when cond else '0';
+	      --   ^^^^^^^^^^^^         <- this branch: Waveform=['1'], Condition=cond
+	      --                ^^^     <- final branch (no ``when``): Waveform=['0'], Condition=None
+	"""
+
+	_waveform:  List[WaveformElement]
+	_condition: Nullable[ExpressionUnion]
+
+	def __init__(
+		self,
+		waveform: Iterable[WaveformElement],
+		condition: Nullable[ExpressionUnion] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._waveform = []
+		for waveformElement in waveform:
+			self._waveform.append(waveformElement)
+			waveformElement.Parent = self
+
+		self._condition = condition
+		if condition is not None:
+			condition.Parent = self
+
+	@readonly
+	def Waveform(self) -> List[WaveformElement]:
+		return self._waveform
+
+	@readonly
+	def Condition(self) -> Nullable[ExpressionUnion]:
+		return self._condition
+
+
+@export
+class ConditionalExpression(ModelEntity):
+	"""
+	One branch of a conditional (variable) assignment (VHDL-2008).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      v := '1' when cond else '0';
+	      --   ^^^^^^^^^^^^         <- this branch: Expression='1', Condition=cond
+	      --                ^^^     <- final branch (no ``when``): Expression='0', Condition=None
+	"""
+
+	_expression: ExpressionUnion
+	_condition:  Nullable[ExpressionUnion]
+
+	def __init__(
+		self,
+		expression: ExpressionUnion,
+		condition: Nullable[ExpressionUnion] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._expression = expression
+		expression.Parent = self
+
+		self._condition = condition
+		if condition is not None:
+			condition.Parent = self
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+	@readonly
+	def Condition(self) -> Nullable[ExpressionUnion]:
+		return self._condition
+
+
+@export
+class SelectedWaveform(BaseCase):
+	"""
+	One alternative of a selected (waveform) signal assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select s <= '1' when 0, '0' when others;
+	      --                    ^^^^^^^^      <- this alternative: Choices=[0], Waveform=['1']
+	"""
+
+	_choices:  List[BaseChoice]
+	_waveform: List[WaveformElement]
+
+	def __init__(
+		self,
+		choices: Iterable[BaseChoice],
+		waveform: Iterable[WaveformElement],
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._choices = []
+		for choice in choices:
+			self._choices.append(choice)
+			choice.Parent = self
+
+		self._waveform = []
+		for waveformElement in waveform:
+			self._waveform.append(waveformElement)
+			waveformElement.Parent = self
+
+	@readonly
+	def Choices(self) -> List[BaseChoice]:
+		return self._choices
+
+	@readonly
+	def Waveform(self) -> List[WaveformElement]:
+		return self._waveform
+
+
+@export
+class OthersSelectedWaveform(BaseCase):
+	"""``with sel select s <= '1' when 0, '0' when others;`` - the ``others`` alternative."""
+
+	_waveform: List[WaveformElement]
+
+	def __init__(self, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(parent)
+
+		self._waveform = []
+		for waveformElement in waveform:
+			self._waveform.append(waveformElement)
+			waveformElement.Parent = self
+
+	@readonly
+	def Waveform(self) -> List[WaveformElement]:
+		return self._waveform
+
+
+@export
+class SelectedExpression(BaseCase):
+	"""
+	One alternative of a selected (variable) assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select v := '1' when 0, '0' when others;
+	      --                   ^^^^^^^^      <- this alternative: Choices=[0], Expression='1'
+	"""
+
+	_choices:    List[BaseChoice]
+	_expression: ExpressionUnion
+
+	def __init__(
+		self,
+		choices: Iterable[BaseChoice],
+		expression: ExpressionUnion,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(parent)
+
+		self._choices = []
+		for choice in choices:
+			self._choices.append(choice)
+			choice.Parent = self
+
+		self._expression = expression
+		expression.Parent = self
+
+	@readonly
+	def Choices(self) -> List[BaseChoice]:
+		return self._choices
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+
+@export
+class OthersSelectedExpression(BaseCase):
+	"""``with sel select v := '1' when 0, '0' when others;`` - the ``others`` alternative."""
+
+	_expression: ExpressionUnion
+
+	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(parent)
+
+		self._expression = expression
+		expression.Parent = self
+
+	@readonly
 	def Expression(self) -> ExpressionUnion:
 		return self._expression

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -39,7 +39,7 @@ from typing                  import List, Iterable, Union, Optional as Nullable
 from pyTooling.Decorators    import export, readonly
 from pyTooling.MetaClasses   import ExtendedType
 
-from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, BaseCase, BaseChoice, WaveformElement
+from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, BaseCase, BaseChoice, WaveformElement, ConditionalMixin
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Symbol      import Symbol, SignalSymbol, VariableSymbol
 from pyVHDLModel.Association import ParameterAssociationItem
@@ -135,7 +135,7 @@ class AssignmentMixin(metaclass=ExtendedType, mixin=True):
 		self._target = target
 		target.Parent = self
 
-	@property
+	@readonly
 	def Target(self) -> Symbol:
 		return self._target
 
@@ -144,7 +144,7 @@ class AssignmentMixin(metaclass=ExtendedType, mixin=True):
 class SignalAssignmentMixin(AssignmentMixin, mixin=True):
 	"""A mixin-class for all signal assignment statements."""
 
-	@property
+	@readonly
 	def Target(self) -> SignalSymbol:
 		return self._target
 
@@ -162,17 +162,49 @@ class VariableAssignmentMixin(AssignmentMixin, mixin=True):
 		self._expression = expression
 		expression.Parent = self
 
-	@property
+	@readonly
 	def Target(self) -> VariableSymbol:
 		return self._target
 
-	@property
+	@readonly
 	def Expression(self) -> ExpressionUnion:
 		return self._expression
 
 
 @export
-class ConditionalWaveform(ModelEntity):
+class WaveformMixin(metaclass=ExtendedType, mixin=True):
+	"""A mixin-class for all statements/entities holding a waveform (a list of :class:`WaveformElement`)."""
+
+	_waveform: List[WaveformElement]
+
+	def __init__(self, waveform: Iterable[WaveformElement]) -> None:
+		self._waveform = []
+		for waveformElement in waveform:
+			self._waveform.append(waveformElement)
+			waveformElement.Parent = self
+
+	@readonly
+	def Waveform(self) -> List[WaveformElement]:
+		return self._waveform
+
+
+@export
+class ExpressionMixin(metaclass=ExtendedType, mixin=True):
+	"""A mixin-class for all statements/entities holding a single expression."""
+
+	_expression: ExpressionUnion
+
+	def __init__(self, expression: ExpressionUnion) -> None:
+		self._expression = expression
+		expression.Parent = self
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+
+@export
+class ConditionalWaveform(ModelEntity, WaveformMixin, ConditionalMixin):
 	"""
 	One branch of a conditional (waveform) signal assignment.
 
@@ -185,9 +217,6 @@ class ConditionalWaveform(ModelEntity):
 	      --                ^^^     <- final branch (no ``when``): Waveform=['0'], Condition=None
 	"""
 
-	_waveform:  List[WaveformElement]
-	_condition: Nullable[ExpressionUnion]
-
 	def __init__(
 		self,
 		waveform: Iterable[WaveformElement],
@@ -195,27 +224,12 @@ class ConditionalWaveform(ModelEntity):
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
-
-		self._waveform = []
-		for waveformElement in waveform:
-			self._waveform.append(waveformElement)
-			waveformElement.Parent = self
-
-		self._condition = condition
-		if condition is not None:
-			condition.Parent = self
-
-	@readonly
-	def Waveform(self) -> List[WaveformElement]:
-		return self._waveform
-
-	@readonly
-	def Condition(self) -> Nullable[ExpressionUnion]:
-		return self._condition
+		WaveformMixin.__init__(self, waveform)
+		ConditionalMixin.__init__(self, condition)
 
 
 @export
-class ConditionalExpression(ModelEntity):
+class ConditionalExpression(ModelEntity, ExpressionMixin, ConditionalMixin):
 	"""
 	One branch of a conditional (variable) assignment (VHDL-2008).
 
@@ -228,9 +242,6 @@ class ConditionalExpression(ModelEntity):
 	      --                ^^^     <- final branch (no ``when``): Expression='0', Condition=None
 	"""
 
-	_expression: ExpressionUnion
-	_condition:  Nullable[ExpressionUnion]
-
 	def __init__(
 		self,
 		expression: ExpressionUnion,
@@ -238,21 +249,8 @@ class ConditionalExpression(ModelEntity):
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
-
-		self._expression = expression
-		expression.Parent = self
-
-		self._condition = condition
-		if condition is not None:
-			condition.Parent = self
-
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
-
-	@readonly
-	def Condition(self) -> Nullable[ExpressionUnion]:
-		return self._condition
+		ExpressionMixin.__init__(self, expression)
+		ConditionalMixin.__init__(self, condition)
 
 
 @export
@@ -276,7 +274,7 @@ class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
-class SelectedWaveform(BaseCase):
+class SelectedWaveform(BaseCase, WaveformMixin):
 	"""
 	One alternative of a selected (waveform) signal assignment.
 
@@ -288,8 +286,7 @@ class SelectedWaveform(BaseCase):
 	      --                    ^^^^^^^^      <- this alternative: Choices=[0], Waveform=['1']
 	"""
 
-	_choices:  List[BaseChoice]
-	_waveform: List[WaveformElement]
+	_choices: List[BaseChoice]
 
 	def __init__(
 		self,
@@ -298,47 +295,29 @@ class SelectedWaveform(BaseCase):
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
+		WaveformMixin.__init__(self, waveform)
 
 		self._choices = []
 		for choice in choices:
 			self._choices.append(choice)
 			choice.Parent = self
 
-		self._waveform = []
-		for waveformElement in waveform:
-			self._waveform.append(waveformElement)
-			waveformElement.Parent = self
-
 	@readonly
 	def Choices(self) -> List[BaseChoice]:
 		return self._choices
 
-	@readonly
-	def Waveform(self) -> List[WaveformElement]:
-		return self._waveform
-
 
 @export
-class OthersSelectedWaveform(BaseCase):
+class OthersSelectedWaveform(BaseCase, WaveformMixin):
 	"""``with sel select s <= '1' when 0, '0' when others;`` - the ``others`` alternative."""
-
-	_waveform: List[WaveformElement]
 
 	def __init__(self, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
-
-		self._waveform = []
-		for waveformElement in waveform:
-			self._waveform.append(waveformElement)
-			waveformElement.Parent = self
-
-	@readonly
-	def Waveform(self) -> List[WaveformElement]:
-		return self._waveform
+		WaveformMixin.__init__(self, waveform)
 
 
 @export
-class SelectedExpression(BaseCase):
+class SelectedExpression(BaseCase, ExpressionMixin):
 	"""
 	One alternative of a selected (variable) assignment.
 
@@ -350,8 +329,7 @@ class SelectedExpression(BaseCase):
 	      --                   ^^^^^^^^      <- this alternative: Choices=[0], Expression='1'
 	"""
 
-	_choices:    List[BaseChoice]
-	_expression: ExpressionUnion
+	_choices: List[BaseChoice]
 
 	def __init__(
 		self,
@@ -360,36 +338,22 @@ class SelectedExpression(BaseCase):
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(parent)
+		ExpressionMixin.__init__(self, expression)
 
 		self._choices = []
 		for choice in choices:
 			self._choices.append(choice)
 			choice.Parent = self
 
-		self._expression = expression
-		expression.Parent = self
-
 	@readonly
 	def Choices(self) -> List[BaseChoice]:
 		return self._choices
 
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
-
 
 @export
-class OthersSelectedExpression(BaseCase):
+class OthersSelectedExpression(BaseCase, ExpressionMixin):
 	"""``with sel select v := '1' when 0, '0' when others;`` - the ``others`` alternative."""
-
-	_expression: ExpressionUnion
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
-
-		self._expression = expression
-		expression.Parent = self
-
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
+		ExpressionMixin.__init__(self, expression)

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -51,7 +51,7 @@ from pyVHDLModel.Association import AssociationItem, ParameterAssociationItem
 from pyVHDLModel.Interface   import PortInterfaceItemMixin
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignmentMixin, AllowBlackboxMixin
 from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
-from pyVHDLModel.Common      import ConditionalWaveformsMixin
+from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
 from pyVHDLModel.Sequential  import SequentialStatement, SequentialStatementsMixin, SequentialDeclarationsMixin
 
 
@@ -912,22 +912,10 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 
 
 @export
-class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment):
-	_waveform: List[WaveformElement]
-
+class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin):
 	def __init__(self, label: str, target: SignalSymbol, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
-
-		# TODO: extract to mixin
-		self._waveform = []
-		if waveform is not None:
-			for waveformElement in waveform:
-				self._waveform.append(waveformElement)
-				waveformElement.Parent = self
-
-	@property
-	def Waveform(self) -> List[WaveformElement]:
-		return self._waveform
+		WaveformMixin.__init__(self, waveform)
 
 
 @export

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -40,7 +40,7 @@ from pyTooling.Decorators    import export, readonly
 from pyTooling.MetaClasses   import ExtendedType
 
 from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, DocumentedEntityMixin, Range, BaseChoice, BaseCase, IfBranchMixin
-from pyVHDLModel.Base        import ElsifBranchMixin, ElseBranchMixin, AssertStatementMixin, BlockStatementMixin, WaveformElement
+from pyVHDLModel.Base        import ElsifBranchMixin, ElseBranchMixin, AssertStatementMixin, BlockStatementMixin, WaveformElement, ChoicesMixin
 from pyVHDLModel.Regions     import ConcurrentDeclarationRegionMixin
 from pyVHDLModel.Namespace   import Namespace
 from pyVHDLModel.Name        import Name
@@ -697,7 +697,7 @@ class RangedGenerateChoice(ConcurrentChoice):
 
 
 @export
-class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin):
+class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin, ChoicesMixin):
 	_namespace: Namespace
 
 	def __init__(
@@ -705,6 +705,7 @@ class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMi
 		declaredItems:    Nullable[Iterable] = None,
 		statements:       Nullable[Iterable[ConcurrentStatement]] = None,
 		alternativeLabel: Nullable[str] = None,
+		choices:          Nullable[Iterable[BaseChoice]] = None,
 		allowBlackbox:    Nullable[bool] = None,
 		parent:           Nullable[ModelEntity] = None
 	) -> None:
@@ -721,12 +722,11 @@ class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMi
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
 		ConcurrentStatementsMixin.__init__(self, statements)
 		AllowBlackboxMixin.__init__(self, allowBlackbox)
+		ChoicesMixin.__init__(self, choices)
 
 
 @export
 class GenerateCase(ConcurrentCase):
-	_choices: List[ConcurrentChoice]
-
 	def __init__(
 		self,
 		choices:          Iterable[ConcurrentChoice],
@@ -736,19 +736,7 @@ class GenerateCase(ConcurrentCase):
 		allowBlackbox:    Nullable[bool] = None,
 		parent:           Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(declaredItems, statements, alternativeLabel, allowBlackbox, parent)
-
-		# TODO: move to parent or grandparent
-		self._choices = []
-		if choices is not None:
-			for choice in choices:
-				self._choices.append(choice)
-				choice.Parent = self
-
-	# TODO: move to parent or grandparent
-	@property
-	def Choices(self) -> List[ConcurrentChoice]:
-		return self._choices
+		super().__init__(declaredItems, statements, alternativeLabel, choices, allowBlackbox, parent)
 
 	def __str__(self) -> str:
 		return "when {choices} =>".format(choices=" | ".join(str(c) for c in self._choices))

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -52,6 +52,7 @@ from pyVHDLModel.Interface   import PortInterfaceItemMixin
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignmentMixin, AllowBlackboxMixin
 from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
+from pyVHDLModel.Common      import ExpressionMixin, SelectedWaveformsMixin
 from pyVHDLModel.Sequential  import SequentialStatement, SequentialStatementsMixin, SequentialDeclarationsMixin
 
 
@@ -919,7 +920,7 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin
 
 
 @export
-class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
+class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment, ExpressionMixin, SelectedWaveformsMixin):
 	"""
 	.. admonition:: Example
 
@@ -927,9 +928,6 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
 
 	      with sel select s <= '1' when 0, '0' when others;
 	"""
-
-	_expression:        ExpressionUnion
-	_selectedWaveforms: List[SelectedWaveform]
 
 	def __init__(
 		self,
@@ -940,22 +938,8 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, target, parent)
-
-		self._expression = expression
-		expression.Parent = self
-
-		self._selectedWaveforms = []
-		for selectedWaveform in selectedWaveforms:
-			self._selectedWaveforms.append(selectedWaveform)
-			selectedWaveform.Parent = self
-
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
-
-	@readonly
-	def SelectedWaveforms(self) -> List[SelectedWaveform]:
-		return self._selectedWaveforms
+		ExpressionMixin.__init__(self, expression)
+		SelectedWaveformsMixin.__init__(self, selectedWaveforms)
 
 
 @export

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -49,6 +49,7 @@ from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, Functio
 from pyVHDLModel.Association import AssociationItem, ParameterAssociationItem
 from pyVHDLModel.Interface   import PortInterfaceItemMixin
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignmentMixin, AllowBlackboxMixin
+from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Sequential  import SequentialStatement, SequentialStatementsMixin, SequentialDeclarationsMixin
 
 
@@ -929,14 +930,73 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment):
 
 @export
 class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
-	def __init__(self, label: str, target: Name, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select s <= '1' when 0, '0' when others;
+	"""
+
+	_expression:        ExpressionUnion
+	_selectedWaveforms: List[SelectedWaveform]
+
+	def __init__(
+		self,
+		label: str,
+		target: Name,
+		expression: ExpressionUnion,
+		selectedWaveforms: Iterable[SelectedWaveform],
+		parent: Nullable[ModelEntity] = None
+	) -> None:
 		super().__init__(label, target, parent)
+
+		self._expression = expression
+		expression.Parent = self
+
+		self._selectedWaveforms = []
+		for selectedWaveform in selectedWaveforms:
+			self._selectedWaveforms.append(selectedWaveform)
+			selectedWaveform.Parent = self
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+	@readonly
+	def SelectedWaveforms(self) -> List[SelectedWaveform]:
+		return self._selectedWaveforms
 
 
 @export
 class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment):
-	def __init__(self, label: str, target: Name, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= '1' when cond1 else '0' when cond2 else 'Z';
+	"""
+
+	_conditionalWaveforms: List[ConditionalWaveform]
+
+	def __init__(
+		self,
+		label: str,
+		target: Name,
+		conditionalWaveforms: Iterable[ConditionalWaveform],
+		parent: Nullable[ModelEntity] = None
+	) -> None:
 		super().__init__(label, target, parent)
+
+		self._conditionalWaveforms = []
+		for conditionalWaveform in conditionalWaveforms:
+			self._conditionalWaveforms.append(conditionalWaveform)
+			conditionalWaveform.Parent = self
+
+	@readonly
+	def ConditionalWaveforms(self) -> List[ConditionalWaveform]:
+		return self._conditionalWaveforms
 
 
 @export

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -45,11 +45,13 @@ from pyVHDLModel.Regions     import ConcurrentDeclarationRegionMixin
 from pyVHDLModel.Namespace   import Namespace
 from pyVHDLModel.Name        import Name
 from pyVHDLModel.Symbol      import ComponentInstantiationSymbol, EntityInstantiationSymbol, ArchitectureSymbol, ConfigurationInstantiationSymbol
+from pyVHDLModel.Symbol      import SignalSymbol
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Association import AssociationItem, ParameterAssociationItem
 from pyVHDLModel.Interface   import PortInterfaceItemMixin
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignmentMixin, AllowBlackboxMixin
 from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
+from pyVHDLModel.Common      import ConditionalWaveformsMixin
 from pyVHDLModel.Sequential  import SequentialStatement, SequentialStatementsMixin, SequentialDeclarationsMixin
 
 
@@ -904,7 +906,7 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 	   * :class:`~pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment`
 	   * :class:`~pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment`
 	"""
-	def __init__(self, label: str, target: Name, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, label: str, target: SignalSymbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
 
@@ -913,7 +915,7 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment):
 	_waveform: List[WaveformElement]
 
-	def __init__(self, label: str, target: Name, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, label: str, target: SignalSymbol, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
 
 		# TODO: extract to mixin
@@ -944,7 +946,7 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
 	def __init__(
 		self,
 		label: str,
-		target: Name,
+		target: SignalSymbol,
 		expression: ExpressionUnion,
 		selectedWaveforms: Iterable[SelectedWaveform],
 		parent: Nullable[ModelEntity] = None
@@ -969,7 +971,7 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment):
 
 
 @export
-class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment):
+class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment, ConditionalWaveformsMixin):
 	"""
 	.. admonition:: Example
 
@@ -978,25 +980,15 @@ class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment):
 	      s <= '1' when cond1 else '0' when cond2 else 'Z';
 	"""
 
-	_conditionalWaveforms: List[ConditionalWaveform]
-
 	def __init__(
 		self,
 		label: str,
-		target: Name,
+		target: SignalSymbol,
 		conditionalWaveforms: Iterable[ConditionalWaveform],
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, target, parent)
-
-		self._conditionalWaveforms = []
-		for conditionalWaveform in conditionalWaveforms:
-			self._conditionalWaveforms.append(conditionalWaveform)
-			conditionalWaveform.Parent = self
-
-	@readonly
-	def ConditionalWaveforms(self) -> List[ConditionalWaveform]:
-		return self._conditionalWaveforms
+		ConditionalWaveformsMixin.__init__(self, conditionalWaveforms)
 
 
 @export

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -11,8 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
-# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -46,6 +46,7 @@ from pyVHDLModel.Common      import Statement, ProcedureCallMixin
 from pyVHDLModel.Common      import AssignmentMixin, SignalAssignmentMixin, VariableAssignmentMixin
 from pyVHDLModel.Common      import ConditionalWaveform, ConditionalExpression
 from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
+from pyVHDLModel.Common      import ExpressionMixin, SelectedWaveformsMixin, SelectedExpressionsMixin
 from pyVHDLModel.Common      import SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import SelectedExpression, OthersSelectedExpression
 from pyVHDLModel.Association import ParameterAssociationItem
@@ -167,7 +168,7 @@ class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmen
 
 
 @export
-class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin):
+class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin, ExpressionMixin, SelectedExpressionsMixin):
 	"""
 	.. admonition:: Example
 
@@ -175,9 +176,6 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin)
 
 	      with sel select v := '1' when 0, '0' when others;
 	"""
-
-	_expression:         ExpressionUnion
-	_selectedExpressions: List[SelectedExpression]
 
 	def __init__(
 		self,
@@ -189,26 +187,12 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin)
 	) -> None:
 		super().__init__(label, parent)
 		AssignmentMixin.__init__(self, target)
-
-		self._expression = expression
-		expression.Parent = self
-
-		self._selectedExpressions = []
-		for selectedExpression in selectedExpressions:
-			self._selectedExpressions.append(selectedExpression)
-			selectedExpression.Parent = self
-
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
-
-	@readonly
-	def SelectedExpressions(self) -> List[SelectedExpression]:
-		return self._selectedExpressions
+		ExpressionMixin.__init__(self, expression)
+		SelectedExpressionsMixin.__init__(self, selectedExpressions)
 
 
 @export
-class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMixin):
+class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMixin, ExpressionMixin, SelectedWaveformsMixin):
 	"""
 	.. admonition:: Example
 
@@ -216,9 +200,6 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 
 	      with sel select s <= '1' when 0, '0' when others;
 	"""
-
-	_expression:        ExpressionUnion
-	_selectedWaveforms: List[SelectedWaveform]
 
 	def __init__(
 		self,
@@ -230,26 +211,12 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 	) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
-
-		self._expression = expression
-		expression.Parent = self
-
-		self._selectedWaveforms = []
-		for selectedWaveform in selectedWaveforms:
-			self._selectedWaveforms.append(selectedWaveform)
-			selectedWaveform.Parent = self
-
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
-
-	@readonly
-	def SelectedWaveforms(self) -> List[SelectedWaveform]:
-		return self._selectedWaveforms
+		ExpressionMixin.__init__(self, expression)
+		SelectedWaveformsMixin.__init__(self, selectedWaveforms)
 
 
 @export
-class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin):
+class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin, ExpressionMixin):
 	"""
 	.. admonition:: Example
 
@@ -257,8 +224,6 @@ class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin):
 
 	      s <= force '1';
 	"""
-
-	_expression: ExpressionUnion
 
 	def __init__(
 		self,
@@ -269,13 +234,7 @@ class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin):
 	) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
-
-		self._expression = expression
-		expression.Parent = self
-
-	@readonly
-	def Expression(self) -> ExpressionUnion:
-		return self._expression
+		ExpressionMixin.__init__(self, expression)
 
 
 @export

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -41,10 +41,11 @@ from pyTooling.MetaClasses   import ExtendedType
 
 from pyVHDLModel.Base        import ModelEntity, ExpressionUnion, Range, BaseChoice, BaseCase, ConditionalMixin, IfBranchMixin, ElsifBranchMixin
 from pyVHDLModel.Base        import ElseBranchMixin, ReportStatementMixin, AssertStatementMixin, WaveformElement
-from pyVHDLModel.Symbol      import Symbol
+from pyVHDLModel.Symbol      import Symbol, SignalSymbol, VariableSymbol
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin
 from pyVHDLModel.Common      import AssignmentMixin, SignalAssignmentMixin, VariableAssignmentMixin
 from pyVHDLModel.Common      import ConditionalWaveform, ConditionalExpression
+from pyVHDLModel.Common      import ConditionalWaveformsMixin
 from pyVHDLModel.Common      import SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import SelectedExpression, OthersSelectedExpression
 from pyVHDLModel.Association import ParameterAssociationItem
@@ -92,7 +93,7 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 
 @export
 class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
-	def __init__(self, target: Symbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
 
@@ -101,7 +102,7 @@ class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
 class SequentialSimpleSignalAssignment(SequentialSignalAssignment):
 	_waveform: List[WaveformElement]
 
-	def __init__(self, target: Symbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, target: SignalSymbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(target, label, parent)
 
 		# TODO: extract to mixin
@@ -123,7 +124,7 @@ class SequentialSimpleSignalAssignment(SequentialSignalAssignment):
 
 @export
 class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin):
-	def __init__(self, target: Symbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, target: VariableSymbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		VariableAssignmentMixin.__init__(self, target, expression)
 
@@ -142,7 +143,7 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 
 	def __init__(
 		self,
-		target: Symbol,
+		target: VariableSymbol,
 		conditionalExpressions: Iterable[ConditionalExpression],
 		label: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
@@ -161,7 +162,7 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 
 
 @export
-class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmentMixin):
+class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmentMixin, ConditionalWaveformsMixin):
 	"""
 	.. admonition:: Example
 
@@ -170,26 +171,16 @@ class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmen
 	      s <= '1' when cond1 else '0' when cond2 else 'Z';
 	"""
 
-	_conditionalWaveforms: List[ConditionalWaveform]
-
 	def __init__(
 		self,
-		target: Symbol,
+		target: SignalSymbol,
 		conditionalWaveforms: Iterable[ConditionalWaveform],
 		label: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
-
-		self._conditionalWaveforms = []
-		for conditionalWaveform in conditionalWaveforms:
-			self._conditionalWaveforms.append(conditionalWaveform)
-			conditionalWaveform.Parent = self
-
-	@readonly
-	def ConditionalWaveforms(self) -> List[ConditionalWaveform]:
-		return self._conditionalWaveforms
+		ConditionalWaveformsMixin.__init__(self, conditionalWaveforms)
 
 
 @export
@@ -207,7 +198,7 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin)
 
 	def __init__(
 		self,
-		target: Symbol,
+		target: VariableSymbol,
 		expression: ExpressionUnion,
 		selectedExpressions: Iterable[SelectedExpression],
 		label: Nullable[str] = None,
@@ -248,7 +239,7 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 
 	def __init__(
 		self,
-		target: Symbol,
+		target: SignalSymbol,
 		expression: ExpressionUnion,
 		selectedWaveforms: Iterable[SelectedWaveform],
 		label: Nullable[str] = None,
@@ -288,7 +279,7 @@ class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin):
 
 	def __init__(
 		self,
-		target: Symbol,
+		target: SignalSymbol,
 		expression: ExpressionUnion,
 		label: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
@@ -314,7 +305,7 @@ class SignalReleaseAssignment(SequentialStatement, SignalAssignmentMixin):
 	      s <= release;
 	"""
 
-	def __init__(self, target: Symbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
 

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -40,7 +40,7 @@ from pyTooling.Decorators    import export, readonly
 from pyTooling.MetaClasses   import ExtendedType
 
 from pyVHDLModel.Base        import ModelEntity, ExpressionUnion, Range, BaseChoice, BaseCase, ConditionalMixin, IfBranchMixin, ElsifBranchMixin
-from pyVHDLModel.Base        import ElseBranchMixin, ReportStatementMixin, AssertStatementMixin, WaveformElement
+from pyVHDLModel.Base        import ElseBranchMixin, ReportStatementMixin, AssertStatementMixin, WaveformElement, ChoicesMixin
 from pyVHDLModel.Symbol      import Symbol, SignalSymbol, VariableSymbol
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin
 from pyVHDLModel.Common      import AssignmentMixin, SignalAssignmentMixin, VariableAssignmentMixin
@@ -409,34 +409,22 @@ class RangedChoice(SequentialChoice):
 
 
 @export
-class SequentialCase(BaseCase, SequentialStatementsMixin):
-	_choices: List
-
-	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
+class SequentialCase(BaseCase, SequentialStatementsMixin, ChoicesMixin):
+	def __init__(
+		self,
+		statements: Nullable[Iterable[SequentialStatement]] = None,
+		choices: Nullable[Iterable[BaseChoice]] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
 		super().__init__(parent)
 		SequentialStatementsMixin.__init__(self, statements)
-
-		# TODO: what about choices?
-
-	@property
-	def Choices(self) -> List[BaseChoice]:
-		return self._choices
+		ChoicesMixin.__init__(self, choices)
 
 
 @export
 class Case(SequentialCase):
 	def __init__(self, choices: Iterable[SequentialChoice], statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(statements, parent)
-
-		self._choices = []
-		if choices is not None:
-			for choice in choices:
-				self._choices.append(choice)
-				choice.Parent = self
-
-	@property
-	def Choices(self) -> List[SequentialChoice]:
-		return self._choices
+		super().__init__(statements, choices, parent)
 
 	def __str__(self) -> str:
 		return "when {choices} =>".format(choices=" | ".join(str(c) for c in self._choices))

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -45,7 +45,7 @@ from pyVHDLModel.Symbol      import Symbol, SignalSymbol, VariableSymbol
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin
 from pyVHDLModel.Common      import AssignmentMixin, SignalAssignmentMixin, VariableAssignmentMixin
 from pyVHDLModel.Common      import ConditionalWaveform, ConditionalExpression
-from pyVHDLModel.Common      import ConditionalWaveformsMixin
+from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
 from pyVHDLModel.Common      import SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import SelectedExpression, OthersSelectedExpression
 from pyVHDLModel.Association import ParameterAssociationItem
@@ -99,27 +99,10 @@ class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
 
 
 @export
-class SequentialSimpleSignalAssignment(SequentialSignalAssignment):
-	_waveform: List[WaveformElement]
-
+class SequentialSimpleSignalAssignment(SequentialSignalAssignment, WaveformMixin):
 	def __init__(self, target: SignalSymbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(target, label, parent)
-
-		# TODO: extract to mixin
-		self._waveform = []
-		if waveform is not None:
-			for waveformElement in waveform:
-				self._waveform.append(waveformElement)
-				waveformElement.Parent = self
-
-	@readonly
-	def Waveform(self) -> List[WaveformElement]:
-		"""
-		Read-only property to access the list waveform elements (:attr:`_waveform`).
-
-		:returns: A list of waveform elements.
-		"""
-		return self._waveform
+		WaveformMixin.__init__(self, waveform)
 
 
 @export

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -43,7 +43,10 @@ from pyVHDLModel.Base        import ModelEntity, ExpressionUnion, Range, BaseCho
 from pyVHDLModel.Base        import ElseBranchMixin, ReportStatementMixin, AssertStatementMixin, WaveformElement
 from pyVHDLModel.Symbol      import Symbol
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin
-from pyVHDLModel.Common      import SignalAssignmentMixin, VariableAssignmentMixin
+from pyVHDLModel.Common      import AssignmentMixin, SignalAssignmentMixin, VariableAssignmentMixin
+from pyVHDLModel.Common      import ConditionalWaveform, ConditionalExpression
+from pyVHDLModel.Common      import SelectedWaveform, OthersSelectedWaveform
+from pyVHDLModel.Common      import SelectedExpression, OthersSelectedExpression
 from pyVHDLModel.Association import ParameterAssociationItem
 
 
@@ -123,6 +126,197 @@ class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin)
 	def __init__(self, target: Symbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		VariableAssignmentMixin.__init__(self, target, expression)
+
+
+@export
+class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      v := '1' when cond1 else '0' when cond2 else 'Z';
+	"""
+
+	_conditionalExpressions: List[ConditionalExpression]
+
+	def __init__(
+		self,
+		target: Symbol,
+		conditionalExpressions: Iterable[ConditionalExpression],
+		label: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(label, parent)
+		AssignmentMixin.__init__(self, target)
+
+		self._conditionalExpressions = []
+		for conditionalExpression in conditionalExpressions:
+			self._conditionalExpressions.append(conditionalExpression)
+			conditionalExpression.Parent = self
+
+	@readonly
+	def ConditionalExpressions(self) -> List[ConditionalExpression]:
+		return self._conditionalExpressions
+
+
+@export
+class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmentMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= '1' when cond1 else '0' when cond2 else 'Z';
+	"""
+
+	_conditionalWaveforms: List[ConditionalWaveform]
+
+	def __init__(
+		self,
+		target: Symbol,
+		conditionalWaveforms: Iterable[ConditionalWaveform],
+		label: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(label, parent)
+		SignalAssignmentMixin.__init__(self, target)
+
+		self._conditionalWaveforms = []
+		for conditionalWaveform in conditionalWaveforms:
+			self._conditionalWaveforms.append(conditionalWaveform)
+			conditionalWaveform.Parent = self
+
+	@readonly
+	def ConditionalWaveforms(self) -> List[ConditionalWaveform]:
+		return self._conditionalWaveforms
+
+
+@export
+class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select v := '1' when 0, '0' when others;
+	"""
+
+	_expression:         ExpressionUnion
+	_selectedExpressions: List[SelectedExpression]
+
+	def __init__(
+		self,
+		target: Symbol,
+		expression: ExpressionUnion,
+		selectedExpressions: Iterable[SelectedExpression],
+		label: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(label, parent)
+		AssignmentMixin.__init__(self, target)
+
+		self._expression = expression
+		expression.Parent = self
+
+		self._selectedExpressions = []
+		for selectedExpression in selectedExpressions:
+			self._selectedExpressions.append(selectedExpression)
+			selectedExpression.Parent = self
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+	@readonly
+	def SelectedExpressions(self) -> List[SelectedExpression]:
+		return self._selectedExpressions
+
+
+@export
+class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select s <= '1' when 0, '0' when others;
+	"""
+
+	_expression:        ExpressionUnion
+	_selectedWaveforms: List[SelectedWaveform]
+
+	def __init__(
+		self,
+		target: Symbol,
+		expression: ExpressionUnion,
+		selectedWaveforms: Iterable[SelectedWaveform],
+		label: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(label, parent)
+		SignalAssignmentMixin.__init__(self, target)
+
+		self._expression = expression
+		expression.Parent = self
+
+		self._selectedWaveforms = []
+		for selectedWaveform in selectedWaveforms:
+			self._selectedWaveforms.append(selectedWaveform)
+			selectedWaveform.Parent = self
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+	@readonly
+	def SelectedWaveforms(self) -> List[SelectedWaveform]:
+		return self._selectedWaveforms
+
+
+@export
+class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= force '1';
+	"""
+
+	_expression: ExpressionUnion
+
+	def __init__(
+		self,
+		target: Symbol,
+		expression: ExpressionUnion,
+		label: Nullable[str] = None,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(label, parent)
+		SignalAssignmentMixin.__init__(self, target)
+
+		self._expression = expression
+		expression.Parent = self
+
+	@readonly
+	def Expression(self) -> ExpressionUnion:
+		return self._expression
+
+
+@export
+class SignalReleaseAssignment(SequentialStatement, SignalAssignmentMixin):
+	"""
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= release;
+	"""
+
+	def __init__(self, target: Symbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(label, parent)
+		SignalAssignmentMixin.__init__(self, target)
 
 
 @export

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -273,6 +273,56 @@ class ConfigurationSymbol(Symbol):
 
 
 @export
+class VariableSymbol(Symbol):
+	"""
+	Represents a reference (name) to a variable, e.g. the target of a variable assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      v := '1';
+	      --^
+	"""
+
+	def __init__(self, name: Name) -> None:
+		super().__init__(name, PossibleReference.Variable)
+
+	@property
+	def Variable(self) -> Nullable['Variable']:
+		return self._reference
+
+	@Variable.setter
+	def Variable(self, value: 'Variable') -> None:
+		self._reference = value
+
+
+@export
+class SignalSymbol(Symbol):
+	"""
+	Represents a reference (name) to a signal, e.g. the target of a signal assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= '1';
+	      --^
+	"""
+
+	def __init__(self, name: Name) -> None:
+		super().__init__(name, PossibleReference.Signal)
+
+	@property
+	def Signal(self) -> Nullable['Signal']:
+		return self._reference
+
+	@Signal.setter
+	def Signal(self, value: 'Signal') -> None:
+		self._reference = value
+
+
+@export
 class ContextReferenceSymbol(Symbol):
 	"""
 	Represents a reference (name) to a context.

--- a/tests/unit/Assignment.py
+++ b/tests/unit/Assignment.py
@@ -1,0 +1,193 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for conditional/selected/force/release assignment statements (Concurrent.py, Sequential.py, Common.py)."""
+from unittest import TestCase
+
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import Symbol, PossibleReference
+from pyVHDLModel.Base        import WaveformElement
+from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral
+from pyVHDLModel.Sequential  import IndexedChoice
+from pyVHDLModel.Common      import (
+	ConditionalWaveform, ConditionalExpression,
+	SelectedWaveform, OthersSelectedWaveform,
+	SelectedExpression, OthersSelectedExpression,
+)
+from pyVHDLModel.Concurrent  import ConcurrentConditionalSignalAssignment, ConcurrentSelectedSignalAssignment
+from pyVHDLModel.Sequential  import (
+	SequentialVariableAssignment,
+	SequentialConditionalVariableAssignment, SequentialConditionalSignalAssignment,
+	SequentialSelectedVariableAssignment, SequentialSelectedSignalAssignment,
+	SignalForceAssignment, SignalReleaseAssignment,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _target() -> Symbol:
+	return Symbol(SimpleName("s"), PossibleReference.Signal)
+
+
+class ConditionalAndSelectedBuildingBlocks(TestCase):
+	def test_ConditionalWaveform(self) -> None:
+		condition = IntegerLiteral(1)
+		waveform = [WaveformElement(CharacterLiteral("'1'"))]
+		cw = ConditionalWaveform(waveform, condition)
+
+		self.assertIs(condition, cw.Condition)
+		self.assertEqual(1, len(cw.Waveform))
+
+	def test_ConditionalWaveform_FinalBranch(self) -> None:
+		"""The final ('else') branch has no condition."""
+		cw = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
+
+		self.assertIsNone(cw.Condition)
+
+	def test_ConditionalExpression(self) -> None:
+		condition = IntegerLiteral(1)
+		expression = CharacterLiteral("'1'")
+		ce = ConditionalExpression(expression, condition)
+
+		self.assertIs(expression, ce.Expression)
+		self.assertIs(condition, ce.Condition)
+
+	def test_SelectedWaveform(self) -> None:
+		choice = IndexedChoice(IntegerLiteral(0))
+		waveform = [WaveformElement(CharacterLiteral("'1'"))]
+		sw = SelectedWaveform([choice], waveform)
+
+		self.assertEqual(1, len(sw.Choices))
+		self.assertEqual(1, len(sw.Waveform))
+
+	def test_OthersSelectedWaveform(self) -> None:
+		waveform = [WaveformElement(CharacterLiteral("'0'"))]
+		osw = OthersSelectedWaveform(waveform)
+
+		self.assertEqual(1, len(osw.Waveform))
+
+	def test_SelectedExpression(self) -> None:
+		choice = IndexedChoice(IntegerLiteral(0))
+		expression = CharacterLiteral("'1'")
+		se = SelectedExpression([choice], expression)
+
+		self.assertEqual(1, len(se.Choices))
+		self.assertIs(expression, se.Expression)
+
+	def test_OthersSelectedExpression(self) -> None:
+		expression = CharacterLiteral("'0'")
+		ose = OthersSelectedExpression(expression)
+
+		self.assertIs(expression, ose.Expression)
+
+
+class ConcurrentAssignments(TestCase):
+	def test_ConditionalSignalAssignment(self) -> None:
+		"""``s <= '1' when cond else '0';`` - regression test: this class was previously a bare stub
+		accepting a single 'expression' parameter that didn't fit what a conditional signal
+		assignment actually needs to store at all."""
+		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
+		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
+
+		assignment = ConcurrentConditionalSignalAssignment("lbl", _target(), [cw1, cw2])
+
+		self.assertEqual(2, len(assignment.ConditionalWaveforms))
+		self.assertIsNone(assignment.ConditionalWaveforms[-1].Condition)
+
+	def test_SelectedSignalAssignment(self) -> None:
+		"""``with sel select s <= '1' when 0, '0' when others;`` - same kind of stub as above."""
+		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
+		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
+
+		assignment = ConcurrentSelectedSignalAssignment("lbl", _target(), IntegerLiteral(0), [sw, osw])
+
+		self.assertEqual(2, len(assignment.SelectedWaveforms))
+
+
+class SequentialAssignments(TestCase):
+	def test_SimpleVariableAssignment(self) -> None:
+		"""``v := '1';``"""
+		assignment = SequentialVariableAssignment(_target(), CharacterLiteral("'1'"))
+
+		self.assertEqual("'1'", str(assignment.Expression))
+
+	def test_ConditionalVariableAssignment(self) -> None:
+		"""``v := '1' when cond else '0';`` (VHDL-2008)"""
+		ce1 = ConditionalExpression(CharacterLiteral("'1'"), IntegerLiteral(1))
+		ce2 = ConditionalExpression(CharacterLiteral("'0'"))
+
+		assignment = SequentialConditionalVariableAssignment(_target(), [ce1, ce2])
+
+		self.assertEqual(2, len(assignment.ConditionalExpressions))
+		self.assertIsNotNone(assignment.Target)
+
+	def test_ConditionalSignalAssignment(self) -> None:
+		"""``s <= '1' when cond else '0';`` (sequential form, VHDL-2008)"""
+		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
+		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
+
+		assignment = SequentialConditionalSignalAssignment(_target(), [cw1, cw2])
+
+		self.assertEqual(2, len(assignment.ConditionalWaveforms))
+
+	def test_SelectedVariableAssignment(self) -> None:
+		"""``with sel select v := '1' when 0, '0' when others;``"""
+		se = SelectedExpression([IndexedChoice(IntegerLiteral(0))], CharacterLiteral("'1'"))
+		ose = OthersSelectedExpression(CharacterLiteral("'0'"))
+
+		assignment = SequentialSelectedVariableAssignment(_target(), IntegerLiteral(0), [se, ose])
+
+		self.assertEqual(2, len(assignment.SelectedExpressions))
+
+	def test_SelectedSignalAssignment(self) -> None:
+		"""``with sel select s <= '1' when 0, '0' when others;`` (sequential form)"""
+		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
+		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
+
+		assignment = SequentialSelectedSignalAssignment(_target(), IntegerLiteral(0), [sw, osw])
+
+		self.assertEqual(2, len(assignment.SelectedWaveforms))
+
+	def test_SignalForceAssignment(self) -> None:
+		"""``s <= force '1';`` (VHDL-2008)"""
+		assignment = SignalForceAssignment(_target(), CharacterLiteral("'1'"))
+
+		self.assertEqual("'1'", str(assignment.Expression))
+
+	def test_SignalReleaseAssignment(self) -> None:
+		"""``s <= release;`` (VHDL-2008) - no expression at all."""
+		assignment = SignalReleaseAssignment(_target())
+
+		self.assertIsNotNone(assignment.Target)

--- a/tests/unit/Assignment.py
+++ b/tests/unit/Assignment.py
@@ -11,8 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
-# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #
@@ -33,7 +32,7 @@
 from unittest import TestCase
 
 from pyVHDLModel.Name        import SimpleName
-from pyVHDLModel.Symbol      import Symbol, PossibleReference
+from pyVHDLModel.Symbol      import SignalSymbol, VariableSymbol
 from pyVHDLModel.Base        import WaveformElement
 from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral
 from pyVHDLModel.Sequential  import IndexedChoice
@@ -57,8 +56,12 @@ if __name__ == "__main__":  # pragma: no cover
 	exit(1)
 
 
-def _target() -> Symbol:
-	return Symbol(SimpleName("s"), PossibleReference.Signal)
+def _signalTarget() -> SignalSymbol:
+	return SignalSymbol(SimpleName("s"))
+
+
+def _variableTarget() -> VariableSymbol:
+	return VariableSymbol(SimpleName("v"))
 
 
 class ConditionalAndSelectedBuildingBlocks(TestCase):
@@ -121,7 +124,7 @@ class ConcurrentAssignments(TestCase):
 		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
 		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = ConcurrentConditionalSignalAssignment("lbl", _target(), [cw1, cw2])
+		assignment = ConcurrentConditionalSignalAssignment("lbl", _signalTarget(), [cw1, cw2])
 
 		self.assertEqual(2, len(assignment.ConditionalWaveforms))
 		self.assertIsNone(assignment.ConditionalWaveforms[-1].Condition)
@@ -131,7 +134,7 @@ class ConcurrentAssignments(TestCase):
 		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
 		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = ConcurrentSelectedSignalAssignment("lbl", _target(), IntegerLiteral(0), [sw, osw])
+		assignment = ConcurrentSelectedSignalAssignment("lbl", _signalTarget(), IntegerLiteral(0), [sw, osw])
 
 		self.assertEqual(2, len(assignment.SelectedWaveforms))
 
@@ -139,7 +142,7 @@ class ConcurrentAssignments(TestCase):
 class SequentialAssignments(TestCase):
 	def test_SimpleVariableAssignment(self) -> None:
 		"""``v := '1';``"""
-		assignment = SequentialVariableAssignment(_target(), CharacterLiteral("'1'"))
+		assignment = SequentialVariableAssignment(_variableTarget(), CharacterLiteral("'1'"))
 
 		self.assertEqual("'1'", str(assignment.Expression))
 
@@ -148,7 +151,7 @@ class SequentialAssignments(TestCase):
 		ce1 = ConditionalExpression(CharacterLiteral("'1'"), IntegerLiteral(1))
 		ce2 = ConditionalExpression(CharacterLiteral("'0'"))
 
-		assignment = SequentialConditionalVariableAssignment(_target(), [ce1, ce2])
+		assignment = SequentialConditionalVariableAssignment(_variableTarget(), [ce1, ce2])
 
 		self.assertEqual(2, len(assignment.ConditionalExpressions))
 		self.assertIsNotNone(assignment.Target)
@@ -158,7 +161,7 @@ class SequentialAssignments(TestCase):
 		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
 		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = SequentialConditionalSignalAssignment(_target(), [cw1, cw2])
+		assignment = SequentialConditionalSignalAssignment(_signalTarget(), [cw1, cw2])
 
 		self.assertEqual(2, len(assignment.ConditionalWaveforms))
 
@@ -167,7 +170,7 @@ class SequentialAssignments(TestCase):
 		se = SelectedExpression([IndexedChoice(IntegerLiteral(0))], CharacterLiteral("'1'"))
 		ose = OthersSelectedExpression(CharacterLiteral("'0'"))
 
-		assignment = SequentialSelectedVariableAssignment(_target(), IntegerLiteral(0), [se, ose])
+		assignment = SequentialSelectedVariableAssignment(_variableTarget(), IntegerLiteral(0), [se, ose])
 
 		self.assertEqual(2, len(assignment.SelectedExpressions))
 
@@ -176,18 +179,18 @@ class SequentialAssignments(TestCase):
 		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
 		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = SequentialSelectedSignalAssignment(_target(), IntegerLiteral(0), [sw, osw])
+		assignment = SequentialSelectedSignalAssignment(_signalTarget(), IntegerLiteral(0), [sw, osw])
 
 		self.assertEqual(2, len(assignment.SelectedWaveforms))
 
 	def test_SignalForceAssignment(self) -> None:
 		"""``s <= force '1';`` (VHDL-2008)"""
-		assignment = SignalForceAssignment(_target(), CharacterLiteral("'1'"))
+		assignment = SignalForceAssignment(_signalTarget(), CharacterLiteral("'1'"))
 
 		self.assertEqual("'1'", str(assignment.Expression))
 
 	def test_SignalReleaseAssignment(self) -> None:
 		"""``s <= release;`` (VHDL-2008) - no expression at all."""
-		assignment = SignalReleaseAssignment(_target())
+		assignment = SignalReleaseAssignment(_signalTarget())
 
 		self.assertIsNotNone(assignment.Target)

--- a/tests/unit/Configuration.py
+++ b/tests/unit/Configuration.py
@@ -11,8 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
-# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Declaration.py
+++ b/tests/unit/Declaration.py
@@ -11,8 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
-# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Interface.py
+++ b/tests/unit/Interface.py
@@ -11,8 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
-# Copyright 2016-2017 Patrick Lehmann - Dresden, Germany                                                               #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #


### PR DESCRIPTION
## Summary

Design discussed and agreed on in chat first, then implemented. Covers the remaining gap in both
the concurrent and sequential statement dispatchers - everything else in both was already complete
(confirmed by a full audit of both dispatchers before starting).

## New shared building blocks (`Common.py`)

Used by both concurrent and sequential forms, since GHDL represents the sequential and concurrent
conditional-signal-assignment/selected-signal-assignment forms with the exact same underlying
structure:

- `ConditionalWaveform` / `ConditionalExpression`: one branch of a conditional assignment
  (waveform-or-expression + optional condition; `None` condition = the final "else" branch).
- `SelectedWaveform` / `OthersSelectedWaveform`, `SelectedExpression` / `OthersSelectedExpression`:
  one alternative of a selected assignment, mirroring the `GenerateCase`/`OthersGenerateCase`
  pattern (choices + associated content) rather than modeling "others" as a special choice value,
  since a selected-assignment "others" alternative - like a generate-case "others" - can't be
  combined with other choices via `|` and is better represented as a distinct alternative kind.

## Fixed two existing stubs (`Concurrent.py`)

Both previously accepted an `expression` parameter not actually suited to what they need to store:
- `ConcurrentConditionalSignalAssignment`: now holds `ConditionalWaveforms`.
- `ConcurrentSelectedSignalAssignment`: now holds the select expression + `SelectedWaveforms`.

## Six new classes (`Sequential.py`)

- `SequentialConditionalVariableAssignment` / `SequentialConditionalSignalAssignment` (VHDL-2008)
- `SequentialSelectedVariableAssignment` / `SequentialSelectedSignalAssignment`
- `SignalForceAssignment` / `SignalReleaseAssignment` (VHDL-2008)

**Note**: `SequentialConditionalVariableAssignment` and `SequentialSelectedVariableAssignment`
inherit `AssignmentMixin` (`Target` only), not `VariableAssignmentMixin` - the latter also promises
a single `Expression` property backed by a single stored value, which doesn't fit either class
(they hold a list of conditional expressions, or a select expression plus a list of selected
expressions). Caught this while implementing, before it became a live `AttributeError` on first
access.

`SequentialVariableAssignment` (simple, non-conditional/selected) was already fully implemented -
not touched here, only the two more elaborate sequential variable-assignment forms are new.

## Testing

Added `tests/unit/Assignment.py`, covering all 9 statement classes plus the building blocks. Full
suite: `117 passed` (was 101), no regressions.

## Companion change

pyGHDL.dom PR translating all 9 statement kinds using these classes.
