### PR TITLE
Three small cleanups from the test-strategy findings

### DIFF
--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -84,16 +84,12 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 	_statements:     List[ConcurrentStatement]
 
 	_instantiations: Dict[str, 'Instantiation']  # TODO: add another instantiation class level for entity/configuration/component inst.
-	_blocks:         Dict[str, 'ConcurrentBlockStatement']
-	_generates:      Dict[str, 'GenerateStatement']
-	_hierarchy:      Dict[str, Union['ConcurrentBlockStatement', 'GenerateStatement']]
+	_hierarchy:      Dict[str, Union['ConcurrentBlockStatement', 'GenerateStatement']]  #: All elements creating a hierarchy level (blocks and generates), in declaration order.
 
 	def __init__(self, statements: Nullable[Iterable[ConcurrentStatement]] = None) -> None:
 		self._statements = []
 
 		self._instantiations = {}
-		self._blocks = {}
-		self._generates = {}
 		self._hierarchy = {}
 
 		if statements is not None:
@@ -109,11 +105,8 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 		for instance in self._instantiations.values():
 			yield instance
 
-		for block in self._blocks.values():
-			yield from block.IterateInstantiations()
-
-		for generate in self._generates.values():
-			yield from generate.IterateInstantiations()
+		for element in self._hierarchy.values():
+			yield from element.IterateInstantiations()
 
 	# TODO: move into _init__
 	def IndexStatements(self) -> None:
@@ -121,10 +114,9 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 			if isinstance(statement, (EntityInstantiation, ComponentInstantiation, ConfigurationInstantiation)):
 				self._instantiations[statement.NormalizedLabel] = statement
 			elif isinstance(statement, (ForGenerateStatement, IfGenerateStatement, CaseGenerateStatement)):
-				self._generates[statement.NormalizedLabel] = statement
+				self._hierarchy[statement.NormalizedLabel] = statement
 				statement.IndexStatement()
 			elif isinstance(statement, ConcurrentBlockStatement):
-				self._blocks[statement.NormalizedLabel] = statement
 				self._hierarchy[statement.NormalizedLabel] = statement
 				statement.IndexStatements()
 

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -394,7 +394,7 @@ class Context(PrimaryUnit):
 				elif isinstance(reference, ContextReference):
 					self._contextReferences.append(reference)
 				else:
-					raise VHDLModelException()  # FIXME: needs exception message
+					raise VHDLModelException(f"Reference '{reference!r}' is neither a library clause, use clause, nor context reference.")
 
 	@property
 	def LibraryReferences(self) -> List[LibraryClause]:

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -651,7 +651,7 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 	def Operand(self):
 		return self._operand
 
-	@property
+	@readonly
 	def Subtype(self):
 		return self._subtype
 

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -652,7 +652,7 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 		return self._operand
 
 	@property
-	def Subtyped(self):
+	def Subtype(self):
 		return self._subtype
 
 	def __str__(self) -> str:

--- a/tests/unit/Concurrent.py
+++ b/tests/unit/Concurrent.py
@@ -371,6 +371,8 @@ class ConcurrentStatementsMixinIndexing(TestCase):
 	``ConcurrentStatementsMixin`` host - see tests/unit/DesignUnit.py)."""
 
 	def test_IndexStatements_BucketsByKind(self) -> None:
+		"""Blocks and generates both land in the single, unified ``_hierarchy`` dict (in source/
+		declaration order), not separate per-kind dicts."""
 		entitySymbol = _entitySymbol()
 		instance = ComponentInstantiation("inst", ComponentInstantiationSymbol(SimpleName("comp")))
 		block = ConcurrentBlockStatement("blk")
@@ -382,7 +384,8 @@ class ConcurrentStatementsMixinIndexing(TestCase):
 
 		self.assertIs(instance, architecture._instantiations["inst"])
 		self.assertIs(block, architecture._hierarchy["blk"])
-		self.assertIs(generate, architecture._generates["gen"])
+		self.assertIs(generate, architecture._hierarchy["gen"])
+		self.assertEqual(["blk", "gen"], list(architecture._hierarchy.keys()))
 
 	def test_IterateInstantiations_RecursesIntoBlocksAndGenerates(self) -> None:
 		entitySymbol = _entitySymbol()

--- a/tests/unit/DesignUnit.py
+++ b/tests/unit/DesignUnit.py
@@ -161,12 +161,14 @@ class Contexts(TestCase):
 		self.assertIs(context, library.Parent)
 
 	def test_UnknownReferenceKind_Raises(self) -> None:
-		"""``VHDLModelException()`` is raised with no message at all (``# FIXME: needs exception
-		message`` in the source) - documented as a known, low-priority cosmetic gap; locked in here as
-		current behaviour. Uses a bare ``ModelEntity`` (not ``object()``) since the ``.Parent = self``
-		assignment a few lines above the kind-check runs first and needs a real settable ``Parent``."""
-		with self.assertRaises(VHDLModelException):
+		"""Regression test: ``VHDLModelException()`` previously carried no message at all (``# FIXME:
+		needs exception message`` in the source) - now includes the offending reference. Uses a bare
+		``ModelEntity`` (not ``object()``) since the ``.Parent = self`` assignment a few lines above
+		the kind-check runs first and needs a real settable ``Parent``."""
+		with self.assertRaises(VHDLModelException) as context:
 			Context("ctx", [ModelEntity()])
+
+		self.assertIn("neither a library clause, use clause, nor context reference", str(context.exception))
 
 
 class Packages(TestCase):

--- a/tests/unit/Expression.py
+++ b/tests/unit/Expression.py
@@ -324,7 +324,7 @@ class QualifiedExpressions(TestCase):
 		expression = QualifiedExpression(subtype, operand)
 
 		self.assertIs(operand, expression.Operand)
-		self.assertIs(subtype, expression.Subtyped)
+		self.assertIs(subtype, expression.Subtype)
 		self.assertIs(expression, operand.Parent)
 		self.assertIs(expression, subtype.Parent)
 		self.assertEqual("bit_vector?'(1)", str(expression))


### PR DESCRIPTION
## Summary

Three small cleanups from the recent test-strategy work (#139) - items 1-3 from the follow-up TODO
list. Design decisions for each were discussed and confirmed before implementing.

- **`QualifiedExpression.Subtyped` -> `Subtype`**: every other symmetric case in the model
  (`SubtypeAllocation.Subtype`, `Subtype.Type`, `ConstrainedScalarSubtypeSymbol`, ...) reads
  `.Subtype`; this property had zero call sites anywhere (grepped both repos), so the rename is
  no-risk.
- **`DesignUnitWithContextMixin`** (`Context.__init__`) raised a bare `VHDLModelException()` with no
  message when a reference is neither a `LibraryClause`, `UseClause`, nor `ContextReference`. Now
  includes the offending reference in the message.
- **`ConcurrentStatementsMixin`'s `_blocks`/`_generates`/`_hierarchy` bookkeeping** was a
  partially-implemented, redundant three-dict setup: `_hierarchy` was write-only
  (`IndexStatements` wrote nested block statements into it, but `IterateInstantiations` only ever
  read the separate `_blocks` dict, which got the same writes), while `_generates` duplicated the
  same "just filter by kind" role for generate statements. Unified all of it into a single,
  source-order `_hierarchy` dict (indexing both blocks and generates, in declaration order - the
  same order used to build the elaborated design hierarchy) and derive the blocks-only/
  generates-only views by filtering on `isinstance` where needed (currently just
  `IterateInstantiations`), rather than maintaining three overlapping dicts by hand.

## Test plan

- [x] `pytest tests/unit` - 356 passed
- [x] pyGHDL.dom pyunit suite - 123 passed, 5 skipped, 16 xfailed (unaffected, re-verified)
