### PR TITLE
Add level-1 construction/property/parent-wiring tests across the model

### DIFF
--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -124,6 +124,7 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 				self._generates[statement.NormalizedLabel] = statement
 				statement.IndexStatement()
 			elif isinstance(statement, ConcurrentBlockStatement):
+				self._blocks[statement.NormalizedLabel] = statement
 				self._hierarchy[statement.NormalizedLabel] = statement
 				statement.IndexStatements()
 
@@ -619,7 +620,7 @@ class IfGenerateStatement(GenerateStatement):
 		# Connect namespaces
 		namespace = self._ifBranch._namespace
 		namespace.ParentNamespace = parent._namespace
-		if namespace._name == "":
+		if namespace._name is None:
 			namespace._name = self._normalizedLabel
 
 		for elseBranch in self._elsifBranches:

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -302,7 +302,7 @@ class UnaryExpression(BaseExpression):
 		super().__init__(parent)
 
 		self._operand = operand
-		# operand.Parent = self  # FIXME: operand is provided as None
+		operand.Parent = self
 
 	@readonly
 	def Operand(self):

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -521,7 +521,7 @@ class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin, DocumentedEntityMi
 
 
 @export
-class GenericGroup(InterfaceGroup):
+class GenericGroup(InterfaceGroup, WithGenericsMixin):
 	def __init__(
 		self,
 		genericItems:  Iterable[GenericInterfaceItemMixin],
@@ -565,7 +565,7 @@ class PortGroup(InterfaceGroup, WithPortsMixin):
 
 
 @export
-class ParameterGroup(InterfaceGroup):
+class ParameterGroup(InterfaceGroup, WithParametersMixin):
 	def __init__(
 		self,
 		parameterItems: Iterable[ParameterInterfaceItemMixin],

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -222,7 +222,7 @@ class OpenName(Name):
 	Most likely this name is used in port associations.
 	"""
 	def __init__(self, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__("open", parent)  # TODO: the case of 'OPEN' is not preserved
+		super().__init__("open", parent=parent)  # TODO: the case of 'OPEN' is not preserved
 
 	def __str__(self) -> str:
 		return "open"

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -167,6 +167,8 @@ class DeferredConstant(BaseConstant):
 	) -> None:
 		super().__init__(identifiers, subtype, documentation, parent)
 
+		self._constantReference = None
+
 	@readonly
 	def ConstantReference(self) -> Nullable[Constant]:
 		return self._constantReference

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -380,7 +380,7 @@ class IndexedChoice(SequentialChoice):
 		super().__init__(parent)
 
 		self._expression = expression
-		# expression.Parent = self    # FIXME: received None
+		expression.Parent = self
 
 	@property
 	def Expression(self) -> ExpressionUnion:
@@ -520,6 +520,8 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 	def __init__(self, condition: Nullable[ExpressionUnion] = None, loopLabel: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:  # TODO: is this label (currently str) a Name or a Label class?
 		super().__init__(parent)
 		ConditionalMixin.__init__(self, condition)
+
+		self._loopReference = None
 
 		# TODO: loopLabel
 		# TODO: loop reference -> is it a symbol?

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -162,9 +162,10 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 
 	_protectedType: ProtectedType
 
-	def __init__(self, protectedType: ProtectedType) -> None:
+	def __init__(self, protectedType: Nullable[ProtectedType] = None) -> None:
 		self._protectedType = protectedType
-		protectedType.Parent = self
+		if protectedType is not None:
+			protectedType.Parent = self
 
 	@readonly
 	def ProtectedType(self) -> ProtectedType:

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -63,7 +63,7 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
 
-		_objectVertex = None
+		self._objectVertex = None
 
 
 @export
@@ -88,8 +88,8 @@ class Subtype(BaseType):
 	_range:              Range
 	_resolutionFunction: 'Function'
 
-	def __init__(self, identifier: str, symbol: Symbol, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, symbol: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._type = symbol
 		self._baseType = None
@@ -129,8 +129,8 @@ class RangedScalarType(ScalarType):
 	_leftBound:  ExpressionUnion
 	_rightBound: ExpressionUnion
 
-	def __init__(self, identifier: str, rng: Union[Range, Name], parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, rng: Union[Range, Name], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 		self._range = rng
 
 	@readonly
@@ -158,8 +158,8 @@ class DiscreteTypeMixin(metaclass=ExtendedType, mixin=True):
 class EnumeratedType(ScalarType, DiscreteTypeMixin):
 	_literals: List[EnumerationLiteral]
 
-	def __init__(self, identifier: str, literals: Iterable[EnumerationLiteral], parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, literals: Iterable[EnumerationLiteral], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._literals = []
 		if literals is not None:
@@ -177,8 +177,8 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 
 @export
 class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
-	def __init__(self, identifier: str, rng: Union[Range, Name], parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, rng, parent)
+	def __init__(self, identifier: str, rng: Union[Range, Name], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, rng, documentation, parent)
 
 	def __str__(self) -> str:
 		return f"{self._identifier} is range {self._range}"
@@ -186,8 +186,8 @@ class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
 
 @export
 class RealType(RangedScalarType, NumericTypeMixin):
-	def __init__(self, identifier: str, rng: Union[Range, Name], parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, rng, parent)
+	def __init__(self, identifier: str, rng: Union[Range, Name], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, rng, documentation, parent)
 
 	def __str__(self) -> str:
 		return f"{self._identifier} is range {self._range}"
@@ -204,9 +204,10 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 		rng: Union[Range, Name],
 		primaryUnit: str,
 		units: Iterable[Tuple[str, PhysicalIntegerLiteral]],
+		documentation: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(identifier, rng, parent)
+		super().__init__(identifier, rng, documentation, parent)
 
 		self._primaryUnit = primaryUnit
 
@@ -242,9 +243,10 @@ class ArrayType(CompositeType):
 		identifier: str,
 		indices: Iterable,
 		elementSubtype: Symbol,
+		documentation: Nullable[str] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
-		super().__init__(identifier, parent)
+		super().__init__(identifier, documentation, parent)
 
 		self._dimensions = []
 		for index in indices:
@@ -289,8 +291,8 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 class RecordType(CompositeType):
 	_elements: List[RecordTypeElement]
 
-	def __init__(self, identifier: str, elements: Nullable[Iterable[RecordTypeElement]] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, elements: Nullable[Iterable[RecordTypeElement]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._elements = []  # TODO: convert to dict
 		if elements is not None:
@@ -310,8 +312,8 @@ class RecordType(CompositeType):
 class ProtectedType(FullType):
 	_methods: List[Union['Procedure', 'Function']]
 
-	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._methods = []
 		if methods is not None:
@@ -328,8 +330,8 @@ class ProtectedType(FullType):
 class ProtectedTypeBody(FullType):
 	_methods: List[Union['Procedure', 'Function']]
 
-	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._methods = []
 		if declaredItems is not None:
@@ -347,8 +349,8 @@ class ProtectedTypeBody(FullType):
 class AccessType(FullType):
 	_designatedSubtype: Symbol
 
-	def __init__(self, identifier: str, designatedSubtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, designatedSubtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._designatedSubtype = designatedSubtype
 		designatedSubtype.Parent = self
@@ -365,8 +367,8 @@ class AccessType(FullType):
 class FileType(FullType):
 	_designatedSubtype: Symbol
 
-	def __init__(self, identifier: str, designatedSubtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
-		super().__init__(identifier, parent)
+	def __init__(self, identifier: str, designatedSubtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(identifier, documentation, parent)
 
 		self._designatedSubtype = designatedSubtype
 		designatedSubtype.Parent = self
@@ -376,4 +378,4 @@ class FileType(FullType):
 		return self._designatedSubtype
 
 	def __str__(self) -> str:
-		return f"{self._identifier} is access {self._designatedSubtype}"
+		return f"{self._identifier} is file of {self._designatedSubtype}"

--- a/tests/unit/Base.py
+++ b/tests/unit/Base.py
@@ -1,0 +1,248 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Tests for pyVHDLModel.Base.
+
+Level-1 tests: instantiate each mixin's simplest real consumer and check construction, property
+access and parent-wiring. A mixin has no independent existence (mixin classes here can't be
+instantiated standalone - they rely on the composed class's slots), so each is tested through its
+narrowest real consumer rather than a synthetic stand-in class.
+
+Mixins already fully exercised elsewhere are intentionally not repeated here:
+
+- ``NamedEntityMixin``, ``ConditionalMixin`` - covered via tests/unit/Hierarchy.py and
+  tests/unit/Assignment.py (``ConditionalWaveform``) respectively.
+- ``ChoicesMixin`` with a non-empty choice list - covered via tests/unit/Assignment.py
+  (``SelectedWaveform`` et al.). Only the ``choices=None`` default path is added here.
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Base        import Direction, Mode, ModelEntity, Range, WaveformElement
+from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral
+from pyVHDLModel.Interface   import InterfaceGroup
+from pyVHDLModel.Sequential  import IfBranch, ElsifBranch, ElseBranch, SequentialReportStatement, SequentialAssertStatement, SequentialCase
+from pyVHDLModel.Concurrent  import ConcurrentBlockStatement
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class DirectionEnum(TestCase):
+	def test_To(self) -> None:
+		self.assertEqual("to", str(Direction.To))
+
+	def test_DownTo(self) -> None:
+		self.assertEqual("downto", str(Direction.DownTo))
+
+
+class ModeEnum(TestCase):
+	def test_AllValues(self) -> None:
+		"""Every ``Mode`` value has a dedicated formatting slot in ``Mode.__str__``'s lookup tuple."""
+		expected = {
+			Mode.Default: "",
+			Mode.In:      "in",
+			Mode.Out:     "out",
+			Mode.InOut:   "inout",
+			Mode.Buffer:  "buffer",
+			Mode.Linkage: "linkage",
+		}
+
+		for mode, text in expected.items():
+			self.assertEqual(text, str(mode))
+
+
+class ModelEntities(TestCase):
+	def test_NoParent(self) -> None:
+		entity = ModelEntity()
+
+		self.assertIsNone(entity.Parent)
+
+	def test_ConstructedWithParent(self) -> None:
+		parent = ModelEntity()
+		entity = ModelEntity(parent=parent)
+
+		self.assertIs(parent, entity.Parent)
+
+	def test_ParentSetter(self) -> None:
+		parent = ModelEntity()
+		entity = ModelEntity()
+		entity.Parent = parent
+
+		self.assertIs(parent, entity.Parent)
+
+	def test_ParentSetter_RejectsNone(self) -> None:
+		"""Unlike the constructor (where omitting ``parent`` is normal for a not-yet-attached root), the
+		``Parent`` setter rejects ``None`` outright - it's only ever used to attach an entity to a real
+		parent after the fact."""
+		entity = ModelEntity(parent=ModelEntity())
+
+		with self.assertRaises(ValueError):
+			entity.Parent = None
+
+
+class OptionallyNamedEntity(TestCase):
+	"""``InterfaceGroup`` is the only current consumer of ``OptionallyNamedEntityMixin``."""
+
+	def test_WithName(self) -> None:
+		group = InterfaceGroup("generics")
+
+		self.assertEqual("generics", group.Identifier)
+		self.assertEqual("generics", group.NormalizedIdentifier)
+
+	def test_WithoutName(self) -> None:
+		group = InterfaceGroup()
+
+		self.assertIsNone(group.Identifier)
+		self.assertIsNone(group.NormalizedIdentifier)
+
+	def test_NameIsNormalized(self) -> None:
+		group = InterfaceGroup("Generics")
+
+		self.assertEqual("generics", group.NormalizedIdentifier)
+
+
+class BranchMixins(TestCase):
+	"""``IfBranch``/``ElsifBranch``/``ElseBranch`` are the only consumers of ``BranchMixin``,
+	``ConditionalBranchMixin`` and the ``If-``/``Elsif-``/``ElseBranchMixin`` variants."""
+
+	def test_IfBranch(self) -> None:
+		condition = IntegerLiteral(1)
+		branch = IfBranch(condition)
+
+		self.assertIs(condition, branch.Condition)
+		self.assertEqual(0, len(branch.Statements))
+
+	def test_ElsifBranch(self) -> None:
+		condition = IntegerLiteral(1)
+		branch = ElsifBranch(condition)
+
+		self.assertIs(condition, branch.Condition)
+
+	def test_ElseBranch(self) -> None:
+		"""The ``else`` branch has no condition at all - ``ElseBranchMixin`` doesn't inherit
+		``ConditionalMixin``."""
+		branch = ElseBranch()
+
+		self.assertEqual(0, len(branch.Statements))
+
+
+class ReportAndAssertStatementMixins(TestCase):
+	def test_ReportStatement_MessageAndSeverity(self) -> None:
+		message = CharacterLiteral("'a'")
+		severity = IntegerLiteral(1)
+		statement = SequentialReportStatement(message, severity)
+
+		self.assertIs(message, statement.Message)
+		self.assertIs(severity, statement.Severity)
+
+	def test_ReportStatement_MessageOnly(self) -> None:
+		"""``severity`` genuinely defaults to omitted in the grammar (``report "msg";`` without a
+		``severity`` clause)."""
+		message = CharacterLiteral("'a'")
+		statement = SequentialReportStatement(message)
+
+		self.assertIs(message, statement.Message)
+		self.assertIsNone(statement.Severity)
+
+	def test_AssertStatement(self) -> None:
+		"""``AssertStatementMixin`` adds a required ``Condition`` on top of ``ReportStatementMixin``'s
+		optional message/severity."""
+		condition = IntegerLiteral(1)
+		message = CharacterLiteral("'a'")
+		statement = SequentialAssertStatement(condition, message)
+
+		self.assertIs(condition, statement.Condition)
+		self.assertIs(message, statement.Message)
+		self.assertIsNone(statement.Severity)
+
+
+class BlockStatementMixinHost(TestCase):
+	"""``ConcurrentBlockStatement`` is the only consumer of ``BlockStatementMixin``. Also covers
+	``LabeledEntityMixin.NormalizedLabel``, which no other current test reads (only ``.Label``)."""
+
+	def test_MinimalBlock(self) -> None:
+		block = ConcurrentBlockStatement("BLK")
+
+		self.assertEqual("BLK", block.Label)
+		self.assertEqual("blk", block.NormalizedLabel)
+
+
+class ChoicesMixinHost(TestCase):
+	def test_NoChoices(self) -> None:
+		"""``choices=None`` (the default) - the non-empty-list path is already covered via
+		tests/unit/Assignment.py's ``SelectedWaveform``/``SelectedExpression`` tests."""
+		case = SequentialCase()
+
+		self.assertEqual(0, len(case.Choices))
+
+
+class Ranges(TestCase):
+	"""``Range`` (``3 downto 0``) - a concrete class defined directly in Base.py, not a mixin."""
+
+	def test_Construction(self) -> None:
+		left = IntegerLiteral(3)
+		right = IntegerLiteral(0)
+		range_ = Range(left, right, Direction.DownTo)
+
+		self.assertIs(left, range_.LeftBound)
+		self.assertIs(right, range_.RightBound)
+		self.assertIs(Direction.DownTo, range_.Direction)
+		self.assertIs(range_, left.Parent)
+		self.assertIs(range_, right.Parent)
+
+	def test_ToString(self) -> None:
+		range_ = Range(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
+
+		self.assertEqual("0 to 7", str(range_))
+
+
+class WaveformElements(TestCase):
+	"""``WaveformElement`` (``'1' after 5 ns``) - a concrete class defined directly in Base.py, not a
+	mixin. tests/unit/Assignment.py already constructs these but never reads ``.Expression``/
+	``.After``."""
+
+	def test_WithoutAfter(self) -> None:
+		expression = CharacterLiteral("'1'")
+		element = WaveformElement(expression)
+
+		self.assertIs(expression, element.Expression)
+		self.assertIsNone(element.After)
+
+	def test_WithAfter(self) -> None:
+		expression = CharacterLiteral("'1'")
+		after = IntegerLiteral(5)
+		element = WaveformElement(expression, after)
+
+		self.assertIs(after, element.After)
+		self.assertIs(element, after.Parent)

--- a/tests/unit/Concurrent.py
+++ b/tests/unit/Concurrent.py
@@ -1,0 +1,397 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Tests for pyVHDLModel.Concurrent - the concurrent statement kinds not already covered by
+tests/unit/Assignment.py (conditional/selected signal assignments) or tests/unit/Base.py
+(ConcurrentBlockStatement's BlockStatementMixin/LabeledEntityMixin wiring).
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Base        import Direction, Range
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import (
+	ComponentInstantiationSymbol, EntityInstantiationSymbol, ArchitectureSymbol,
+	ConfigurationInstantiationSymbol, SignalSymbol, Symbol, PossibleReference, EntitySymbol,
+)
+from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral
+from pyVHDLModel.Association import GenericAssociationItem, PortAssociationItem
+from pyVHDLModel.Base        import WaveformElement
+from pyVHDLModel.DesignUnit  import Architecture
+from pyVHDLModel.Concurrent  import (
+	ComponentInstantiation, EntityInstantiation, ConfigurationInstantiation,
+	ProcessStatement, ConcurrentProcedureCall, ConcurrentBlockStatement,
+	IfGenerateBranch, ElsifGenerateBranch, ElseGenerateBranch,
+	GenerateStatement, IfGenerateStatement,
+	IndexedGenerateChoice, RangedGenerateChoice, GenerateCase, OthersGenerateCase, CaseGenerateStatement,
+	ForGenerateStatement, ConcurrentSimpleSignalAssignment, ConcurrentAssertStatement,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _entitySymbol(name: str = "e") -> EntitySymbol:
+	return EntitySymbol(SimpleName(name))
+
+
+class Instantiations(TestCase):
+	def test_ComponentInstantiation(self) -> None:
+		componentSymbol = ComponentInstantiationSymbol(SimpleName("comp"))
+		generic = GenericAssociationItem(SimpleName("G"), IntegerLiteral(1))
+		port = PortAssociationItem(SimpleName("p"), SimpleName("s"))
+		instance = ComponentInstantiation("inst", componentSymbol, [generic], [port])
+
+		self.assertIs(componentSymbol, instance.Component)
+		self.assertIs(instance, componentSymbol.Parent)
+		self.assertEqual(1, len(instance.GenericAssociationItems))
+		self.assertIs(instance, generic.Parent)
+		self.assertEqual(1, len(instance.PortAssociationItems))
+		self.assertIs(instance, port.Parent)
+
+	def test_EntityInstantiation_WithArchitecture(self) -> None:
+		entitySymbol = EntityInstantiationSymbol(SimpleName("ent"))
+		architectureSymbol = ArchitectureSymbol(SimpleName("rtl"))
+		instance = EntityInstantiation("inst", entitySymbol, architectureSymbol)
+
+		self.assertIs(entitySymbol, instance.Entity)
+		self.assertIs(architectureSymbol, instance.Architecture)
+		self.assertIs(instance, architectureSymbol.Parent)
+
+	def test_EntityInstantiation_WithoutArchitecture(self) -> None:
+		instance = EntityInstantiation("inst", EntityInstantiationSymbol(SimpleName("ent")))
+
+		self.assertIsNone(instance.Architecture)
+
+	def test_ConfigurationInstantiation(self) -> None:
+		configurationSymbol = ConfigurationInstantiationSymbol(SimpleName("cfg"))
+		instance = ConfigurationInstantiation("inst", configurationSymbol)
+
+		self.assertIs(configurationSymbol, instance.Configuration)
+		self.assertIs(instance, configurationSymbol.Parent)
+
+
+class ProcessStatements(TestCase):
+	def test_Empty(self) -> None:
+		"""``proc: process begin end process;``"""
+		process = ProcessStatement("proc")
+
+		self.assertEqual("proc", process.Label)
+		self.assertIsNone(process.SensitivityList)
+		self.assertEqual(0, len(process.DeclaredItems))
+		self.assertEqual(0, len(process.Statements))
+
+	def test_WithSensitivityList(self) -> None:
+		"""``proc: process(clk) begin end process;``"""
+		clk = SimpleName("clk")
+		process = ProcessStatement("proc", sensitivityList=[clk])
+
+		self.assertEqual(1, len(process.SensitivityList))
+		self.assertIs(clk, process.SensitivityList[0])
+
+
+class ConcurrentProcedureCalls(TestCase):
+	def test_Construction(self) -> None:
+		procedureName = Symbol(SimpleName("proc"), PossibleReference.Procedure)
+		call = ConcurrentProcedureCall("lbl", procedureName)
+
+		self.assertIs(procedureName, call.Procedure)
+		self.assertEqual("lbl", call.Label)
+
+
+class ConcurrentBlockStatements(TestCase):
+	"""``BlockStatementMixin``/``LabeledEntityMixin`` wiring is already covered in tests/unit/Base.py;
+	this covers the block-specific state (port items, declared items/statements via
+	``ConcurrentDeclarationRegionMixin``/``ConcurrentStatementsMixin``) instead."""
+
+	def test_WithPortItems(self) -> None:
+		portItem = PortAssociationItem(SimpleName("p"), SimpleName("s"))
+		block = ConcurrentBlockStatement("blk", portItems=[portItem])
+
+		self.assertEqual(1, len(block.PortItems))
+		self.assertIs(portItem, block.PortItems[0])
+		self.assertIs(block, portItem.Parent)
+
+	def test_NestedBlock_ConnectsNamespaceOnParentAssignment(self) -> None:
+		outer = ConcurrentBlockStatement("outer")
+		inner = ConcurrentBlockStatement("inner")
+		inner.Parent = outer
+
+		self.assertIs(outer, inner.Parent)
+		self.assertIs(outer._namespace, inner._namespace.ParentNamespace)
+
+
+class GenerateBranches(TestCase):
+	def test_IfGenerateBranch(self) -> None:
+		condition = IntegerLiteral(1)
+		branch = IfGenerateBranch(condition, alternativeLabel="LBL")
+
+		self.assertIs(condition, branch.Condition)
+		self.assertEqual("LBL", branch.AlternativeLabel)
+		self.assertEqual("lbl", branch.NormalizedAlternativeLabel)
+
+	def test_IfGenerateBranch_NoLabel(self) -> None:
+		branch = IfGenerateBranch(IntegerLiteral(1))
+
+		self.assertIsNone(branch.AlternativeLabel)
+		self.assertIsNone(branch.NormalizedAlternativeLabel)
+
+	def test_ElsifGenerateBranch(self) -> None:
+		condition = IntegerLiteral(1)
+		branch = ElsifGenerateBranch(condition)
+
+		self.assertIs(condition, branch.Condition)
+
+	def test_ElseGenerateBranch(self) -> None:
+		branch = ElseGenerateBranch()
+
+		self.assertEqual(0, len(branch.Statements))
+
+
+class GenerateStatements(TestCase):
+	def test_AbstractMethodsRaise(self) -> None:
+		"""``GenerateStatement`` itself is meant to always be used through a concrete subclass -
+		``IterateInstantiations``/``IndexStatement`` are placeholders raising ``NotImplementedError``
+		if a subclass doesn't override them (none of the three real subclasses omit them, so this only
+		matters if constructed directly, as done here)."""
+		statement = GenerateStatement("gen")
+
+		with self.assertRaises(NotImplementedError):
+			next(statement.IterateInstantiations())
+
+		with self.assertRaises(NotImplementedError):
+			statement.IndexStatement()
+
+
+class IfGenerateStatements(TestCase):
+	def test_IfOnly(self) -> None:
+		ifBranch = IfGenerateBranch(IntegerLiteral(1))
+		statement = IfGenerateStatement("gen", ifBranch)
+
+		self.assertIs(ifBranch, statement.IfBranch)
+		self.assertIs(statement, ifBranch.Parent)
+		self.assertEqual(0, len(statement.ElsifBranches))
+		self.assertIsNone(statement.ElseBranch)
+
+	def test_IfElsifElse_ConnectsNamespaces(self) -> None:
+		"""Namespace-connection happens in the ``Parent`` property setter override, not the
+		constructor - passing ``parent=`` to ``__init__`` sets ``self._parent`` directly and never
+		goes through the overridden setter, so this must assign ``.Parent`` after construction.
+
+		Also a regression test: the fallback that names the if-branch's namespace after the
+		statement's own label (for the common, unlabelled-branch case) compared
+		``namespace._name == ""``, but an unlabelled ``GenerateBranch`` always constructs its
+		namespace with ``_normalizedAlternativeLabel``, which defaults to ``None`` - not ``""`` - so
+		the fallback never actually fired. Fixed to compare against ``None``."""
+		architecture = Architecture("rtl", _entitySymbol())
+		ifBranch = IfGenerateBranch(IntegerLiteral(1))
+		elsifBranch = ElsifGenerateBranch(IntegerLiteral(2))
+		elseBranch = ElseGenerateBranch()
+		statement = IfGenerateStatement("gen", ifBranch, [elsifBranch], elseBranch)
+
+		statement.Parent = architecture
+
+		self.assertIs(architecture._namespace, ifBranch._namespace.ParentNamespace)
+		self.assertIs(architecture._namespace, elsifBranch._namespace.ParentNamespace)
+		self.assertIs(architecture._namespace, elseBranch._namespace.ParentNamespace)
+		self.assertEqual("gen", ifBranch._namespace._name)
+
+	def test_IterateInstantiations_And_IndexStatement(self) -> None:
+		componentSymbol = ComponentInstantiationSymbol(SimpleName("comp"))
+		instance = ComponentInstantiation("inst", componentSymbol)
+		ifBranch = IfGenerateBranch(IntegerLiteral(1), statements=[instance])
+		statement = IfGenerateStatement("gen", ifBranch)
+
+		statement.IndexStatement()
+		instantiations = list(statement.IterateInstantiations())
+
+		self.assertEqual(1, len(instantiations))
+		self.assertIs(instance, instantiations[0])
+
+
+class GenerateChoices(TestCase):
+	def test_IndexedGenerateChoice(self) -> None:
+		expression = IntegerLiteral(0)
+		choice = IndexedGenerateChoice(expression)
+
+		self.assertIs(expression, choice.Expression)
+		self.assertIs(choice, expression.Parent)
+		self.assertEqual("0", str(choice))
+
+	def test_RangedGenerateChoice(self) -> None:
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		choice = RangedGenerateChoice(rng)
+
+		self.assertIs(rng, choice.Range)
+		self.assertEqual("0 to 3", str(choice))
+
+
+class GenerateCases(TestCase):
+	def test_GenerateCase(self) -> None:
+		choice = IndexedGenerateChoice(IntegerLiteral(0))
+		case = GenerateCase([choice])
+
+		self.assertEqual(1, len(case.Choices))
+		self.assertEqual("when 0 =>", str(case))
+
+	def test_OthersGenerateCase(self) -> None:
+		case = OthersGenerateCase()
+
+		self.assertEqual("when others =>", str(case))
+
+
+class CaseGenerateStatements(TestCase):
+	def test_Construction(self) -> None:
+		expression = IntegerLiteral(0)
+		case = GenerateCase([IndexedGenerateChoice(IntegerLiteral(0))])
+		statement = CaseGenerateStatement("gen", expression, [case])
+
+		self.assertIs(expression, statement.SelectExpression)
+		self.assertIs(statement, expression.Parent)
+		self.assertEqual(1, len(statement.Cases))
+		self.assertIs(case, statement.Cases[0])
+		self.assertIs(statement, case.Parent)
+
+	def test_ConnectsNamespaceOnParentAssignment(self) -> None:
+		architecture = Architecture("rtl", _entitySymbol())
+		case = GenerateCase([IndexedGenerateChoice(IntegerLiteral(0))])
+		statement = CaseGenerateStatement("gen", IntegerLiteral(0), [case])
+
+		statement.Parent = architecture
+
+		self.assertIs(architecture._namespace, case._namespace.ParentNamespace)
+
+	def test_IterateInstantiations_And_IndexStatement(self) -> None:
+		componentSymbol = ComponentInstantiationSymbol(SimpleName("comp"))
+		instance = ComponentInstantiation("inst", componentSymbol)
+		case = GenerateCase([IndexedGenerateChoice(IntegerLiteral(0))], statements=[instance])
+		statement = CaseGenerateStatement("gen", IntegerLiteral(0), [case])
+
+		statement.IndexStatement()
+		instantiations = list(statement.IterateInstantiations())
+
+		self.assertEqual(1, len(instantiations))
+		self.assertIs(instance, instantiations[0])
+
+
+class ForGenerateStatements(TestCase):
+	def test_Construction(self) -> None:
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		statement = ForGenerateStatement("gen", "i", rng)
+
+		self.assertEqual("i", statement.LoopIndex)
+		self.assertIs(rng, statement.Range)
+		self.assertIs(statement, rng.Parent)
+
+	def test_ConnectsNamespaceOnParentAssignment(self) -> None:
+		architecture = Architecture("rtl", _entitySymbol())
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		statement = ForGenerateStatement("gen", "i", rng)
+
+		statement.Parent = architecture
+
+		self.assertIs(architecture._namespace, statement._namespace.ParentNamespace)
+
+	def test_IterateInstantiations_And_IndexStatement(self) -> None:
+		componentSymbol = ComponentInstantiationSymbol(SimpleName("comp"))
+		instance = ComponentInstantiation("inst", componentSymbol)
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		statement = ForGenerateStatement("gen", "i", rng, statements=[instance])
+
+		statement.IndexStatement()
+		instantiations = list(statement.IterateInstantiations())
+
+		self.assertEqual(1, len(instantiations))
+		self.assertIs(instance, instantiations[0])
+
+
+class ConcurrentSimpleSignalAssignments(TestCase):
+	def test_Construction(self) -> None:
+		"""``s <= '1';``"""
+		target = SignalSymbol(SimpleName("s"))
+		waveformElement = WaveformElement(CharacterLiteral("'1'"))
+		assignment = ConcurrentSimpleSignalAssignment("lbl", target, [waveformElement])
+
+		self.assertIs(target, assignment.Target)
+		self.assertEqual(1, len(assignment.Waveform))
+		self.assertIs(waveformElement, assignment.Waveform[0])
+
+
+class ConcurrentAssertStatements(TestCase):
+	def test_Full(self) -> None:
+		condition = IntegerLiteral(1)
+		message = CharacterLiteral("'a'")
+		severity = IntegerLiteral(2)
+		statement = ConcurrentAssertStatement(condition, message, severity, label="lbl")
+
+		self.assertIs(condition, statement.Condition)
+		self.assertIs(message, statement.Message)
+		self.assertIs(severity, statement.Severity)
+		self.assertEqual("lbl", statement.Label)
+
+	def test_NoSeverityNoLabel(self) -> None:
+		statement = ConcurrentAssertStatement(IntegerLiteral(1), CharacterLiteral("'a'"))
+
+		self.assertIsNone(statement.Severity)
+		self.assertIsNone(statement.Label)
+
+
+class ConcurrentStatementsMixinIndexing(TestCase):
+	"""Tested via ``Architecture`` (the canonical ``ConcurrentDeclarationRegionMixin``/
+	``ConcurrentStatementsMixin`` host - see tests/unit/DesignUnit.py)."""
+
+	def test_IndexStatements_BucketsByKind(self) -> None:
+		entitySymbol = _entitySymbol()
+		instance = ComponentInstantiation("inst", ComponentInstantiationSymbol(SimpleName("comp")))
+		block = ConcurrentBlockStatement("blk")
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		generate = ForGenerateStatement("gen", "i", rng)
+
+		architecture = Architecture("rtl", entitySymbol, statements=[instance, block, generate])
+		architecture.IndexStatements()
+
+		self.assertIs(instance, architecture._instantiations["inst"])
+		self.assertIs(block, architecture._hierarchy["blk"])
+		self.assertIs(generate, architecture._generates["gen"])
+
+	def test_IterateInstantiations_RecursesIntoBlocksAndGenerates(self) -> None:
+		entitySymbol = _entitySymbol()
+		nestedInstance = ComponentInstantiation("nested_inst", ComponentInstantiationSymbol(SimpleName("comp")))
+		block = ConcurrentBlockStatement("blk", statements=[nestedInstance])
+
+		architecture = Architecture("rtl", entitySymbol, statements=[block])
+		architecture.IndexStatements()
+		instantiations = list(architecture.IterateInstantiations())
+
+		self.assertEqual(1, len(instantiations))
+		self.assertIs(nestedInstance, instantiations[0])

--- a/tests/unit/DesignUnit.py
+++ b/tests/unit/DesignUnit.py
@@ -1,0 +1,352 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Tests for pyVHDLModel.DesignUnit and pyVHDLModel.Regions.
+
+``ConcurrentDeclarationRegionMixin`` (Regions.py) is shared by ``Package``, ``PackageBody``,
+``Entity``, ``Architecture`` and (via Common.py/Concurrent.py, tested in their own slice)
+``ConcurrentBlockStatement`` and the generate-statement branches. Its actual indexing behaviour is
+tested once here via ``Architecture`` as the canonical host; every other consumer below gets only a
+one-line smoke test confirming the mixin is wired up.
+"""
+from unittest import TestCase
+
+from pyVHDLModel            import VHDLModelException
+from pyVHDLModel.Base       import ModelEntity
+from pyVHDLModel.Name       import SimpleName, SelectedName
+from pyVHDLModel.Symbol     import EntitySymbol, PackageSymbol, LibraryReferenceSymbol, SimpleSubtypeSymbol
+from pyVHDLModel.Object     import Constant, Signal, Variable, SharedVariable, File, DeferredConstant
+from pyVHDLModel.Type       import FullType, Subtype
+from pyVHDLModel.Subprogram import Function, Procedure
+from pyVHDLModel.DesignUnit import (
+	Reference, LibraryClause, UseClause, ContextReference,
+	DesignUnit, PrimaryUnit, SecondaryUnit, Context,
+	Package, PackageBody, Entity, Architecture, Component, Configuration,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _entitySymbol(name: str = "ent") -> EntitySymbol:
+	return EntitySymbol(SimpleName(name))
+
+
+class References(TestCase):
+	def test_LibraryClause(self) -> None:
+		symbol = LibraryReferenceSymbol(SimpleName("ieee"))
+		clause = LibraryClause([symbol])
+
+		self.assertEqual(1, len(clause.Symbols))
+		self.assertIs(symbol, clause.Symbols[0])
+
+	def test_UseClause(self) -> None:
+		"""``UseClause``/``ContextReference`` add no behaviour of their own over the generic
+		``Reference`` base - only ``LibraryClause`` overrides ``Symbols``' type hint."""
+		clause = UseClause([])
+
+		self.assertIsInstance(clause, Reference)
+
+	def test_ContextReference(self) -> None:
+		reference = ContextReference([])
+
+		self.assertIsInstance(reference, Reference)
+
+
+class DesignUnits(TestCase):
+	"""``DesignUnit`` itself has no public non-abstract-in-spirit subclass without extra state, so
+	it's tested directly via its own class rather than through e.g. ``Context``."""
+
+	def test_NoContextItems(self) -> None:
+		unit = DesignUnit("u")
+
+		self.assertEqual("u", unit.Identifier)
+		self.assertEqual(0, len(unit.ContextItems))
+		self.assertEqual(0, len(unit.LibraryReferences))
+		self.assertEqual(0, len(unit.PackageReferences))
+		self.assertEqual(0, len(unit.ContextReferences))
+		self.assertIsNone(unit.Document)
+		self.assertIsNone(unit.DependencyVertex)
+		self.assertIsNone(unit.HierarchyVertex)
+
+	def test_ContextItemsAreSeparatedByKind(self) -> None:
+		library = LibraryClause([LibraryReferenceSymbol(SimpleName("ieee"))])
+		use = UseClause([])
+		context = ContextReference([])
+		unit = DesignUnit("u", [library, use, context])
+
+		self.assertEqual(3, len(unit.ContextItems))
+		self.assertEqual([library], unit.LibraryReferences)
+		self.assertEqual([use], unit.PackageReferences)
+		self.assertEqual([context], unit.ContextReferences)
+
+	def test_DocumentSetter(self) -> None:
+		unit = DesignUnit("u")
+		document = object()
+		unit.Document = document
+
+		self.assertIs(document, unit.Document)
+
+	def test_LibrarySetter(self) -> None:
+		"""``Library`` is just a renamed view onto the same ``_parent`` field every ``ModelEntity``
+		has."""
+		unit = DesignUnit("u")
+		library = ModelEntity()
+		unit.Library = library
+
+		self.assertIs(library, unit.Library)
+		self.assertIs(library, unit.Parent)
+
+
+class MarkerSubclasses(TestCase):
+	def test_PrimaryUnit(self) -> None:
+		unit = PrimaryUnit("u")
+
+		self.assertEqual("u", unit.Identifier)
+
+	def test_SecondaryUnit(self) -> None:
+		unit = SecondaryUnit("u")
+
+		self.assertEqual("u", unit.Identifier)
+
+
+class Contexts(TestCase):
+	def test_NoReferences(self) -> None:
+		context = Context("ctx")
+
+		self.assertEqual(0, len(context.LibraryReferences))
+		self.assertEqual(0, len(context.PackageReferences))
+		self.assertEqual(0, len(context.ContextReferences))
+
+	def test_ReferencesAreSeparatedByKind(self) -> None:
+		library = LibraryClause([LibraryReferenceSymbol(SimpleName("ieee"))])
+		use = UseClause([])
+		contextReference = ContextReference([])
+		context = Context("ctx", [library, use, contextReference])
+
+		self.assertEqual([library], context.LibraryReferences)
+		self.assertEqual([use], context.PackageReferences)
+		self.assertEqual([contextReference], context.ContextReferences)
+		self.assertIs(context, library.Parent)
+
+	def test_UnknownReferenceKind_Raises(self) -> None:
+		"""``VHDLModelException()`` is raised with no message at all (``# FIXME: needs exception
+		message`` in the source) - documented as a known, low-priority cosmetic gap; locked in here as
+		current behaviour. Uses a bare ``ModelEntity`` (not ``object()``) since the ``.Parent = self``
+		assignment a few lines above the kind-check runs first and needs a real settable ``Parent``."""
+		with self.assertRaises(VHDLModelException):
+			Context("ctx", [ModelEntity()])
+
+
+class Packages(TestCase):
+	def test_Minimal(self) -> None:
+		package = Package("pkg")
+
+		self.assertEqual(0, len(package.DeclaredItems))
+		self.assertEqual(0, len(package.DeferredConstants))
+		self.assertEqual(0, len(package.Components))
+		self.assertIsNone(package.PackageBody)
+
+	def test_IndexDeferredConstant(self) -> None:
+		"""``Package`` overrides ``_IndexOtherDeclaredItem`` to additionally index deferred constants
+		and components - not covered by the generic ``IndexDeclaredItems`` in Regions.py, so tested
+		here specifically."""
+		deferredConstant = DeferredConstant(["BITS"], SimpleSubtypeSymbol(SimpleName("positive")))
+		package = Package("pkg", declaredItems=[deferredConstant])
+		package.IndexDeclaredItems()
+
+		self.assertIs(deferredConstant, package.DeferredConstants["bits"])
+
+	def test_IndexComponent(self) -> None:
+		component = Component("comp")
+		package = Package("pkg", declaredItems=[component])
+		package.IndexDeclaredItems()
+
+		self.assertIs(component, package.Components["comp"])
+
+
+class PackageBodies(TestCase):
+	def test_Minimal(self) -> None:
+		packageSymbol = PackageSymbol(SimpleName("pkg"))
+		body = PackageBody(packageSymbol)
+
+		self.assertIs(packageSymbol, body.Package)
+		self.assertIs(body, packageSymbol.Parent)
+		self.assertEqual(0, len(body.DeclaredItems))
+
+	def test_LinkDeclaredItemsToPackage_IsANoOpStub(self) -> None:
+		body = PackageBody(PackageSymbol(SimpleName("pkg")))
+
+		self.assertIsNone(body.LinkDeclaredItemsToPackage())
+
+
+class Entities(TestCase):
+	def test_Minimal(self) -> None:
+		entity = Entity("ent")
+
+		self.assertEqual(0, len(entity.DeclaredItems))
+		self.assertEqual(0, len(entity.Statements))
+		self.assertEqual(0, len(entity.Architectures))
+
+
+class Architectures(TestCase):
+	def test_Minimal(self) -> None:
+		entitySymbol = _entitySymbol()
+		architecture = Architecture("rtl", entitySymbol)
+
+		self.assertIs(entitySymbol, architecture.Entity)
+		self.assertIs(architecture, entitySymbol.Parent)
+		self.assertEqual(0, len(architecture.DeclaredItems))
+		self.assertEqual(0, len(architecture.Statements))
+
+	def test_RegionStartsEmpty(self) -> None:
+		architecture = Architecture("rtl", _entitySymbol())
+
+		self.assertEqual(0, len(architecture.Types))
+		self.assertEqual(0, len(architecture.Subtypes))
+		self.assertEqual(0, len(architecture.Constants))
+		self.assertEqual(0, len(architecture.Signals))
+		self.assertEqual(0, len(architecture.SharedVariables))
+		self.assertEqual(0, len(architecture.Files))
+		self.assertEqual(0, len(architecture.Functions))
+		self.assertEqual(0, len(architecture.Procedures))
+		self.assertEqual(0, len(architecture.Components))
+
+	def test_IndexDeclaredItems(self) -> None:
+		fullType = FullType("my_type")
+		subtype = Subtype("my_subtype", SimpleSubtypeSymbol(SimpleName("bit")))
+		constant = Constant(["C"], SimpleSubtypeSymbol(SimpleName("natural")))
+		signal = Signal(["s"], SimpleSubtypeSymbol(SimpleName("bit")))
+		sharedVariable = SharedVariable(["sv"], SimpleSubtypeSymbol(SimpleName("natural")))
+		file = File(["f"], SimpleSubtypeSymbol(SimpleName("text")))
+		function = Function("f_func", SimpleSubtypeSymbol(SimpleName("integer")))
+		procedure = Procedure("p_proc")
+
+		architecture = Architecture(
+			"rtl", _entitySymbol(),
+			declaredItems=[fullType, subtype, constant, signal, sharedVariable, file, function, procedure],
+		)
+		architecture.IndexDeclaredItems()
+
+		self.assertIs(fullType, architecture.Types["my_type"])
+		self.assertIs(subtype, architecture.Subtypes["my_subtype"])
+		self.assertIs(constant, architecture.Constants["c"])
+		self.assertIs(signal, architecture.Signals["s"])
+		self.assertIs(sharedVariable, architecture.SharedVariables["sv"])
+		self.assertIs(file, architecture.Files["f"])
+		self.assertIs(function, architecture.Functions["f_func"])
+		self.assertIs(procedure, architecture.Procedures["p_proc"])
+
+	def test_IndexDeclaredItems_AlsoPopulatesNamespace(self) -> None:
+		constant = Constant(["C"], SimpleSubtypeSymbol(SimpleName("natural")))
+		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[constant])
+		architecture.IndexDeclaredItems()
+
+		self.assertIs(constant, architecture._namespace.Elements()["c"])
+
+	def test_IndexDeclaredItems_VariablesAreNotYetIndexed(self) -> None:
+		"""Still-open gap (documented in Regions.py's own TODO): variables declared directly in a
+		concurrent declaration region raise a warning instead of being indexed anywhere - locked in as
+		current behaviour, not a regression."""
+		variable = Variable(["v"], SimpleSubtypeSymbol(SimpleName("natural")))
+		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[variable])
+
+		architecture.IndexDeclaredItems()  # must not raise, only warn
+
+	def test_IndexDeclaredItems_OverloadsCollide(self) -> None:
+		"""Regression-tracking test, not a fix: see Findings.md - ``Functions``/``Procedures`` are
+		typed as ``Dict[str, Dict[str, Function]]`` (name -> signature -> subprogram) but indexed as a
+		flat ``Dict[str, Function]``, so two overloads sharing a name silently collide into one entry."""
+		overload1 = Function("f", SimpleSubtypeSymbol(SimpleName("integer")))
+		overload2 = Function("f", SimpleSubtypeSymbol(SimpleName("boolean")))
+		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[overload1, overload2])
+		architecture.IndexDeclaredItems()
+
+		self.assertEqual(1, len(architecture.Functions))
+		self.assertIs(overload2, architecture.Functions["f"])
+
+
+class Components(TestCase):
+	def test_Minimal(self) -> None:
+		component = Component("comp")
+
+		self.assertEqual("comp", component.Identifier)
+		self.assertIsNone(component.IsBlackbox)
+		self.assertEqual(0, len(component.GenericItems))
+		self.assertEqual(0, len(component.PortItems))
+		self.assertIsNone(component.Entity)
+
+	def test_WithGenericAndPortItems(self) -> None:
+		"""Uses bare ``ModelEntity`` stand-ins - ``Component``'s own generic-/port-item loops only
+		append and set ``.Parent``, they don't care about the item's real type (real
+		``GenericInterfaceItemMixin``/``PortInterfaceItemMixin`` classes are covered in their own
+		slice)."""
+		genericItem = ModelEntity()
+		portItem = ModelEntity()
+		component = Component("comp", genericItems=[genericItem], portItems=[portItem])
+
+		self.assertEqual(1, len(component.GenericItems))
+		self.assertIs(genericItem, component.GenericItems[0])
+		self.assertIs(component, genericItem.Parent)
+		self.assertEqual(1, len(component.PortItems))
+		self.assertIs(portItem, component.PortItems[0])
+		self.assertIs(component, portItem.Parent)
+
+	def test_EntitySetter_AlsoClearsBlackboxFlag(self) -> None:
+		component = Component("comp")
+		entity = Entity("ent")
+		component.Entity = entity
+
+		self.assertIs(entity, component.Entity)
+		self.assertFalse(component.IsBlackbox)
+
+
+class Configurations(TestCase):
+	"""The *design-unit* ``configuration cfg of ent is ... end configuration;`` - not to be confused
+	with ``pyVHDLModel.Configuration.ComponentConfiguration``/``BlockConfiguration``, which are tested
+	in tests/unit/Configuration.py."""
+
+	def test_Minimal(self) -> None:
+		from pyVHDLModel.Configuration import BlockConfiguration
+		from pyVHDLModel.Symbol import Symbol, PossibleReference
+
+		entitySymbol = _entitySymbol()
+		blockSpec = Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)
+		blockConfiguration = BlockConfiguration(blockSpec)
+		configuration = Configuration("cfg", entitySymbol, blockConfiguration)
+
+		self.assertIs(entitySymbol, configuration.Entity)
+		self.assertIs(configuration, entitySymbol.Parent)
+		self.assertIs(blockConfiguration, configuration.BlockConfiguration)
+		self.assertIs(configuration, blockConfiguration.Parent)

--- a/tests/unit/Expression.py
+++ b/tests/unit/Expression.py
@@ -1,0 +1,437 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Tests for pyVHDLModel.Expression.
+
+Most of this module is dozens of leaf subclasses that only fix a ``_FORMAT`` class variable
+(``AdditionExpression``, ``EqualExpression``, ``RotateLeftExpression``, ...). Their shared
+construction/parent-wiring behaviour is tested once via the immediate base class
+(``UnaryExpression``/``BinaryExpression``), then every leaf subclass's ``_FORMAT`` is checked
+table-driven in one ``str()``-formatting test rather than one hand-written test per class.
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Base       import Direction, Range
+from pyVHDLModel.Name       import SimpleName
+from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
+from pyVHDLModel.Expression import (
+	BaseExpression, Literal,
+	NullLiteral, EnumerationLiteral, IntegerLiteral, FloatingPointLiteral,
+	PhysicalIntegerLiteral, PhysicalFloatingLiteral, CharacterLiteral, StringLiteral,
+	BinaryBitStringLiteral, OctalBitStringLiteral, DecimalBitStringLiteral, HexadecimalBitStringLiteral,
+	UnaryExpression,
+	NegationExpression, IdentityExpression, InverseExpression,
+	UnaryAndExpression, UnaryNandExpression, UnaryOrExpression, UnaryNorExpression,
+	UnaryXorExpression, UnaryXnorExpression, AbsoluteExpression, TypeConversion, SubExpression,
+	BinaryExpression,
+	AscendingRangeExpression, DescendingRangeExpression,
+	AdditionExpression, SubtractionExpression, ConcatenationExpression,
+	MultiplyExpression, DivisionExpression, RemainderExpression, ModuloExpression, ExponentiationExpression,
+	AndExpression, NandExpression, OrExpression, NorExpression, XorExpression, XnorExpression,
+	EqualExpression, UnequalExpression, GreaterThanExpression, GreaterEqualExpression,
+	LessThanExpression, LessEqualExpression,
+	MatchingEqualExpression, MatchingUnequalExpression, MatchingGreaterThanExpression,
+	MatchingGreaterEqualExpression, MatchingLessThanExpression, MatchingLessEqualExpression,
+	ShiftRightLogicExpression, ShiftLeftLogicExpression,
+	ShiftRightArithmeticExpression, ShiftLeftArithmeticExpression,
+	RotateRightExpression, RotateLeftExpression,
+	QualifiedExpression, TernaryExpression, WhenElseExpression,
+	FunctionCall, SubtypeAllocation, QualifiedExpressionAllocation,
+	AggregateElement, SimpleAggregateElement, IndexedAggregateElement, RangedAggregateElement,
+	NamedAggregateElement, OthersAggregateElement, Aggregate,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class Literals(TestCase):
+	"""``BaseExpression`` itself (``class BaseExpression(ModelEntity): pass``) is never instantiated
+	directly here, matching the same reasoning as ``Allocation``/``Type`` (see tests/unit/Type.py):
+	it has no ``__init__`` override of its own (so there's no independent forwarding-bug risk to
+	check, unlike e.g. the type classes), no VHDL construct is ever "just a BaseExpression", and its
+	``Parent``-wiring behaviour is already covered via plain ``ModelEntity`` in tests/unit/Base.py -
+	every concrete literal/operator/etc. class tested below already exercises it transitively."""
+
+
+	def test_NullLiteral(self) -> None:
+		self.assertEqual("null", str(NullLiteral()))
+
+	def test_EnumerationLiteral(self) -> None:
+		literal = EnumerationLiteral("'1'")
+
+		self.assertEqual("'1'", literal.Value)
+		self.assertEqual("'1'", str(literal))
+
+	def test_IntegerLiteral(self) -> None:
+		literal = IntegerLiteral(42)
+
+		self.assertEqual(42, literal.Value)
+		self.assertEqual("42", str(literal))
+
+	def test_FloatingPointLiteral(self) -> None:
+		literal = FloatingPointLiteral(4.2)
+
+		self.assertEqual(4.2, literal.Value)
+		self.assertEqual("4.2", str(literal))
+
+	def test_CharacterLiteral(self) -> None:
+		literal = CharacterLiteral("'a'")
+
+		self.assertEqual("'a'", literal.Value)
+		self.assertEqual("'a'", str(literal))
+
+	def test_StringLiteral(self) -> None:
+		literal = StringLiteral("hello")
+
+		self.assertEqual("hello", literal.Value)
+		self.assertEqual("\"hello\"", str(literal))
+
+
+class PhysicalLiterals(TestCase):
+	"""``PhysicalLiteral`` itself is never instantiated directly - its own ``_value`` is only declared
+	by ``PhysicalIntegerLiteral``/``PhysicalFloatingLiteral``, so it's exercised only through those two
+	concrete subclasses."""
+
+	def test_PhysicalIntegerLiteral(self) -> None:
+		literal = PhysicalIntegerLiteral(5, "ns")
+
+		self.assertEqual(5, literal.Value)
+		self.assertEqual("ns", literal.UnitName)
+		self.assertEqual("5 ns", str(literal))
+
+	def test_PhysicalFloatingLiteral(self) -> None:
+		literal = PhysicalFloatingLiteral(2.5, "ns")
+
+		self.assertEqual(2.5, literal.Value)
+		self.assertEqual("ns", literal.UnitName)
+		self.assertEqual("2.5 ns", str(literal))
+
+
+class BitStringLiterals(TestCase):
+	"""``BitStringLiteral`` itself is abstract in practice (``_base`` is only set by its four concrete
+	subclasses as a ``ClassVar``); ``Length``/``Signed``/``BinaryValue``/``Bits`` are all still-open
+	gaps beyond ``Value`` itself for ``BinaryValue``/``Bits`` (see the class's own ``.. todo``-less but
+	clearly unfinished state - both always stay ``None``, there's no code anywhere that computes
+	them yet)."""
+
+	def test_Binary(self) -> None:
+		literal = BinaryBitStringLiteral("101")
+
+		self.assertEqual("101", literal.Value)
+		self.assertIsNone(literal.BinaryValue)
+		self.assertIsNone(literal.Bits)
+		self.assertIsNone(literal.Length)
+		self.assertIsNone(literal.Signed)
+		self.assertEqual("b\"101\"", str(literal))
+
+	def test_Octal(self) -> None:
+		self.assertEqual("o\"17\"", str(OctalBitStringLiteral("17")))
+
+	def test_Decimal(self) -> None:
+		self.assertEqual("d\"9\"", str(DecimalBitStringLiteral("9")))
+
+	def test_Hexadecimal(self) -> None:
+		self.assertEqual("x\"FF\"", str(HexadecimalBitStringLiteral("FF")))
+
+	def test_WithLength(self) -> None:
+		"""``8x"F"`` - explicit-length metadata (C.2 in the gap analysis)."""
+		literal = HexadecimalBitStringLiteral("F", length=8)
+
+		self.assertEqual(8, literal.Length)
+		self.assertEqual("8x\"F\"", str(literal))
+
+	def test_Signed(self) -> None:
+		"""``sx"F"`` - signed metadata (C.2 in the gap analysis)."""
+		literal = HexadecimalBitStringLiteral("F", signed=True)
+
+		self.assertTrue(literal.Signed)
+		self.assertEqual("sx\"F\"", str(literal))
+
+	def test_Unsigned(self) -> None:
+		"""``ux"F"`` - unsigned metadata (C.2 in the gap analysis)."""
+		literal = HexadecimalBitStringLiteral("F", signed=False)
+
+		self.assertFalse(literal.Signed)
+		self.assertEqual("ux\"F\"", str(literal))
+
+
+class UnaryExpressions(TestCase):
+	"""Regression test: ``operand.Parent = self`` was previously commented out
+	(``# FIXME: operand is provided as None``) - confirmed stale in the gap analysis (every real
+	construction site always provides a real operand) and now re-enabled. Tested once here via
+	``NegationExpression``; every other unary subclass shares the identical, unoverridden
+	constructor."""
+
+	def test_Construction(self) -> None:
+		operand = IntegerLiteral(1)
+		expression = NegationExpression(operand)
+
+		self.assertIs(operand, expression.Operand)
+		self.assertIs(expression, operand.Parent)
+
+
+_UNARY_FORMATS = (
+	(NegationExpression,   "-1"),
+	(IdentityExpression,   "+1"),
+	(InverseExpression,    "not 1"),
+	(UnaryAndExpression,   "and 1"),
+	(UnaryNandExpression,  "nand 1"),
+	(UnaryOrExpression,    "or 1"),
+	(UnaryNorExpression,   "nor 1"),
+	(UnaryXorExpression,   "xor 1"),
+	(UnaryXnorExpression,  "xnor 1"),
+	(AbsoluteExpression,   "abs 1"),
+	(SubExpression,        "(1)"),
+)
+
+
+class UnaryExpressionFormats(TestCase):
+	def test_AllVariants(self) -> None:
+		for expressionClass, expected in _UNARY_FORMATS:
+			with self.subTest(expression=expressionClass.__name__):
+				self.assertEqual(expected, str(expressionClass(IntegerLiteral(1))))
+
+	def test_TypeConversion_StrRaises(self) -> None:
+		"""Regression-tracking test, not a fix: see Findings.md - unlike every other
+		``UnaryExpression`` subclass, ``TypeConversion`` never fixes a ``_FORMAT`` (it has no field for
+		the target type at all), so ``str()`` always raises. Locked in here so a future fix shows up
+		as an intentional test change rather than a silent behaviour change."""
+		with self.assertRaises(AttributeError):
+			str(TypeConversion(IntegerLiteral(1)))
+
+	def test_SubExpression_IsAlsoAParenthesisExpression(self) -> None:
+		"""``SubExpression`` mixes in ``ParenthesisExpression``, whose own ``Operand`` hardcodes
+		``return None`` - but MRO puts ``UnaryExpression`` first, so the real operand wins and
+		``ParenthesisExpression.Operand`` is never actually reached through this class."""
+		operand = IntegerLiteral(1)
+		expression = SubExpression(operand)
+
+		self.assertIs(operand, expression.Operand)
+
+
+class BinaryExpressions(TestCase):
+	"""Both operands' ``Parent`` wiring is already active (no FIXME here, unlike
+	``UnaryExpression``) - tested once via ``AdditionExpression``; every other binary subclass shares
+	the identical, unoverridden constructor."""
+
+	def test_Construction(self) -> None:
+		left = IntegerLiteral(1)
+		right = IntegerLiteral(2)
+		expression = AdditionExpression(left, right)
+
+		self.assertIs(left, expression.LeftOperand)
+		self.assertIs(right, expression.RightOperand)
+		self.assertIs(expression, left.Parent)
+		self.assertIs(expression, right.Parent)
+
+
+_BINARY_FORMATS = (
+	(AdditionExpression,               "1 + 2"),
+	(SubtractionExpression,            "1 - 2"),
+	(ConcatenationExpression,          "1 & 2"),
+	(MultiplyExpression,               "1 * 2"),
+	(DivisionExpression,               "1 / 2"),
+	(RemainderExpression,              "1 rem 2"),
+	(ModuloExpression,                 "1 mod 2"),
+	(ExponentiationExpression,         "1**2"),
+	(AndExpression,                    "1 and 2"),
+	(NandExpression,                   "1 nand 2"),
+	(OrExpression,                     "1 or 2"),
+	(NorExpression,                    "1 nor 2"),
+	(XorExpression,                    "1 xor 2"),
+	(XnorExpression,                   "1 xnor 2"),
+	(EqualExpression,                  "1 = 2"),
+	(UnequalExpression,                "1 /= 2"),
+	(GreaterThanExpression,            "1 > 2"),
+	(GreaterEqualExpression,           "1 >= 2"),
+	(LessThanExpression,               "1 < 2"),
+	(LessEqualExpression,              "1 <= 2"),
+	(MatchingEqualExpression,          "1 ?= 2"),
+	(MatchingUnequalExpression,        "1 ?/= 2"),
+	(MatchingGreaterThanExpression,    "1 ?> 2"),
+	(MatchingGreaterEqualExpression,   "1 ?>= 2"),
+	(MatchingLessThanExpression,       "1 ?< 2"),
+	(MatchingLessEqualExpression,      "1 ?<= 2"),
+	(ShiftRightLogicExpression,        "1 srl 2"),
+	(ShiftLeftLogicExpression,         "1 sll 2"),
+	(ShiftRightArithmeticExpression,   "1 sra 2"),
+	(ShiftLeftArithmeticExpression,    "1 sla 2"),
+	(RotateRightExpression,            "1 ror 2"),
+	(RotateLeftExpression,             "1 rol 2"),
+)
+
+
+class BinaryExpressionFormats(TestCase):
+	def test_AllVariants(self) -> None:
+		for expressionClass, expected in _BINARY_FORMATS:
+			with self.subTest(expression=expressionClass.__name__):
+				self.assertEqual(expected, str(expressionClass(IntegerLiteral(1), IntegerLiteral(2))))
+
+
+class RangeExpressions(TestCase):
+	"""``AscendingRangeExpression``/``DescendingRangeExpression`` additionally expose ``Direction``
+	over the plain ``BinaryExpression`` shape."""
+
+	def test_Ascending(self) -> None:
+		expression = AscendingRangeExpression(IntegerLiteral(0), IntegerLiteral(7))
+
+		self.assertIs(Direction.To, expression.Direction)
+		self.assertEqual("0 to 7", str(expression))
+
+	def test_Descending(self) -> None:
+		expression = DescendingRangeExpression(IntegerLiteral(7), IntegerLiteral(0))
+
+		self.assertIs(Direction.DownTo, expression.Direction)
+		self.assertEqual("7 downto 0", str(expression))
+
+
+class QualifiedExpressions(TestCase):
+	def test_Construction(self) -> None:
+		subtype = SimpleSubtypeSymbol(SimpleName("bit_vector"))
+		operand = IntegerLiteral(1)
+		expression = QualifiedExpression(subtype, operand)
+
+		self.assertIs(operand, expression.Operand)
+		self.assertIs(subtype, expression.Subtyped)
+		self.assertIs(expression, operand.Parent)
+		self.assertIs(expression, subtype.Parent)
+		self.assertEqual("bit_vector?'(1)", str(expression))
+
+
+class TernaryExpressions(TestCase):
+	"""Regression-tracking test, not a fix: see Findings.md - the constructor never accepts or sets
+	its three operands at all, and ``__str__`` separately indexes past the end of the 4-element
+	``_FORMAT`` tuple. Both are confirmed still-open; this locks in the current (broken) behaviour so
+	a future fix shows up as an intentional test change."""
+
+	def test_ConstructsButOperandsAreUnset(self) -> None:
+		expression = WhenElseExpression()
+
+		with self.assertRaises(AttributeError):
+			expression.FirstOperand
+
+	def test_StrRaises(self) -> None:
+		expression = WhenElseExpression()
+
+		with self.assertRaises(Exception):
+			str(expression)
+
+
+class FunctionCallAndAllocation(TestCase):
+	"""``Allocation`` itself (``class Allocation(BaseExpression): pass``) is never instantiated
+	directly anywhere - real VHDL always uses one of its two concrete subclasses below (``new T`` or
+	``new T'(expr)``), so unlike ``FunctionCall`` (which *is* the real, direct class for a function
+	call expression - there's no further subclass to move it to), there's no bare ``Allocation()``
+	test here."""
+
+	def test_FunctionCall(self) -> None:
+		call = FunctionCall()
+
+		self.assertIsInstance(call, BaseExpression)
+
+	def test_SubtypeAllocation(self) -> None:
+		subtype = SimpleSubtypeSymbol(SimpleName("integer"))
+		allocation = SubtypeAllocation(subtype)
+
+		self.assertIs(subtype, allocation.Subtype)
+		self.assertIs(allocation, subtype.Parent)
+		self.assertEqual("new integer?", str(allocation))
+
+	def test_QualifiedExpressionAllocation(self) -> None:
+		subtype = SimpleSubtypeSymbol(SimpleName("integer"))
+		qualifiedExpression = QualifiedExpression(subtype, IntegerLiteral(1))
+		allocation = QualifiedExpressionAllocation(qualifiedExpression)
+
+		self.assertIs(qualifiedExpression, allocation.QualifiedExpression)
+		self.assertIs(allocation, qualifiedExpression.Parent)
+		self.assertEqual("new integer?'(1)", str(allocation))
+
+
+class AggregateElements(TestCase):
+	def test_SimpleAggregateElement(self) -> None:
+		expression = IntegerLiteral(1)
+		element = SimpleAggregateElement(expression)
+
+		self.assertIs(expression, element.Expression)
+		self.assertIs(element, expression.Parent)
+		self.assertEqual("1", str(element))
+
+	def test_IndexedAggregateElement(self) -> None:
+		index = IntegerLiteral(0)
+		expression = IntegerLiteral(1)
+		element = IndexedAggregateElement(index, expression)
+
+		self.assertIs(index, element.Index)
+		self.assertIs(expression, element.Expression)
+		self.assertIs(element, expression.Parent)
+		self.assertEqual("0 => 1", str(element))
+
+	def test_RangedAggregateElement(self) -> None:
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		expression = IntegerLiteral(1)
+		element = RangedAggregateElement(rng, expression)
+
+		self.assertIs(rng, element.Range)
+		self.assertIs(element, rng.Parent)
+		self.assertIs(element, expression.Parent)
+		self.assertEqual("0 to 3 => 1", str(element))
+
+	def test_NamedAggregateElement(self) -> None:
+		name = SimpleSubtypeSymbol(SimpleName("field"))
+		expression = IntegerLiteral(1)
+		element = NamedAggregateElement(name, expression)
+
+		self.assertIs(name, element.Name)
+		self.assertIs(element, name.Parent)
+		self.assertEqual("field? => 1", str(element))
+
+	def test_OthersAggregateElement(self) -> None:
+		expression = IntegerLiteral(1)
+		element = OthersAggregateElement(expression)
+
+		self.assertIs(expression, element.Expression)
+		self.assertEqual("others => 1", str(element))
+
+
+class Aggregates(TestCase):
+	def test_Construction(self) -> None:
+		element1 = SimpleAggregateElement(IntegerLiteral(1))
+		element2 = SimpleAggregateElement(IntegerLiteral(2))
+		aggregate = Aggregate([element1, element2])
+
+		self.assertEqual(2, len(aggregate.Elements))
+		self.assertIs(aggregate, element1.Parent)
+		self.assertIs(aggregate, element2.Parent)
+		self.assertEqual("(1, 2)", str(aggregate))

--- a/tests/unit/Instantiation.py
+++ b/tests/unit/Instantiation.py
@@ -1,0 +1,119 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Instantiation (VHDL-2008 generic subprogram/package instantiation)."""
+from unittest import TestCase
+
+from pyVHDLModel             import VHDLModelException
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import SubprogramReferenceSymbol, PackageReferenceSymbol, SimpleSubtypeSymbol
+from pyVHDLModel.Expression  import IntegerLiteral
+from pyVHDLModel.Association import GenericAssociationItem
+from pyVHDLModel.DesignUnit  import Package, Component
+from pyVHDLModel.Instantiation import ProcedureInstantiation, FunctionInstantiation, PackageInstantiation
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class ProcedureInstantiations(TestCase):
+	"""``procedure p is new q generic map (...);``"""
+
+	def test_Construction(self) -> None:
+		reference = SubprogramReferenceSymbol(SimpleName("q"))
+		generic = GenericAssociationItem(SimpleName("T"), IntegerLiteral(1))
+		instantiation = ProcedureInstantiation("p", reference, [generic])
+
+		self.assertEqual("p", instantiation.Identifier)
+		self.assertIs(reference, instantiation.SubprogramReference)
+		self.assertIs(instantiation, reference.Parent)
+		self.assertEqual(1, len(instantiation.GenericAssociationItems))
+		self.assertIs(instantiation, generic.Parent)
+
+	def test_NoGenericAssociations(self) -> None:
+		instantiation = ProcedureInstantiation("p", SubprogramReferenceSymbol(SimpleName("q")))
+
+		self.assertEqual(0, len(instantiation.GenericAssociationItems))
+
+
+class FunctionInstantiations(TestCase):
+	"""``function f is new g generic map (...);`` - ``ReturnType`` is deliberately ``Nullable``, see
+	the class's own docstring (never resolvable at the parse-only level, a genuinely unresolved
+	forward reference like ``Symbol.Reference``, not a workaround)."""
+
+	def test_Construction(self) -> None:
+		reference = SubprogramReferenceSymbol(SimpleName("g"))
+		instantiation = FunctionInstantiation("f", reference)
+
+		self.assertIs(reference, instantiation.SubprogramReference)
+		self.assertIsNone(instantiation.ReturnType)
+		self.assertTrue(instantiation.IsPure)
+
+	def test_Impure(self) -> None:
+		instantiation = FunctionInstantiation("f", SubprogramReferenceSymbol(SimpleName("g")), isPure=False)
+
+		self.assertFalse(instantiation.IsPure)
+
+
+class PackageInstantiations(TestCase):
+	"""``package p is new q generic map (...);``"""
+
+	def test_Construction(self) -> None:
+		reference = PackageReferenceSymbol(SimpleName("q"))
+		generic = GenericAssociationItem(SimpleName("T"), IntegerLiteral(1))
+		instantiation = PackageInstantiation("p", reference, genericAssociationItems=[generic])
+
+		self.assertIs(reference, instantiation.PackageReference)
+		self.assertIs(instantiation, reference.Parent)
+		self.assertEqual(1, len(instantiation.GenericAssociationItems))
+		self.assertIs(instantiation, generic.Parent)
+
+	def test_Instantiate_UnlinkedReference_Raises(self) -> None:
+		reference = PackageReferenceSymbol(SimpleName("q"))
+		instantiation = PackageInstantiation("p", reference)
+
+		with self.assertRaises(VHDLModelException):
+			instantiation.Instantiate()
+
+	def test_Instantiate_CopiesComponentsFromGenericPackage(self) -> None:
+		component = Component("comp")
+		genericPackage = Package("q", declaredItems=[component])
+		genericPackage.IndexDeclaredItems()
+
+		reference = PackageReferenceSymbol(SimpleName("q"))
+		reference.Package = genericPackage
+		instantiation = PackageInstantiation("p", reference)
+
+		instantiation.Instantiate()
+
+		self.assertIs(component, instantiation.Components["comp"])

--- a/tests/unit/Interface.py
+++ b/tests/unit/Interface.py
@@ -28,15 +28,29 @@
 # SPDX-License-Identifier: Apache-2.0                                                                                  #
 # ==================================================================================================================== #
 #
-"""Tests for mode views (VHDL-2019) and the Port/Parameter signal interface item split."""
+"""Tests for mode views (VHDL-2019), the Port/Parameter signal interface item split, generic/
+parameter interface item kinds, and the With*Mixin/*Group classes."""
 from unittest import TestCase
 
 from pyVHDLModel.Base       import Mode
 from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Symbol     import SimpleSubtypeSymbol, ModeViewSymbol
+from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Interface  import ModeViewDeclaration, SimpleModeViewElement, CompositeModeViewElement
 from pyVHDLModel.Interface  import PortSignalInterfaceItem, PortSimpleSignalInterfaceItem, PortViewSignalInterfaceItem
 from pyVHDLModel.Interface  import ParameterSignalInterfaceItem, ParameterSimpleSignalInterfaceItem, ParameterViewSignalInterfaceItem
+from pyVHDLModel.Interface  import (
+	GenericConstantInterfaceItem, GenericTypeInterfaceItem,
+	GenericProcedureInterfaceItem, GenericFunctionInterfaceItem,
+	InterfacePackage, GenericPackageInterfaceItem,
+	ParameterConstantInterfaceItem, ParameterVariableInterfaceItem, ParameterFileInterfaceItem,
+	WithGenericsMixin, WithPortsMixin, WithParametersMixin,
+	InterfaceGroup, GenericGroup, PortGroup, ParameterGroup,
+)
+
+
+def _subtype(name: str = "bit") -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName(name))
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -142,3 +156,181 @@ class ParameterSignalInterfaceItems(TestCase):
 		self.assertIsInstance(parameter, ParameterSignalInterfaceItem)
 		self.assertIs(modeViewIndication, parameter.ModeViewIndication)
 		self.assertIs(modeViewIndication, parameter.Subtype)
+
+
+class GenericInterfaceItems(TestCase):
+	def test_GenericConstantInterfaceItem(self) -> None:
+		"""``generic (G : positive := 8);``"""
+		default = IntegerLiteral(8)
+		item = GenericConstantInterfaceItem(["G"], Mode.In, _subtype("positive"), defaultExpression=default)
+
+		self.assertEqual(("G",), item.Identifiers)
+		self.assertIs(Mode.In, item.Mode)
+		self.assertIs(default, item.DefaultExpression)
+
+	def test_GenericTypeInterfaceItem(self) -> None:
+		"""``generic (type T);`` (VHDL-2008)"""
+		item = GenericTypeInterfaceItem("T")
+
+		self.assertEqual("T", item.Identifier)
+
+	def test_GenericProcedureInterfaceItem(self) -> None:
+		"""``generic (procedure proc);`` (VHDL-2008)"""
+		item = GenericProcedureInterfaceItem("proc")
+
+		self.assertEqual("proc", item.Identifier)
+
+	def test_GenericFunctionInterfaceItem_ConstructionRaises(self) -> None:
+		"""``generic (function func return boolean);`` (VHDL-2008) - regression-tracking test, not a
+		fix: see Findings.md (HIGH PRIORITY - confirmed live via pyGHDL.dom's actual translation
+		dispatch, not just a landmine). ``GenericFunctionInterfaceItem`` has no ``returnType``
+		parameter of its own, so ``super().__init__(identifier, documentation, parent)`` misaligns
+		against ``Function.__init__``'s real signature - ``documentation`` lands in the ``returnType``
+		slot, and ``Function.__init__`` unconditionally does ``returnType.Parent = self``, which
+		crashes on anything but a real ``Symbol``. Locked in here so the eventual fix (adding a real
+		``returnType`` parameter) shows up as an intentional test change."""
+		with self.assertRaises(AttributeError):
+			GenericFunctionInterfaceItem("func")
+
+	def test_GenericPackageInterfaceItem(self) -> None:
+		"""``generic (package p is new q generic map (<>));`` (VHDL-2008)"""
+		item = GenericPackageInterfaceItem("p")
+
+		self.assertIsInstance(item, InterfacePackage)
+		self.assertEqual("p", item.Identifier)
+
+
+class ParameterInterfaceItems(TestCase):
+	def test_ParameterConstantInterfaceItem(self) -> None:
+		"""``procedure proc(constant c : in natural);``"""
+		item = ParameterConstantInterfaceItem(["c"], Mode.In, _subtype("natural"))
+
+		self.assertIs(Mode.In, item.Mode)
+
+	def test_ParameterVariableInterfaceItem(self) -> None:
+		"""``procedure proc(variable v : inout natural);``"""
+		item = ParameterVariableInterfaceItem(["v"], Mode.InOut, _subtype("natural"))
+
+		self.assertIs(Mode.InOut, item.Mode)
+
+	def test_ParameterFileInterfaceItem(self) -> None:
+		"""``procedure proc(file f : text);``"""
+		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+
+		self.assertEqual(("f",), item.Identifiers)
+
+
+class WithGenericsPortsParametersMixins(TestCase):
+	"""Tested via a minimal local host combining each mixin with itself (mixins can't be
+	instantiated standalone - see the design note in tests/unit/Base.py); real design-unit/
+	subprogram hosts already exercise these mixins incidentally in their own slices, but nothing
+	elsewhere reads the ``*Count`` properties, so that's the focus here."""
+
+	def test_WithGenericsMixin(self) -> None:
+		class _Host(WithGenericsMixin):
+			pass
+
+		item = GenericTypeInterfaceItem("T")
+		host = _Host([item])
+
+		self.assertEqual(1, host.GenericCount)
+		self.assertIs(item, host.GenericItems[0])
+
+	def test_WithPortsMixin(self) -> None:
+		class _Host(WithPortsMixin):
+			pass
+
+		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
+		host = _Host([item])
+
+		self.assertEqual(1, host.PortCount)
+
+	def test_WithParametersMixin(self) -> None:
+		class _Host(WithParametersMixin):
+			pass
+
+		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+		host = _Host([item])
+
+		self.assertEqual(1, host.ParameterCount)
+
+
+class Groups(TestCase):
+	"""Regression test: ``GenericGroup``/``ParameterGroup`` didn't list ``WithGenericsMixin``/
+	``WithParametersMixin`` as base classes at all (unlike ``PortGroup``, which correctly lists
+	``WithPortsMixin``), so the slots-based metaclass never allocated storage for
+	``_genericItems``/``_parameterItems`` - construction crashed immediately with
+	``AttributeError: ... no __dict__ for setting new attributes``, even for the simplest, empty-list
+	case. Fixed by adding the missing base class to both, mirroring ``PortGroup``."""
+
+	def test_GenericGroup(self) -> None:
+		"""``str()`` happens to work here only because ``GenericTypeInterfaceItem`` is one of the four
+		``NamedEntityMixin``-based (singular ``_identifier``) generic item kinds - see
+		``test_GenericGroup_StrCrashesForObjectBasedItems`` for the far more common case where it
+		doesn't."""
+		item = GenericTypeInterfaceItem("T")
+		group = GenericGroup([item], name="generics")
+
+		self.assertEqual(1, len(group))
+		self.assertEqual([item], list(group))
+		self.assertIn("generics", str(group))
+
+	def test_GenericGroup_Empty(self) -> None:
+		group = GenericGroup([])
+
+		self.assertEqual(0, len(group))
+
+	def test_GenericGroup_StrCrashesForObjectBasedItems(self) -> None:
+		"""Regression-tracking test, not a fix: see Findings.md. ``GenericConstantInterfaceItem`` (and
+		every ``Port*``/``Parameter*`` item - see the two tests below) is ``MultipleNamedEntityMixin``-
+		based (plural ``_identifiers``), but ``GenericGroup.__str__`` reads the singular
+		``_identifier``, which doesn't exist on this kind of item."""
+		item = GenericConstantInterfaceItem(["G"], Mode.In, _subtype("positive"))
+		group = GenericGroup([item])
+
+		with self.assertRaises(AttributeError):
+			str(group)
+
+	def test_PortGroup(self) -> None:
+		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
+		group = PortGroup([item], name="ports")
+
+		self.assertEqual(1, len(group))
+		self.assertEqual([item], list(group))
+
+	def test_PortGroup_StrCrashes(self) -> None:
+		"""Regression-tracking test, not a fix: see Findings.md - ports are always
+		``MultipleNamedEntityMixin``-based, so ``PortGroup.__str__`` (reading singular
+		``_identifier``) crashes for essentially any realistic content."""
+		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
+		group = PortGroup([item])
+
+		with self.assertRaises(AttributeError):
+			str(group)
+
+	def test_ParameterGroup(self) -> None:
+		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+		group = ParameterGroup([item], name="parameters")
+
+		self.assertEqual(1, len(group))
+		self.assertEqual([item], list(group))
+
+	def test_ParameterGroup_Empty(self) -> None:
+		group = ParameterGroup([])
+
+		self.assertEqual(0, len(group))
+
+	def test_ParameterGroup_StrCrashes(self) -> None:
+		"""Regression-tracking test, not a fix: see Findings.md - parameters are always
+		``MultipleNamedEntityMixin``-based, so ``ParameterGroup.__str__`` (reading singular
+		``_identifier``) crashes for essentially any realistic content."""
+		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+		group = ParameterGroup([item])
+
+		with self.assertRaises(AttributeError):
+			str(group)
+
+	def test_InterfaceGroup_NoName(self) -> None:
+		group = InterfaceGroup()
+
+		self.assertIsNone(group.Identifier)

--- a/tests/unit/Name.py
+++ b/tests/unit/Name.py
@@ -1,0 +1,187 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Name."""
+from unittest import TestCase
+
+from pyVHDLModel.Base        import ModelEntity
+from pyVHDLModel.Expression  import IntegerLiteral
+from pyVHDLModel.Association import GenericAssociationItem
+from pyVHDLModel.Name        import (
+	Name, SimpleName, ParenthesisName, IndexedName, SlicedName, SelectedName, AttributeName, AllName, OpenName,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class Names(TestCase):
+	def test_NoPrefixNoParent(self) -> None:
+		name = Name("foo")
+
+		self.assertEqual("foo", name.Identifier)
+		self.assertEqual("foo", name.NormalizedIdentifier)
+		self.assertIsNone(name.Prefix)
+		self.assertFalse(name.HasPrefix)
+		self.assertIs(name, name.Root)
+		self.assertIsNone(name.Parent)
+		self.assertEqual("foo", str(name))
+		self.assertEqual("Name: 'foo'", repr(name))
+
+	def test_IdentifierIsNormalized(self) -> None:
+		name = Name("FOO")
+
+		self.assertEqual("FOO", name.Identifier)
+		self.assertEqual("foo", name.NormalizedIdentifier)
+
+	def test_WithPrefix(self) -> None:
+		"""``Root`` is inherited from the prefix's own root, so for a two-element chain it's simply the
+		prefix itself; see ``test_RootIsTransitiveAcrossAChain`` for a longer chain."""
+		prefix = Name("pkg")
+		name = Name("member", prefix)
+
+		self.assertIs(prefix, name.Prefix)
+		self.assertTrue(name.HasPrefix)
+		self.assertIs(prefix, name.Root)
+
+	def test_RootIsTransitiveAcrossAChain(self) -> None:
+		root = Name("a")
+		middle = Name("b", root)
+		leaf = Name("c", middle)
+
+		self.assertIs(root, middle.Root)
+		self.assertIs(root, leaf.Root)
+		self.assertIs(middle, leaf.Prefix)
+
+	def test_WithParent(self) -> None:
+		parent = ModelEntity()
+		name = Name("foo", parent=parent)
+
+		self.assertIs(parent, name.Parent)
+
+
+class SimpleNames(TestCase):
+	def test_Construction(self) -> None:
+		name = SimpleName("sig")
+
+		self.assertEqual("sig", name.Identifier)
+		self.assertFalse(name.HasPrefix)
+
+
+class ParenthesisNames(TestCase):
+	"""``arr(3)`` - e.g. an indexed name written through the generic ``ParenthesisName`` before it's
+	disambiguated into an indexed name, slice, or function call."""
+
+	def test_Construction(self) -> None:
+		prefix = SimpleName("arr")
+		association = GenericAssociationItem(None, IntegerLiteral(3))
+		name = ParenthesisName(prefix, [association])
+
+		self.assertEqual(1, len(name.Associations))
+		self.assertIs(association, name.Associations[0])
+		self.assertIs(name, association.Parent)
+		self.assertEqual("arr(3)", str(name))
+
+
+class IndexedNames(TestCase):
+	def test_Construction(self) -> None:
+		prefix = SimpleName("arr")
+		index = IntegerLiteral(3)
+		name = IndexedName(prefix, [index])
+
+		self.assertEqual(1, len(name.Indices))
+		self.assertIs(index, name.Indices[0])
+		self.assertIs(name, index.Parent)
+		self.assertEqual("arr(3)", str(name))
+
+
+class SlicedNames(TestCase):
+	def test_Construction(self) -> None:
+		prefix = SimpleName("v")
+		name = SlicedName("", prefix)
+
+		self.assertIs(prefix, name.Prefix)
+
+
+class SelectedNames(TestCase):
+	def test_Construction(self) -> None:
+		prefix = SimpleName("pkg")
+		name = SelectedName("member", prefix)
+
+		self.assertEqual("member", name.Identifier)
+		self.assertIs(prefix, name.Prefix)
+		self.assertEqual("pkg.member", str(name))
+
+
+class AttributeNames(TestCase):
+	def test_Construction(self) -> None:
+		prefix = SimpleName("sig")
+		name = AttributeName("range", prefix)
+
+		self.assertEqual("range", name.Identifier)
+		self.assertEqual("sig'range", str(name))
+
+
+class AllNames(TestCase):
+	"""``use ieee.numeric_std.all;`` - ``AllName`` is a ``SelectedName`` fixed to the identifier
+	``"all"``."""
+
+	def test_Construction(self) -> None:
+		prefix = SimpleName("numeric_std")
+		name = AllName(prefix)
+
+		self.assertEqual("all", name.Identifier)
+		self.assertEqual("numeric_std.all", str(name))
+
+
+class OpenNames(TestCase):
+	"""Regression test: the ``parent`` argument was previously forwarded positionally into ``Name.
+	__init__``'s ``prefix`` parameter instead of its ``parent`` parameter (``super().__init__("open",
+	parent)``), so any ``OpenName(parent=...)`` call crashed with an ``AttributeError`` the moment
+	``Name.__init__`` tried to read ``prefix._root`` off whatever non-``Name`` object had been passed
+	as ``parent``."""
+
+	def test_ConstructionWithoutParent(self) -> None:
+		name = OpenName()
+
+		self.assertEqual("open", name.Identifier)
+		self.assertIsNone(name.Prefix)
+		self.assertIsNone(name.Parent)
+		self.assertEqual("open", str(name))
+
+	def test_ConstructionWithParent(self) -> None:
+		parent = ModelEntity()
+		name = OpenName(parent)
+
+		self.assertIs(parent, name.Parent)
+		self.assertIsNone(name.Prefix)

--- a/tests/unit/Object.py
+++ b/tests/unit/Object.py
@@ -1,0 +1,180 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Object."""
+from unittest import TestCase
+
+from pyVHDLModel.Name       import SimpleName
+from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
+from pyVHDLModel.Expression import IntegerLiteral
+from pyVHDLModel.Object     import Constant, DeferredConstant, Variable, Signal, SharedVariable, File
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _subtype(name: str = "natural") -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName(name))
+
+
+class ObjBaseBehaviour(TestCase):
+	"""``Obj`` itself has no public subclass without a more specific meaning, so its shared behaviour
+	(multiple identifiers, subtype parent-wiring, the object-graph vertex) is tested once here via
+	``Signal`` - any ``Obj`` subclass would do equally well, since none of this is overridden."""
+
+	def test_SingleIdentifier(self) -> None:
+		subtype = _subtype()
+		signal = Signal(["s"], subtype)
+
+		self.assertEqual(("s",), signal.Identifiers)
+		self.assertEqual(("s",), signal.NormalizedIdentifiers)
+		self.assertIs(subtype, signal.Subtype)
+		self.assertIs(signal, subtype.Parent)
+
+	def test_MultipleIdentifiers(self) -> None:
+		"""``signal a, b, C : bit;`` declares three signals from one declaration."""
+		signal = Signal(["a", "b", "C"], _subtype("bit"))
+
+		self.assertEqual(("a", "b", "C"), signal.Identifiers)
+		self.assertEqual(("a", "b", "c"), signal.NormalizedIdentifiers)
+
+	def test_ObjectVertexDefaultsToNone(self) -> None:
+		"""``ObjectVertex`` is only populated once an object graph is built elsewhere; a freshly
+		constructed object was never inserted into one."""
+		signal = Signal(["s"], _subtype())
+
+		self.assertIsNone(signal.ObjectVertex)
+
+	def test_Documentation(self) -> None:
+		signal = Signal(["s"], _subtype(), documentation="a signal")
+
+		self.assertEqual("a signal", signal.Documentation)
+
+	def test_NoDocumentation(self) -> None:
+		signal = Signal(["s"], _subtype())
+
+		self.assertIsNone(signal.Documentation)
+
+
+class WithDefaultExpression(TestCase):
+	"""``WithDefaultExpressionMixin`` is shared by ``Constant``, ``Variable`` and ``Signal`` - tested
+	once via ``Signal`` for the parent-wiring behaviour, plus one smoke test per consumer below to
+	confirm each is actually wired up."""
+
+	def test_WithDefaultExpression(self) -> None:
+		default = IntegerLiteral(0)
+		signal = Signal(["s"], _subtype(), defaultExpression=default)
+
+		self.assertIs(default, signal.DefaultExpression)
+		self.assertIs(signal, default.Parent)
+
+	def test_WithoutDefaultExpression(self) -> None:
+		signal = Signal(["s"], _subtype())
+
+		self.assertIsNone(signal.DefaultExpression)
+
+
+class Constants(TestCase):
+	def test_WithDefault(self) -> None:
+		default = IntegerLiteral(8)
+		constant = Constant(["BITS"], _subtype("positive"), defaultExpression=default)
+
+		self.assertEqual(("BITS",), constant.Identifiers)
+		self.assertIs(default, constant.DefaultExpression)
+
+	def test_WithoutDefault(self) -> None:
+		"""Constructible without a default even though real VHDL always requires one for a (non-
+		deferred) constant - the model doesn't enforce that grammar rule itself."""
+		constant = Constant(["BITS"], _subtype("positive"))
+
+		self.assertIsNone(constant.DefaultExpression)
+
+
+class DeferredConstants(TestCase):
+	"""``constant BITS : positive;`` (in a package declaration, completed later in the package body)."""
+
+	def test_Construction(self) -> None:
+		constant = DeferredConstant(["BITS"], _subtype("positive"))
+
+		self.assertEqual(("BITS",), constant.Identifiers)
+		self.assertIsNone(constant.ConstantReference)
+		"""``Symbol.__str__`` appends ``?`` for an unresolved reference - the subtype symbol here was
+		never resolved against a real type, so it renders as ``positive?``."""
+		self.assertEqual("constant BITS : positive?", str(constant))
+
+
+class Variables(TestCase):
+	def test_WithDefault(self) -> None:
+		default = IntegerLiteral(0)
+		variable = Variable(["result"], _subtype("natural"), defaultExpression=default)
+
+		self.assertIs(default, variable.DefaultExpression)
+
+	def test_WithoutDefault(self) -> None:
+		variable = Variable(["result"], _subtype("natural"))
+
+		self.assertIsNone(variable.DefaultExpression)
+
+
+class Signals(TestCase):
+	def test_WithDefault(self) -> None:
+		default = IntegerLiteral(0)
+		signal = Signal(["counter"], _subtype("unsigned"), defaultExpression=default)
+
+		self.assertIs(default, signal.DefaultExpression)
+
+	def test_WithoutDefault(self) -> None:
+		signal = Signal(["counter"], _subtype("unsigned"))
+
+		self.assertIsNone(signal.DefaultExpression)
+
+
+class SharedVariables(TestCase):
+	"""``shared variable`` - not implemented beyond the base ``Obj`` shape (see the ``.. todo::`` in
+	the class docstring)."""
+
+	def test_Construction(self) -> None:
+		variable = SharedVariable(["v"], _subtype("natural"))
+
+		self.assertEqual(("v",), variable.Identifiers)
+		self.assertIs(SharedVariable, type(variable))
+
+
+class Files(TestCase):
+	"""``file`` - not implemented beyond the base ``Obj`` shape (see the ``.. todo::`` in the class
+	docstring); open-mode/logical-name are not modelled at all yet."""
+
+	def test_Construction(self) -> None:
+		file = File(["f"], _subtype("text"))
+
+		self.assertEqual(("f",), file.Identifiers)

--- a/tests/unit/Sequential.py
+++ b/tests/unit/Sequential.py
@@ -1,0 +1,275 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Tests for pyVHDLModel.Sequential - the sequential statement kinds not already covered by
+tests/unit/Assignment.py (conditional/selected/force/release assignments) or
+tests/unit/Base.py (branches, report/assert statements, choices).
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Base        import ModelEntity, Direction, Range
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import SignalSymbol, VariableSymbol, Symbol, PossibleReference
+from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral, PhysicalIntegerLiteral
+from pyVHDLModel.Association import ParameterAssociationItem
+from pyVHDLModel.Sequential  import (
+	SequentialProcedureCall, SequentialSignalAssignment, SequentialSimpleSignalAssignment,
+	CompoundStatement, IfBranch, ElseBranch, IfStatement,
+	IndexedChoice, RangedChoice, Case, OthersCase, CaseStatement,
+	LoopStatement, EndlessLoopStatement, ForLoopStatement, WhileLoopStatement,
+	NextStatement, ExitStatement, NullStatement, ReturnStatement, WaitStatement,
+)
+from pyVHDLModel.Base        import WaveformElement
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _signalTarget(name: str = "s") -> SignalSymbol:
+	return SignalSymbol(SimpleName(name))
+
+
+class SequentialProcedureCalls(TestCase):
+	"""``ProcedureCallMixin`` is shared with ``ConcurrentProcedureCall`` (tests/unit/Concurrent.py);
+	tested once here since the mixin's own logic doesn't differ between the two."""
+
+	def test_WithParameters(self) -> None:
+		procedureName = Symbol(SimpleName("proc"), PossibleReference.Procedure)
+		parameter = ParameterAssociationItem(None, IntegerLiteral(1))
+		call = SequentialProcedureCall(procedureName, [parameter], label="lbl")
+
+		self.assertIs(procedureName, call.Procedure)
+		self.assertIs(call, procedureName.Parent)
+		self.assertEqual(1, len(call.ParameterAssociationItems))
+		self.assertIs(call, parameter.Parent)
+		self.assertEqual("lbl", call.Label)
+
+	def test_NoParameters(self) -> None:
+		call = SequentialProcedureCall(Symbol(SimpleName("proc"), PossibleReference.Procedure))
+
+		self.assertEqual(0, len(call.ParameterAssociationItems))
+		self.assertIsNone(call.Label)
+
+
+class SequentialSignalAssignments(TestCase):
+	def test_Construction(self) -> None:
+		target = _signalTarget()
+		assignment = SequentialSignalAssignment(target, label="lbl")
+
+		self.assertIs(target, assignment.Target)
+		self.assertIs(assignment, target.Parent)
+		self.assertEqual("lbl", assignment.Label)
+
+
+class SequentialSimpleSignalAssignments(TestCase):
+	def test_Construction(self) -> None:
+		"""``s <= '1';``"""
+		target = _signalTarget()
+		waveformElement = WaveformElement(CharacterLiteral("'1'"))
+		assignment = SequentialSimpleSignalAssignment(target, [waveformElement])
+
+		self.assertIs(target, assignment.Target)
+		self.assertEqual(1, len(assignment.Waveform))
+		self.assertIs(waveformElement, assignment.Waveform[0])
+		self.assertIs(assignment, waveformElement.Parent)
+
+
+class IfStatements(TestCase):
+	def test_IfOnly(self) -> None:
+		ifBranch = IfBranch(IntegerLiteral(1))
+		statement = IfStatement(ifBranch)
+
+		self.assertIs(ifBranch, statement.IfBranch)
+		self.assertIs(statement, ifBranch.Parent)
+		self.assertEqual(0, len(statement.ElsIfBranches))
+		self.assertIsNone(statement.ElseBranch)
+
+	def test_IfElsifElse(self) -> None:
+		from pyVHDLModel.Sequential import ElsifBranch
+
+		ifBranch = IfBranch(IntegerLiteral(1))
+		elsifBranch = ElsifBranch(IntegerLiteral(2))
+		elseBranch = ElseBranch()
+		statement = IfStatement(ifBranch, [elsifBranch], elseBranch)
+
+		self.assertEqual(1, len(statement.ElsIfBranches))
+		self.assertIs(elsifBranch, statement.ElsIfBranches[0])
+		self.assertIs(statement, elsifBranch.Parent)
+		self.assertIs(elseBranch, statement.ElseBranch)
+		self.assertIs(statement, elseBranch.Parent)
+
+
+class Choices(TestCase):
+	"""Regression test: ``IndexedChoice``'s ``expression.Parent = self`` was previously commented out
+	(``# FIXME: received None``) - confirmed stale in the gap analysis (every real construction site
+	always provides a real expression) and now re-enabled."""
+
+	def test_IndexedChoice(self) -> None:
+		expression = IntegerLiteral(0)
+		choice = IndexedChoice(expression)
+
+		self.assertIs(expression, choice.Expression)
+		self.assertIs(choice, expression.Parent)
+		self.assertEqual("0", str(choice))
+
+	def test_RangedChoice(self) -> None:
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		choice = RangedChoice(rng)
+
+		self.assertIs(rng, choice.Range)
+		self.assertIs(choice, rng.Parent)
+		self.assertEqual("0 to 3", str(choice))
+
+
+class Cases(TestCase):
+	def test_Case(self) -> None:
+		choice = IndexedChoice(IntegerLiteral(0))
+		case = Case([choice])
+
+		self.assertEqual(1, len(case.Choices))
+		self.assertEqual("when 0 =>", str(case))
+
+	def test_Case_MultipleChoices(self) -> None:
+		"""``when 0 | 1 =>``"""
+		case = Case([IndexedChoice(IntegerLiteral(0)), IndexedChoice(IntegerLiteral(1))])
+
+		self.assertEqual("when 0 | 1 =>", str(case))
+
+	def test_OthersCase(self) -> None:
+		case = OthersCase()
+
+		self.assertEqual(0, len(case.Choices))
+		self.assertEqual("when others =>", str(case))
+
+
+class CaseStatements(TestCase):
+	def test_Construction(self) -> None:
+		expression = IntegerLiteral(0)
+		case = Case([IndexedChoice(IntegerLiteral(0))])
+		statement = CaseStatement(expression, [case])
+
+		self.assertIs(expression, statement.SelectExpression)
+		self.assertIs(statement, expression.Parent)
+		self.assertEqual(1, len(statement.Cases))
+		self.assertIs(case, statement.Cases[0])
+		self.assertIs(statement, case.Parent)
+
+
+class LoopStatements(TestCase):
+	def test_EndlessLoopStatement(self) -> None:
+		statement = EndlessLoopStatement(label="lbl")
+
+		self.assertEqual("lbl", statement.Label)
+		self.assertEqual(0, len(statement.Statements))
+
+	def test_ForLoopStatement(self) -> None:
+		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		statement = ForLoopStatement("i", rng)
+
+		self.assertEqual("i", statement.LoopIndex)
+		self.assertIs(rng, statement.Range)
+		self.assertIs(statement, rng.Parent)
+
+	def test_WhileLoopStatement(self) -> None:
+		condition = IntegerLiteral(1)
+		statement = WhileLoopStatement(condition)
+
+		self.assertIs(condition, statement.Condition)
+
+
+class LoopControlStatements(TestCase):
+	"""Regression test: ``_loopReference`` was declared but never initialized in
+	``LoopControlStatement.__init__`` - the same crash-on-first-property-access shape as the fixed
+	``DeferredConstant`` bug. ``NextStatement``/``ExitStatement`` add no state of their own, so the
+	fix is tested via both, once each."""
+
+	def test_NextStatement(self) -> None:
+		condition = IntegerLiteral(1)
+		statement = NextStatement(condition)
+
+		self.assertIs(condition, statement.Condition)
+		self.assertIsNone(statement.LoopReference)
+
+	def test_ExitStatement(self) -> None:
+		statement = ExitStatement()
+
+		self.assertIsNone(statement.Condition)
+		self.assertIsNone(statement.LoopReference)
+
+
+class NullStatements(TestCase):
+	def test_Construction(self) -> None:
+		statement = NullStatement(label="lbl")
+
+		self.assertEqual("lbl", statement.Label)
+
+
+class ReturnStatements(TestCase):
+	def test_WithValue(self) -> None:
+		value = IntegerLiteral(1)
+		statement = ReturnStatement(value)
+
+		self.assertIs(value, statement.ReturnValue)
+		self.assertIs(statement, value.Parent)
+
+	def test_WithoutValue(self) -> None:
+		"""``return;`` (procedures) vs. ``return expr;`` (functions)."""
+		statement = ReturnStatement()
+
+		self.assertIsNone(statement.ReturnValue)
+
+
+class WaitStatements(TestCase):
+	def test_Empty(self) -> None:
+		"""``wait;``"""
+		statement = WaitStatement()
+
+		self.assertIsNone(statement.SensitivityList)
+		self.assertIsNone(statement.Condition)
+		self.assertIsNone(statement.Timeout)
+
+	def test_Full(self) -> None:
+		"""``wait on clock until condition for 10 ns;``"""
+		sensitivitySignal = _signalTarget("clock")
+		condition = IntegerLiteral(1)
+		timeout = PhysicalIntegerLiteral(10, "ns")
+		statement = WaitStatement([sensitivitySignal], condition, timeout)
+
+		self.assertEqual(1, len(statement.SensitivityList))
+		self.assertIs(sensitivitySignal, statement.SensitivityList[0])
+		self.assertIs(statement, sensitivitySignal.Parent)
+		self.assertIs(condition, statement.Condition)
+		self.assertIs(statement, condition.Parent)
+		self.assertIs(timeout, statement.Timeout)
+		self.assertIs(statement, timeout.Parent)

--- a/tests/unit/Subprogram.py
+++ b/tests/unit/Subprogram.py
@@ -1,0 +1,135 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Subprogram."""
+from unittest import TestCase
+
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import SimpleSubtypeSymbol
+from pyVHDLModel.Sequential  import NullStatement
+from pyVHDLModel.Type        import ProtectedType
+from pyVHDLModel.Subprogram  import Procedure, Function, ProcedureMethod, FunctionMethod
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _returnType(name: str = "integer") -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName(name))
+
+
+class Procedures(TestCase):
+	"""``Subprogram`` itself is not meant to be instantiated directly (there's no VHDL construct that
+	is "just" a subprogram, only procedures and functions) - its shared declared-items/statements/
+	generic-items/parameter-items wiring is tested once here via ``Procedure``, the simpler of its two
+	concrete subclasses, rather than on the base class itself."""
+
+	def test_Minimal(self) -> None:
+		procedure = Procedure("proc")
+
+		self.assertEqual("proc", procedure.Identifier)
+		self.assertFalse(procedure.IsPure)
+		self.assertEqual(0, len(procedure.GenericItems))
+		self.assertEqual(0, len(procedure.ParameterItems))
+		self.assertEqual(0, len(procedure.DeclaredItems))
+		self.assertEqual(0, len(procedure.Statements))
+
+	def test_WithDeclaredItemsAndStatements(self) -> None:
+		declaredItem = Procedure("nested")
+		statement = NullStatement()
+		procedure = Procedure("proc", declaredItems=[declaredItem], statements=[statement])
+
+		self.assertEqual(1, len(procedure.DeclaredItems))
+		self.assertIs(procedure, declaredItem.Parent)
+		self.assertEqual(1, len(procedure.Statements))
+		self.assertIs(procedure, statement.Parent)
+
+	def test_WithGenericAndParameterItems(self) -> None:
+		"""Uses bare ``Procedure`` stand-ins for the generic/parameter items - only ``.Parent``-wiring
+		is exercised here, and real ``GenericInterfaceItemMixin``/``ParameterInterfaceItemMixin``
+		classes are covered in tests/unit/Interface.py."""
+		genericItem = Procedure("generic_item")
+		parameterItem = Procedure("parameter_item")
+		procedure = Procedure("proc", genericItems=[genericItem], parameterItems=[parameterItem])
+
+		self.assertEqual(1, len(procedure.GenericItems))
+		self.assertIs(procedure, genericItem.Parent)
+		self.assertEqual(1, len(procedure.ParameterItems))
+		self.assertIs(procedure, parameterItem.Parent)
+
+
+class Functions(TestCase):
+	def test_Minimal(self) -> None:
+		returnType = _returnType()
+		function = Function("func", returnType)
+
+		self.assertIs(returnType, function.ReturnType)
+		self.assertIs(function, returnType.Parent)
+		self.assertTrue(function.IsPure)
+
+	def test_Impure(self) -> None:
+		function = Function("func", _returnType(), isPure=False)
+
+		self.assertFalse(function.IsPure)
+
+
+class MethodMixinHosts(TestCase):
+	"""Regression test: ``MethodMixin.__init__`` set ``protectedType.Parent = self`` unconditionally,
+	but ``protectedType`` genuinely defaults to ``None`` at both call sites (a subprogram declared
+	directly in a protected type body still goes through the same constructor) - so the common,
+	no-argument case crashed immediately with ``AttributeError: 'NoneType' object has no attribute
+	'Parent'``. Fixed to null-check like every other optional-reference mixin in this codebase."""
+
+	def test_ProcedureMethod_WithoutProtectedType(self) -> None:
+		method = ProcedureMethod("proc")
+
+		self.assertIsNone(method.ProtectedType)
+
+	def test_ProcedureMethod_WithProtectedType(self) -> None:
+		protectedType = ProtectedType("pt")
+		method = ProcedureMethod("proc", protectedType=protectedType)
+
+		self.assertIs(protectedType, method.ProtectedType)
+		self.assertIs(method, protectedType.Parent)
+
+	def test_FunctionMethod_WithoutProtectedType(self) -> None:
+		method = FunctionMethod("func", _returnType())
+
+		self.assertIsNone(method.ProtectedType)
+
+	def test_FunctionMethod_WithProtectedType(self) -> None:
+		protectedType = ProtectedType("pt")
+		method = FunctionMethod("func", _returnType(), protectedType=protectedType)
+
+		self.assertIs(protectedType, method.ProtectedType)
+		self.assertIs(method, protectedType.Parent)

--- a/tests/unit/Symbol.py
+++ b/tests/unit/Symbol.py
@@ -1,0 +1,221 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Tests for pyVHDLModel.Symbol.
+
+Most ``Symbol`` subclasses share an identical shape: constructed from just a ``Name``, fixed to one
+``PossibleReference`` flag, with a single settable property used to store the resolved reference.
+That shared shape is tested once, table-driven, in ``SimpleReferenceSymbols`` instead of one
+hand-written test per class. Classes with distinct behaviour (constraints, the ``Symbol`` base
+itself, the object/function-call symbols with no dedicated property) get their own test class.
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Base   import Direction, Range
+from pyVHDLModel.Name   import SimpleName, AllName
+from pyVHDLModel.Expression import IntegerLiteral
+from pyVHDLModel.Symbol import (
+	PossibleReference, Symbol,
+	LibraryReferenceSymbol, PackageReferenceSymbol, ModeViewSymbol, SubprogramReferenceSymbol,
+	ConfigurationSymbol, VariableSymbol, SignalSymbol, ContextReferenceSymbol,
+	PackageMemberReferenceSymbol, AllPackageMembersReferenceSymbol,
+	EntityInstantiationSymbol, ComponentInstantiationSymbol, ConfigurationInstantiationSymbol,
+	EntitySymbol, ArchitectureSymbol, PackageSymbol,
+	RecordElementSymbol, SubtypeSymbol, SimpleSubtypeSymbol,
+	ConstrainedScalarSubtypeSymbol, ConstrainedArraySubtypeSymbol, ConstrainedRecordSubtypeSymbol,
+	SimpleObjectOrFunctionCallSymbol, IndexedObjectOrFunctionCallSymbol,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class SymbolBase(TestCase):
+	"""``Symbol`` itself (used directly for e.g. ``Alias.Name``, which has no single fixed
+	``PossibleReference`` - see the design note in tests/unit/Declaration.py)."""
+
+	def test_Unresolved(self) -> None:
+		name = SimpleName("s")
+		symbol = Symbol(name, PossibleReference.Signal | PossibleReference.Variable)
+
+		self.assertIs(name, symbol.Name)
+		self.assertIsNone(symbol.Reference)
+		self.assertFalse(symbol.IsResolved)
+		self.assertFalse(bool(symbol))
+		self.assertEqual("s?", str(symbol))
+		self.assertEqual("Symbol: 's' -> unresolved", repr(symbol))
+
+	def test_Resolved(self) -> None:
+		"""Resolution is exposed through each subclass's own named property (see
+		``SimpleReferenceSymbols`` below); the base class only exposes the generic, readonly
+		``Reference``/``IsResolved``/``__bool__``/``__str__`` machinery every subclass inherits."""
+		symbol = LibraryReferenceSymbol(SimpleName("ieee"))
+		library = object()
+		symbol.Library = library
+
+		self.assertIs(library, symbol.Reference)
+		self.assertTrue(symbol.IsResolved)
+		self.assertTrue(bool(symbol))
+		self.assertEqual(str(library), str(symbol))
+		self.assertIn("->", repr(symbol))
+
+
+# (SymbolClass, property name, expected PossibleReference)
+_SIMPLE_REFERENCE_SYMBOLS = (
+	(LibraryReferenceSymbol,              "Library",       PossibleReference.Library),
+	(PackageReferenceSymbol,              "Package",       PossibleReference.Package),
+	(ModeViewSymbol,                      "ModeView",      PossibleReference.View),
+	(SubprogramReferenceSymbol,           "Subprogram",    PossibleReference.SubProgram),
+	(ConfigurationSymbol,                 "Configuration", PossibleReference.Configuration),
+	(VariableSymbol,                      "Variable",      PossibleReference.Variable),
+	(SignalSymbol,                        "Signal",        PossibleReference.Signal),
+	(ContextReferenceSymbol,              "Context",       PossibleReference.Context),
+	(PackageMemberReferenceSymbol,        "Member",        PossibleReference.PackageMember),
+	(EntityInstantiationSymbol,           "Entity",        PossibleReference.Entity),
+	(ComponentInstantiationSymbol,        "Component",     PossibleReference.Component),
+	(ConfigurationInstantiationSymbol,    "Configuration", PossibleReference.Configuration),
+	(EntitySymbol,                        "Entity",        PossibleReference.Entity),
+	(ArchitectureSymbol,                  "Architecture",  PossibleReference.Architecture),
+	(PackageSymbol,                       "Package",       PossibleReference.Package),
+)
+
+
+class SimpleReferenceSymbols(TestCase):
+	def test_AllVariants(self) -> None:
+		for symbolClass, propertyName, possibleReference in _SIMPLE_REFERENCE_SYMBOLS:
+			with self.subTest(symbol=symbolClass.__name__):
+				name = SimpleName("target")
+				symbol = symbolClass(name)
+
+				self.assertIs(name, symbol.Name)
+				self.assertIs(possibleReference, symbol._possibleReferences)
+				self.assertIsNone(getattr(symbol, propertyName))
+				self.assertFalse(symbol.IsResolved)
+
+				target = object()
+				setattr(symbol, propertyName, target)
+
+				self.assertIs(target, getattr(symbol, propertyName))
+				self.assertIs(target, symbol.Reference)
+				self.assertTrue(symbol.IsResolved)
+
+	def test_AllPackageMembersReferenceSymbol(self) -> None:
+		"""Same shape as the table above, but the name must be an ``AllName``
+		(``use pkg.all;``), not a plain ``Name``, and the property is plural (``Members``)."""
+		name = AllName(SimpleName("pkg"))
+		symbol = AllPackageMembersReferenceSymbol(name)
+
+		self.assertIs(name, symbol.Name)
+		self.assertIs(PossibleReference.PackageMember, symbol._possibleReferences)
+		self.assertIsNone(symbol.Members)
+
+		target = object()
+		symbol.Members = target
+
+		self.assertIs(target, symbol.Members)
+
+
+class NoPropertyReferenceSymbols(TestCase):
+	"""``RecordElementSymbol``, ``SimpleObjectOrFunctionCallSymbol`` and
+	``IndexedObjectOrFunctionCallSymbol`` fix a ``PossibleReference`` like the table above, but expose
+	no dedicated named property - only the base ``Symbol.Reference``."""
+
+	def test_RecordElementSymbol(self) -> None:
+		symbol = RecordElementSymbol(SimpleName("field"))
+
+		self.assertIs(PossibleReference.RecordElement, symbol._possibleReferences)
+		self.assertIsNone(symbol.Reference)
+
+	def test_SimpleObjectOrFunctionCallSymbol(self) -> None:
+		symbol = SimpleObjectOrFunctionCallSymbol(SimpleName("x"))
+
+		self.assertIs(PossibleReference.SimpleNameInExpression, symbol._possibleReferences)
+
+	def test_IndexedObjectOrFunctionCallSymbol(self) -> None:
+		symbol = IndexedObjectOrFunctionCallSymbol(SimpleName("x"))
+
+		self.assertIs(PossibleReference.Object | PossibleReference.Function, symbol._possibleReferences)
+
+
+class SubtypeSymbols(TestCase):
+	def test_SubtypeSymbol(self) -> None:
+		name = SimpleName("std_logic")
+		symbol = SubtypeSymbol(name)
+
+		self.assertIs(PossibleReference.Type | PossibleReference.Subtype, symbol._possibleReferences)
+		self.assertIsNone(symbol.Subtype)
+
+		target = object()
+		symbol.Subtype = target
+
+		self.assertIs(target, symbol.Subtype)
+
+	def test_SimpleSubtypeSymbol(self) -> None:
+		"""``SimpleSubtypeSymbol`` adds no behaviour of its own over ``SubtypeSymbol``."""
+		symbol = SimpleSubtypeSymbol(SimpleName("bit"))
+
+		self.assertIsNone(symbol.Subtype)
+
+
+class ConstrainedSubtypeSymbols(TestCase):
+	"""``signal s : integer range 0 to 15;`` / ``std_logic_vector(7 downto 0)`` / record constraints."""
+
+	def test_ScalarConstraint_WithRange(self) -> None:
+		constraint = Range(IntegerLiteral(0), IntegerLiteral(15), Direction.To)
+		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"), constraint)
+
+		self.assertIs(constraint, symbol.Constraint)
+
+	def test_ScalarConstraint_WithoutRange(self) -> None:
+		"""``None`` only means the range constraint was written as an attribute name
+		(``subtype s is t'range;``), which isn't implemented yet - not that the source omitted a
+		constraint (it never does for a constrained scalar subtype). See ``Constraint``'s docstring."""
+		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"))
+
+		self.assertIsNone(symbol.Constraint)
+
+	def test_ArrayConstraint(self) -> None:
+		constraint = Range(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)
+		symbol = ConstrainedArraySubtypeSymbol(SimpleName("std_logic_vector"), [constraint])
+
+		self.assertEqual(1, len(symbol.Constraints))
+		self.assertIs(constraint, symbol.Constraints[0])
+
+	def test_RecordConstraint(self) -> None:
+		element = RecordElementSymbol(SimpleName("field"))
+		constraint = Range(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)
+		symbol = ConstrainedRecordSubtypeSymbol(SimpleName("rec_t"), {element: constraint})
+
+		self.assertEqual(1, len(symbol.Constraints))
+		self.assertIs(constraint, symbol.Constraints[element])

--- a/tests/unit/Type.py
+++ b/tests/unit/Type.py
@@ -1,0 +1,311 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Tests for pyVHDLModel.Type."""
+from unittest import TestCase
+
+from pyVHDLModel.Base       import ModelEntity, Direction, Range
+from pyVHDLModel.Name       import SimpleName, AttributeName
+from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
+from pyVHDLModel.Expression import IntegerLiteral, EnumerationLiteral, PhysicalIntegerLiteral
+from pyVHDLModel.Type       import (
+	Subtype, RangedScalarType,
+	EnumeratedType, IntegerType, RealType, PhysicalType,
+	ArrayType, RecordTypeElement, RecordType, ProtectedType, ProtectedTypeBody,
+	AccessType, FileType,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName(name))
+
+
+def _range(left: int = 0, right: int = 15, direction: Direction = Direction.To) -> Range:
+	return Range(IntegerLiteral(left), IntegerLiteral(right), direction)
+
+
+class ParentAndDocumentationWiringAcrossAllLeafTypes(TestCase):
+	"""``BaseType`` provides identifier/documentation/parent handling and the (private,
+	regression-tested-here) ``_objectVertex`` slot to every type class - but ``Type``, ``AnonymousType``,
+	``FullType``, ``ScalarType``, ``CompositeType`` and ``RangedScalarType`` are pure taxonomy markers
+	with no VHDL construct of their own (never directly instantiated anywhere in pyGHDL.dom, confirmed
+	by grep) and either add no ``__init__`` override at all, or (``RangedScalarType``) are only ever
+	reached through a further concrete subclass - so they are deliberately not instantiated directly
+	here. Instead, every *concrete* leaf type below is checked directly, one by one, rather than
+	assuming "tested once via the base class" is enough.
+
+	That assumption is exactly what let a real bug through: unlike a true mixin (one shared
+	implementation), each concrete leaf class below defines its *own* ``__init__`` that independently
+	forwards to ``BaseType.__init__``, so each one carries its own, separate risk of getting that
+	forwarding call wrong. Confirmed and fixed here: every single one of them called
+	``super().__init__(identifier, parent)`` positionally, which ``BaseType``'s
+	``(identifier, documentation=None, parent=None)`` signature silently misinterprets - ``parent``
+	landed in the ``documentation`` slot, and the real ``Parent`` chain was never set (e.g.
+	``ProtectedType("pt", parent=parent)`` previously left ``.Parent`` as ``None`` and
+	``.Documentation`` holding the parent object itself).
+
+	None of these classes exposed their own ``documentation`` parameter at all (only ``BaseType``
+	did) - fixed alongside the ``Parent`` bug, since it's the same forwarding call: every constructor
+	below now accepts ``documentation`` in the same position as ``BaseType`` itself, so each
+	``super().__init__(identifier, documentation, parent)`` call is a plain, correctly-ordered
+	positional forward - no ``parent=`` keyword workaround needed anymore."""
+
+	def test_AllLeafTypes(self) -> None:
+		parent = ModelEntity()
+		builders = (
+			("Subtype", lambda: Subtype("t", _subtypeSymbol(), "doc", parent)),
+			("EnumeratedType", lambda: EnumeratedType("t", [], "doc", parent)),
+			("IntegerType", lambda: IntegerType("t", _range(), "doc", parent)),
+			("RealType", lambda: RealType("t", _range(), "doc", parent)),
+			("PhysicalType", lambda: PhysicalType("t", _range(), "ps", [], "doc", parent)),
+			("ArrayType", lambda: ArrayType("t", [], _subtypeSymbol(), "doc", parent)),
+			("RecordType", lambda: RecordType("t", None, "doc", parent)),
+			("ProtectedType", lambda: ProtectedType("t", None, "doc", parent)),
+			("ProtectedTypeBody", lambda: ProtectedTypeBody("t", None, "doc", parent)),
+			("AccessType", lambda: AccessType("t", _subtypeSymbol(), "doc", parent)),
+			("FileType", lambda: FileType("t", _subtypeSymbol(), "doc", parent)),
+		)
+		for name, build in builders:
+			with self.subTest(type=name):
+				instance = build()
+
+				self.assertIs(parent, instance.Parent)
+				self.assertEqual("doc", instance.Documentation)
+
+	def test_ObjectVertexRegression(self) -> None:
+		"""Regression test, checked once via ``EnumeratedType`` as a representative leaf class (the
+		bug was in ``BaseType.__init__`` itself, shared unchanged by every leaf type): the constructor
+		previously assigned a bare local variable (``_objectVertex = None``) instead of
+		``self._objectVertex = None``, so the declared slot was never actually initialized by the
+		constructor - only ever set from the outside, later, by the object-graph builder in
+		pyVHDLModel/__init__.py. There's no public property for it (unlike
+		``Object.Obj.ObjectVertex``), so this is checked via the private attribute directly."""
+		enumType = EnumeratedType("t", [])
+
+		self.assertIsNone(enumType._objectVertex)
+
+
+class Subtypes(TestCase):
+	def test_Construction(self) -> None:
+		symbol = _subtypeSymbol("std_logic")
+		subtype = Subtype("my_std_logic", symbol)
+
+		self.assertEqual("my_std_logic", subtype.Identifier)
+		self.assertIs(symbol, subtype.Type)
+		self.assertIsNone(subtype.BaseType)
+		self.assertIsNone(subtype.Range)
+		self.assertIsNone(subtype.ResolutionFunction)
+		self.assertEqual("subtype my_std_logic is None", str(subtype))
+
+
+class EnumeratedTypes(TestCase):
+	def test_Construction(self) -> None:
+		literal0 = EnumerationLiteral("'0'")
+		literal1 = EnumerationLiteral("'1'")
+		enumType = EnumeratedType("my_bit", [literal0, literal1])
+
+		self.assertEqual(2, len(enumType.Literals))
+		self.assertIs(enumType, literal0.Parent)
+		self.assertIs(enumType, literal1.Parent)
+		self.assertEqual("my_bit is ('0', '1')", str(enumType))
+
+	def test_NoLiterals(self) -> None:
+		"""``literals`` has no default value in the signature, but the body still guards for ``None``
+		explicitly - accepted here even though nothing currently calls it that way."""
+		enumType = EnumeratedType("empty", None)
+
+		self.assertEqual(0, len(enumType.Literals))
+
+
+class IntegerTypes(TestCase):
+	"""Also covers ``RangedScalarType.Range`` (shared, unmodified, by ``IntegerType``/``RealType``/
+	``PhysicalType``): it accepts either a literal ``Range`` or a ``Name`` (an attribute-based range,
+	e.g. ``type t is range r'range;``), matching its ``Union[Range, Name]`` type hint - checked once
+	here since this behaviour genuinely is a single, shared implementation, unlike the constructor-
+	forwarding concern above."""
+
+	def test_WithLiteralRange(self) -> None:
+		rng = _range(0, 15)
+		integerType = IntegerType("nibble", rng)
+
+		self.assertIs(rng, integerType.Range)
+		self.assertEqual("nibble is range 0 to 15", str(integerType))
+
+	def test_WithAttributeRange(self) -> None:
+		rng = AttributeName("range", SimpleName("r"))
+		integerType = IntegerType("t", rng)
+
+		self.assertIs(rng, integerType.Range)
+
+
+class RealTypes(TestCase):
+	def test_Construction(self) -> None:
+		rng = _range(0, 1)
+		realType = RealType("fraction", rng)
+
+		self.assertIs(rng, realType.Range)
+		self.assertEqual("fraction is range 0 to 1", str(realType))
+
+
+class PhysicalTypes(TestCase):
+	def test_Construction(self) -> None:
+		rng = _range(0, 1000)
+		femtoSeconds = PhysicalIntegerLiteral(1000, "fs")
+		physicalType = PhysicalType("my_time", rng, "ps", [("fs", femtoSeconds)])
+
+		self.assertIs(rng, physicalType.Range)
+		self.assertEqual("ps", physicalType.PrimaryUnit)
+		self.assertEqual(1, len(physicalType.SecondaryUnits))
+		self.assertEqual("fs", physicalType.SecondaryUnits[0][0])
+		self.assertIs(femtoSeconds, physicalType.SecondaryUnits[0][1])
+		self.assertIs(physicalType, femtoSeconds.Parent)
+		self.assertEqual("my_time is range 0 to 1000 units ps; fs = 1000 fs;", str(physicalType))
+
+	def test_NoSecondaryUnits(self) -> None:
+		physicalType = PhysicalType("my_time", _range(0, 1000), "ps", [])
+
+		self.assertEqual(0, len(physicalType.SecondaryUnits))
+
+
+class ArrayTypes(TestCase):
+	"""Regression-tracking test, not a regression fix: still-open gap, already confirmed and
+	documented in the gap analysis - ``ArrayType.__init__`` deliberately (if unfortunately) never
+	wires up ``Parent`` for its indices or element subtype (both ``.Parent = self`` lines are
+	commented out with a FIXME). This locks in the *current* behaviour so a future fix shows up as an
+	intentional test change, not a silent regression."""
+
+	def test_Construction(self) -> None:
+		index = _range(0, 7)
+		elementSubtype = _subtypeSymbol("std_logic")
+		arrayType = ArrayType("my_vector", [index], elementSubtype)
+
+		self.assertEqual(1, len(arrayType.Dimensions))
+		self.assertIs(index, arrayType.Dimensions[0])
+		self.assertIs(elementSubtype, arrayType.ElementType)
+		self.assertEqual("my_vector is array(0 to 7) of std_logic?", str(arrayType))
+
+	def test_ParentIsNotWiredYet(self) -> None:
+		"""``index.Parent`` is genuinely ``None`` (``Range`` is a ``ModelEntity`` with a declared
+		``Parent`` property), but ``elementSubtype.Parent`` doesn't even exist as an attribute -
+		``Symbol`` isn't a ``ModelEntity`` (see the design note in tests/unit/Symbol.py) and nothing
+		ever assigns it here, so there's no ad-hoc attribute to find either."""
+		index = _range(0, 7)
+		elementSubtype = _subtypeSymbol("std_logic")
+		arrayType = ArrayType("my_vector", [index], elementSubtype)
+
+		self.assertIsNone(index.Parent)
+		self.assertFalse(hasattr(elementSubtype, "Parent"))
+
+
+class RecordTypeElements(TestCase):
+	def test_Construction(self) -> None:
+		subtype = _subtypeSymbol("natural")
+		element = RecordTypeElement(["a", "b"], subtype)
+
+		self.assertEqual(("a", "b"), element.Identifiers)
+		self.assertIs(subtype, element.Subtype)
+		self.assertIs(element, subtype.Parent)
+		self.assertEqual("a, b : natural?", str(element))
+
+
+class RecordTypes(TestCase):
+	def test_WithElements(self) -> None:
+		element = RecordTypeElement(["a"], _subtypeSymbol("natural"))
+		recordType = RecordType("my_record", [element])
+
+		self.assertEqual(1, len(recordType.Elements))
+		self.assertIs(element, recordType.Elements[0])
+		self.assertIs(recordType, element.Parent)
+		self.assertEqual("my_record is record a : natural?;", str(recordType))
+
+	def test_NoElements(self) -> None:
+		recordType = RecordType("my_record")
+
+		self.assertEqual(0, len(recordType.Elements))
+
+
+class ProtectedTypes(TestCase):
+	"""``methods`` accepts any pre-built ``ModelEntity`` for its parent-wiring; a plain ``ModelEntity``
+	stand-in keeps this test independent from Subprogram.py, which gets its own dedicated slice."""
+
+	def test_WithMethods(self) -> None:
+		method = ModelEntity()
+		protectedType = ProtectedType("my_protected", [method])
+
+		self.assertEqual(1, len(protectedType.Methods))
+		self.assertIs(protectedType, method.Parent)
+
+	def test_NoMethods(self) -> None:
+		protectedType = ProtectedType("my_protected")
+
+		self.assertEqual(0, len(protectedType.Methods))
+
+
+class ProtectedTypeBodies(TestCase):
+	def test_WithDeclaredItems(self) -> None:
+		method = ModelEntity()
+		body = ProtectedTypeBody("my_protected", [method])
+
+		self.assertEqual(1, len(body.Methods))
+		self.assertIs(body, method.Parent)
+
+	def test_NoDeclaredItems(self) -> None:
+		body = ProtectedTypeBody("my_protected")
+
+		self.assertEqual(0, len(body.Methods))
+
+
+class AccessTypes(TestCase):
+	def test_Construction(self) -> None:
+		designated = _subtypeSymbol("natural")
+		accessType = AccessType("my_pointer", designated)
+
+		self.assertIs(designated, accessType.DesignatedSubtype)
+		self.assertIs(accessType, designated.Parent)
+		self.assertEqual("my_pointer is access natural?", str(accessType))
+
+
+class FileTypes(TestCase):
+	"""Regression test: ``__str__`` previously read ``"...is access ..."`` - copy-pasted from
+	``AccessType`` - instead of the correct ``"...is file of ..."``."""
+
+	def test_Construction(self) -> None:
+		designated = _subtypeSymbol("character")
+		fileType = FileType("text", designated)
+
+		self.assertIs(designated, fileType.DesignatedSubtype)
+		self.assertIs(fileType, designated.Parent)
+		self.assertEqual("text is file of character?", str(fileType))


### PR DESCRIPTION
## Summary

Systematic level-1 test coverage sweep: instantiate every model entity with required and optional
parameter combinations, verify property accessibility, and check parent-wiring. Driven by
`pytest-cov` to find and prioritize actual gaps rather than guessing. Shared mixins are tested once
via a canonical host rather than duplicated per consuming class; classes with no independent VHDL
construct of their own (`Subprogram`, `Type`/`FullType`/`ScalarType`/`CompositeType`/
`RangedScalarType`, `Allocation`) are tested only through their real concrete subclasses, never
directly - confirmed via grep that pyGHDL.dom never constructs them directly either.

- New test modules: `Base`, `Name`, `Symbol`, `Object`, `Type`, `Expression`, `DesignUnit`,
  `Concurrent`, `Sequential`, `Instantiation`, `Subprogram`; `Interface` and `Configuration` extended.
- Coverage: **71% → 85%** overall, **117 → 361** tests.
- pyGHDL.dom's pyunit suite (123 tests) re-verified clean against every change in this branch.

### Bugs found and fixed while writing these tests

- `Name.OpenName.__init__` — positional-argument mixup crashed any `OpenName(parent=...)` call.
- `Object.DeferredConstant` / `Sequential.LoopControlStatement` — uninitialized slots crashed
  `.ConstantReference` / `.LoopReference` on first access (same shape as the previously-fixed
  `Function.ReturnType` bug).
- **`Type.py` — every concrete type class** (`Subtype`, `EnumeratedType`, `IntegerType`/`RealType`/
  `PhysicalType` via `RangedScalarType`, `ArrayType`, `RecordType`, `ProtectedType`,
  `ProtectedTypeBody`, `AccessType`, `FileType`) forwarded `super().__init__(identifier, parent)`
  positionally, which `BaseType`'s `(identifier, documentation=None, parent=None)` signature silently
  misinterpreted — `parent` landed in the `documentation` slot, and the real `Parent` chain was never
  set. Fixed across all of them, and added a real `documentation` parameter to each (in the same
  position `BaseType` expects it), so every constructor is now a plain, correctly-ordered positional
  forward. This bug was specifically hidden by testing shared behaviour only on the abstract base
  class rather than through each concrete subclass — which is exactly why none of these classes are
  tested directly anymore.
- `Type.FileType.__str__` — said `"...is access..."` (copy-pasted from `AccessType`), now
  `"...is file of..."`.
- `Expression.UnaryExpression` / `Sequential.IndexedChoice` — re-enabled two `Parent`-wiring lines the
  prior gap analysis had already confirmed safe to re-enable.
- `Concurrent.ConcurrentStatementsMixin.IndexStatements` — nested block statements were written to
  `_hierarchy` but `IterateInstantiations` reads `_blocks`, so instantiations nested inside a block
  were invisible to it.
- `Concurrent.IfGenerateStatement`'s `Parent` setter — namespace-naming fallback compared against
  `""` instead of `None`, so it never fired for the common unlabelled-branch case.
- `Subprogram.MethodMixin.__init__` — crashed on its own default (no `protectedType`) case.
- `Interface.GenericGroup` / `ParameterGroup` — missing a base class each (`WithGenericsMixin` /
  `WithParametersMixin`), so construction crashed outright even for an empty list.

### Deliberately left open

Tracked externally for deliberate follow-up rather than fixed inline (each needs a real design
decision, not a one-liner) - happy to share that note if useful:

- **HIGH PRIORITY**: `GenericFunctionInterfaceItem` — confirmed **live**-reachable via pyGHDL.dom's
  actual translation dispatch for VHDL-2008 generic-function clauses, not just a landmine.
- `TernaryExpression`/`WhenElseExpression` — never accepts/sets its operands; separately, `__str__`
  indexes past its `_FORMAT` tuple.
- `TypeConversion.__str__` — no field for the target type at all.
- `GenericGroup`/`PortGroup`/`ParameterGroup.__str__` — crash depending on item mix (singular vs.
  plural identifier shape).
- `QualifiedExpression.Subtyped` — likely-unintentional property name (no call sites anywhere).
- `ConcurrentDeclarationRegionMixin.Functions`/`.Procedures` — silently collide on overloads.
- pyGHDL.dom's own `Type.py` mirror classes now pass a stale positional `None` that lands in the new
  `documentation` slot instead of `parent` - confirmed harmless today (verified against the full
  pyGHDL.dom suite), but worth a follow-up there whenever documentation extraction is wired up.
- Two `Namespace.py` items, set aside per your direction (tested separately).

## Test plan

- [x] `pytest tests/unit` — 361 passed
- [x] pyGHDL.dom pyunit suite (dom/libghdl/lsp) — 123 passed, 5 skipped, 16 xfailed, re-run after every change in this branch
