### PR TITLE
Fix four expression/interface/region gaps from the test-strategy findings

### DIFF
--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -40,7 +40,7 @@ from typing               import Tuple, List, Iterable, Union, ClassVar, Optiona
 from pyTooling.Decorators import export, readonly
 
 from pyVHDLModel.Base     import ModelEntity, Direction, Range
-from pyVHDLModel.Symbol   import Symbol
+from pyVHDLModel.Symbol   import Symbol, SubtypeSymbol
 
 
 ExpressionUnion = Union[
@@ -364,7 +364,26 @@ class AbsoluteExpression(UnaryExpression):
 
 @export
 class TypeConversion(UnaryExpression):
-	pass
+	"""``natural(x)`` - a type conversion. Unlike every other :class:`UnaryExpression` subclass, its
+	"operator" is the target type name itself, not a fixed string, so it doesn't participate in the
+	shared ``_FORMAT``-based :meth:`UnaryExpression.__str__` at all - it carries its own
+	:attr:`_targetSubtype` (mirroring :class:`QualifiedExpression`'s ``_subtype``) and overrides
+	``__str__`` accordingly."""
+
+	_targetSubtype: SubtypeSymbol
+
+	def __init__(self, targetSubtype: SubtypeSymbol, operand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
+		super().__init__(operand, parent)
+
+		self._targetSubtype = targetSubtype
+		targetSubtype.Parent = self
+
+	@readonly
+	def TargetSubtype(self) -> SubtypeSymbol:
+		return self._targetSubtype
+
+	def __str__(self) -> str:
+		return f"{self._targetSubtype!s}({self._operand!s})"
 
 
 @export
@@ -661,29 +680,41 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 
 @export
 class TernaryExpression(BaseExpression):
-	"""A ``TernaryExpression`` is a base-class for all ternary expressions."""
+	"""
+	A ``TernaryExpression`` is a base-class for all ternary expressions.
 
-	_FORMAT: Tuple[str, str, str, str]
+	The three operands are deliberately *not* exposed as public properties here: unlike
+	:class:`UnaryExpression`/:class:`BinaryExpression` (where "the operand"/"left operand"/"right
+	operand" are already the natural domain names for every consumer), a ternary's three operands
+	play a different semantic role depending on the concrete expression - e.g.
+	:class:`WhenElseExpression`'s are really "then value"/"condition"/"else value". Each concrete
+	subclass is expected to expose its own, appropriately-named properties over the shared
+	``_firstOperand``/``_secondOperand``/``_thirdOperand`` fields, rather than duplicating a
+	generic and a specific name for the same value.
+	"""
+
+	_FORMAT: Tuple[str, str, str, str]  # FIXME: needs ClassVar[...] when pyTooling gets fixed.
 	_firstOperand:  ExpressionUnion
 	_secondOperand: ExpressionUnion
 	_thirdOperand:  ExpressionUnion
 
-	def __init__(self, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(
+		self,
+		firstOperand: ExpressionUnion,
+		secondOperand: ExpressionUnion,
+		thirdOperand: ExpressionUnion,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
 		super().__init__(parent)
 
-		# FIXME: parameters and initializers are missing !!
+		self._firstOperand = firstOperand
+		firstOperand.Parent = self
 
-	@property
-	def FirstOperand(self):
-		return self._firstOperand
+		self._secondOperand = secondOperand
+		secondOperand.Parent = self
 
-	@property
-	def SecondOperand(self):
-		return self._secondOperand
-
-	@property
-	def ThirdOperand(self):
-		return self._thirdOperand
+		self._thirdOperand = thirdOperand
+		thirdOperand.Parent = self
 
 	def __str__(self) -> str:
 		return "{beforeFirstOperator}{firstOperand!s}{beforeSecondOperator}{secondOperand!s}{beforeThirdOperator}{thirdOperand!s}{lastOperator}".format(
@@ -693,13 +724,40 @@ class TernaryExpression(BaseExpression):
 			secondOperand=self._secondOperand,
 			beforeThirdOperator=self._FORMAT[2],
 			thirdOperand=self._thirdOperand,
-			lastOperator=self._FORMAT[4],
+			lastOperator=self._FORMAT[3],
 		)
 
 
 @export
 class WhenElseExpression(TernaryExpression):
+	"""
+	``thenValue when condition else elseValue`` (VHDL-2008 conditional expression, usable anywhere an
+	expression is expected - distinct from :class:`~pyVHDLModel.Common.ConditionalExpression`, which
+	models the cascading when/else list used in a conditional *assignment*).
+	"""
+
 	_FORMAT = ("", " when ", " else ", "")
+
+	def __init__(
+		self,
+		thenValue: ExpressionUnion,
+		condition: ExpressionUnion,
+		elseValue: ExpressionUnion,
+		parent: Nullable[ModelEntity] = None
+	) -> None:
+		super().__init__(thenValue, condition, elseValue, parent)
+
+	@readonly
+	def ThenValue(self) -> ExpressionUnion:
+		return self._firstOperand
+
+	@readonly
+	def Condition(self) -> ExpressionUnion:
+		return self._secondOperand
+
+	@readonly
+	def ElseValue(self) -> ExpressionUnion:
+		return self._thirdOperand
 
 
 @export

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -34,7 +34,7 @@ This module contains parts of an abstract document language model for VHDL.
 
 Interface items are used in generic, port and parameter declarations.
 """
-from typing                 import Iterable, Optional as Nullable, List, Iterator
+from typing                 import Iterable, Optional as Nullable, List, Iterator, Tuple
 
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
@@ -46,6 +46,25 @@ from pyVHDLModel.Base       import ExpressionUnion, Mode
 from pyVHDLModel.Object     import Constant, Signal, Variable, File
 from pyVHDLModel.Subprogram import Procedure, Function
 from pyVHDLModel.Type       import Type
+
+
+def _identifiersOf(item) -> Tuple[str, ...]:
+	"""
+	Returns an item's identifier(s) as a tuple, regardless of whether it's ``NamedEntityMixin``-based
+	(a single ``Identifier``: ``GenericTypeInterfaceItem``, ``GenericProcedureInterfaceItem``,
+	``GenericFunctionInterfaceItem``, ``GenericPackageInterfaceItem``) or ``MultipleNamedEntityMixin``-
+	based (plural ``Identifiers``: every ``Constant``/``Signal``/``Variable``/``File``-derived item,
+	since a single declaration can name several objects at once, e.g. ``port (p1, p2 : in bit);``).
+
+	Narrowly-scoped fix; a bigger redesign is under consideration (a real ``__str__`` on
+	``NamedEntityMixin``/``MultipleNamedEntityMixin`` themselves, so a group's own ``__str__`` could
+	just delegate to ``str(item)`` instead of reaching into identifier shape at all) - deferred to its
+	own branch rather than done here.
+	"""
+	if isinstance(item, MultipleNamedEntityMixin):
+		return item.Identifiers
+
+	return (item.Identifier,)
 
 
 @export
@@ -539,7 +558,8 @@ class GenericGroup(InterfaceGroup, WithGenericsMixin):
 		return iter(self._genericItems)
 
 	def __str__(self) -> str:
-		return f"GenericGroup {self._identifier} ({len(self._genericItems)}) - generics: {', '.join(p._identifier for p in self._genericItems)})"
+		names = ", ".join(name for item in self._genericItems for name in _identifiersOf(item))
+		return f"GenericGroup {self._identifier} ({len(self._genericItems)}) - generics: {names})"
 
 
 @export
@@ -561,7 +581,8 @@ class PortGroup(InterfaceGroup, WithPortsMixin):
 		return iter(self._portItems)
 
 	def __str__(self) -> str:
-		return f"PortGroup: {self._identifier} ({len(self._portItems)}) - ports: {', '.join(p._identifier for p in self._portItems)})"
+		names = ", ".join(name for item in self._portItems for name in _identifiersOf(item))
+		return f"PortGroup: {self._identifier} ({len(self._portItems)}) - ports: {names})"
 
 
 @export
@@ -583,4 +604,5 @@ class ParameterGroup(InterfaceGroup, WithParametersMixin):
 		return iter(self._parameterItems)
 
 	def __str__(self) -> str:
-		return f"ParameterGroup {self._identifier} ({len(self._parameterItems)}) - parameters: {', '.join(p._identifier for p in self._parameterItems)})"
+		names = ", ".join(name for item in self._parameterItems for name in _identifiersOf(item))
+		return f"ParameterGroup {self._identifier} ({len(self._parameterItems)}) - parameters: {names})"

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -60,9 +60,10 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 	_signals:         Dict[str, Signal]                 #: Dictionary of all signals declared in this concurrent declaration region.
 	_sharedVariables: Dict[str, SharedVariable]         #: Dictionary of all shared variables declared in this concurrent declaration region.
 	_files:           Dict[str, File]                   #: Dictionary of all files declared in this concurrent declaration region.
-	# _subprograms:     Dict[str, Dict[str, Subprogram]]  #: Dictionary of all subprograms declared in this concurrent declaration region.
-	_functions:       Dict[str, Dict[str, Function]]    #: Dictionary of all functions declared in this concurrent declaration region.
-	_procedures:      Dict[str, Dict[str, Procedure]]   #: Dictionary of all procedures declared in this concurrent declaration region.
+	# _subprograms:     Dict[str, List[Subprogram]]  #: Dictionary of all subprograms declared in this concurrent declaration region.
+	# FIXME: overloads are only collected into a list, not matched/resolved by signature.
+	_functions:       Dict[str, List[Function]]         #: Dictionary of all functions declared in this concurrent declaration region, keyed by name; each entry is a list of overloads.
+	_procedures:      Dict[str, List[Procedure]]        #: Dictionary of all procedures declared in this concurrent declaration region, keyed by name; each entry is a list of overloads.
 	_components:      Dict[str, Any]                    #: Dictionary of all components declared in this concurrent declaration region.
 
 	def __init__(self, declaredItems: Nullable[Iterable] = None) -> None:
@@ -122,11 +123,11 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 	# 	return self._subprograms
 
 	@readonly
-	def Functions(self) -> Dict[str, Dict[str, Function]]:
+	def Functions(self) -> Dict[str, List[Function]]:
 		return self._functions
 
 	@readonly
-	def Procedures(self) -> Dict[str, Dict[str, Procedure]]:
+	def Procedures(self) -> Dict[str, List[Procedure]]:
 		return self._procedures
 
 	@readonly
@@ -173,10 +174,14 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 				self._subtypes[item._normalizedIdentifier] = item
 				self._namespace._elements[item._normalizedIdentifier] = item
 			elif isinstance(item, Function):
-				self._functions[item._normalizedIdentifier] = item
+				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
+				#        real overload resolution yet).
+				self._functions.setdefault(item._normalizedIdentifier, []).append(item)
 				self._namespace._elements[item._normalizedIdentifier] = item
 			elif isinstance(item, Procedure):
-				self._procedures[item._normalizedIdentifier] = item
+				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
+				#        real overload resolution yet).
+				self._procedures.setdefault(item._normalizedIdentifier, []).append(item)
 				self._namespace._elements[item._normalizedIdentifier] = item
 			elif isinstance(item, Constant):
 				for normalizedIdentifier in item._normalizedIdentifiers:

--- a/tests/unit/DesignUnit.py
+++ b/tests/unit/DesignUnit.py
@@ -265,8 +265,10 @@ class Architectures(TestCase):
 		self.assertIs(signal, architecture.Signals["s"])
 		self.assertIs(sharedVariable, architecture.SharedVariables["sv"])
 		self.assertIs(file, architecture.Files["f"])
-		self.assertIs(function, architecture.Functions["f_func"])
-		self.assertIs(procedure, architecture.Procedures["p_proc"])
+		self.assertEqual(1, len(architecture.Functions["f_func"]))
+		self.assertIs(function, architecture.Functions["f_func"][0])
+		self.assertEqual(1, len(architecture.Procedures["p_proc"]))
+		self.assertIs(procedure, architecture.Procedures["p_proc"][0])
 
 	def test_IndexDeclaredItems_AlsoPopulatesNamespace(self) -> None:
 		constant = Constant(["C"], SimpleSubtypeSymbol(SimpleName("natural")))
@@ -284,17 +286,34 @@ class Architectures(TestCase):
 
 		architecture.IndexDeclaredItems()  # must not raise, only warn
 
-	def test_IndexDeclaredItems_OverloadsCollide(self) -> None:
-		"""Regression-tracking test, not a fix: see Findings.md - ``Functions``/``Procedures`` are
-		typed as ``Dict[str, Dict[str, Function]]`` (name -> signature -> subprogram) but indexed as a
-		flat ``Dict[str, Function]``, so two overloads sharing a name silently collide into one entry."""
+	def test_IndexDeclaredItems_Overloads(self) -> None:
+		"""Regression test: two overloads sharing a name used to silently collide into one entry (a
+		flat ``Dict[str, Function]``) - the second always overwrote the first, with no error or
+		warning. Fixed by collecting overloads into a list per name instead.
+
+		FIXME: this only *avoids the collision* - it doesn't actually resolve overloads by signature
+		(matching call-site argument types against each candidate's parameter/return types). A real
+		textual-signature-based attempt was tried and rejected as unreliable (aliased/case-differing
+		subtype names would be misjudged as distinct, and symbol resolution happening after indexing
+		could change the comparison basis). For now, ``Functions``/``Procedures`` just return every
+		overload found under a given name, unresolved."""
 		overload1 = Function("f", SimpleSubtypeSymbol(SimpleName("integer")))
 		overload2 = Function("f", SimpleSubtypeSymbol(SimpleName("boolean")))
 		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[overload1, overload2])
 		architecture.IndexDeclaredItems()
 
 		self.assertEqual(1, len(architecture.Functions))
-		self.assertIs(overload2, architecture.Functions["f"])
+		self.assertEqual([overload1, overload2], architecture.Functions["f"])
+
+	def test_IndexDeclaredItems_ProcedureOverloads(self) -> None:
+		"""Same as above, but for procedures."""
+		overload1 = Procedure("p")
+		overload2 = Procedure("p")
+		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[overload1, overload2])
+		architecture.IndexDeclaredItems()
+
+		self.assertEqual(1, len(architecture.Procedures))
+		self.assertEqual([overload1, overload2], architecture.Procedures["p"])
 
 
 class Components(TestCase):

--- a/tests/unit/Expression.py
+++ b/tests/unit/Expression.py
@@ -223,14 +223,6 @@ class UnaryExpressionFormats(TestCase):
 			with self.subTest(expression=expressionClass.__name__):
 				self.assertEqual(expected, str(expressionClass(IntegerLiteral(1))))
 
-	def test_TypeConversion_StrRaises(self) -> None:
-		"""Regression-tracking test, not a fix: see Findings.md - unlike every other
-		``UnaryExpression`` subclass, ``TypeConversion`` never fixes a ``_FORMAT`` (it has no field for
-		the target type at all), so ``str()`` always raises. Locked in here so a future fix shows up
-		as an intentional test change rather than a silent behaviour change."""
-		with self.assertRaises(AttributeError):
-			str(TypeConversion(IntegerLiteral(1)))
-
 	def test_SubExpression_IsAlsoAParenthesisExpression(self) -> None:
 		"""``SubExpression`` mixes in ``ParenthesisExpression``, whose own ``Operand`` hardcodes
 		``return None`` - but MRO puts ``UnaryExpression`` first, so the real operand wins and
@@ -239,6 +231,26 @@ class UnaryExpressionFormats(TestCase):
 		expression = SubExpression(operand)
 
 		self.assertIs(operand, expression.Operand)
+
+
+class TypeConversions(TestCase):
+	"""Regression test: ``TypeConversion`` previously had no field for the target type at all (just
+	``pass``, inheriting ``UnaryExpression`` unchanged) - unlike every other ``UnaryExpression``
+	subclass, its "operator" is the target type name itself, not a fixed ``_FORMAT`` string, so
+	``str()`` always raised ``AttributeError``. Fixed by adding ``_targetSubtype`` (mirroring
+	``QualifiedExpression._subtype``) and a dedicated ``__str__``."""
+
+	def test_Construction(self) -> None:
+		"""``natural(x)``"""
+		targetSubtype = SimpleSubtypeSymbol(SimpleName("natural"))
+		operand = IntegerLiteral(1)
+		expression = TypeConversion(targetSubtype, operand)
+
+		self.assertIs(targetSubtype, expression.TargetSubtype)
+		self.assertIs(expression, targetSubtype.Parent)
+		self.assertIs(operand, expression.Operand)
+		self.assertIs(expression, operand.Parent)
+		self.assertEqual("natural?(1)", str(expression))
 
 
 class BinaryExpressions(TestCase):
@@ -331,22 +343,31 @@ class QualifiedExpressions(TestCase):
 
 
 class TernaryExpressions(TestCase):
-	"""Regression-tracking test, not a fix: see Findings.md - the constructor never accepts or sets
-	its three operands at all, and ``__str__`` separately indexes past the end of the 4-element
-	``_FORMAT`` tuple. Both are confirmed still-open; this locks in the current (broken) behaviour so
-	a future fix shows up as an intentional test change."""
+	"""Regression test: the constructor previously never accepted or set its three operands at all
+	(``# FIXME: parameters and initializers are missing !!``), and ``__str__`` separately indexed past
+	the end of the 4-element ``_FORMAT`` tuple (``self._FORMAT[4]``). Both fixed together - the
+	constructor now takes the three operands (wiring ``Parent`` for each), and ``__str__`` reads
+	``_FORMAT[3]``.
 
-	def test_ConstructsButOperandsAreUnset(self) -> None:
-		expression = WhenElseExpression()
+	``TernaryExpression`` itself deliberately exposes no public ``FirstOperand``/``SecondOperand``/
+	``ThirdOperand`` properties (see its class docstring) - only ``WhenElseExpression``'s own
+	``ThenValue``/``Condition``/``ElseValue`` are public, so this is tested only through that concrete
+	subclass."""
 
-		with self.assertRaises(AttributeError):
-			expression.FirstOperand
+	def test_Construction(self) -> None:
+		"""``thenValue when condition else elseValue``"""
+		thenValue = IntegerLiteral(1)
+		condition = IntegerLiteral(2)
+		elseValue = IntegerLiteral(3)
+		expression = WhenElseExpression(thenValue, condition, elseValue)
 
-	def test_StrRaises(self) -> None:
-		expression = WhenElseExpression()
-
-		with self.assertRaises(Exception):
-			str(expression)
+		self.assertIs(thenValue, expression.ThenValue)
+		self.assertIs(expression, thenValue.Parent)
+		self.assertIs(condition, expression.Condition)
+		self.assertIs(expression, condition.Parent)
+		self.assertIs(elseValue, expression.ElseValue)
+		self.assertIs(expression, elseValue.Parent)
+		self.assertEqual("1 when 2 else 3", str(expression))
 
 
 class FunctionCallAndAllocation(TestCase):

--- a/tests/unit/Interface.py
+++ b/tests/unit/Interface.py
@@ -256,40 +256,47 @@ class WithGenericsPortsParametersMixins(TestCase):
 
 
 class Groups(TestCase):
-	"""Regression test: ``GenericGroup``/``ParameterGroup`` didn't list ``WithGenericsMixin``/
-	``WithParametersMixin`` as base classes at all (unlike ``PortGroup``, which correctly lists
-	``WithPortsMixin``), so the slots-based metaclass never allocated storage for
+	"""Regression test (missing base class): ``GenericGroup``/``ParameterGroup`` didn't list
+	``WithGenericsMixin``/``WithParametersMixin`` as base classes at all (unlike ``PortGroup``, which
+	correctly lists ``WithPortsMixin``), so the slots-based metaclass never allocated storage for
 	``_genericItems``/``_parameterItems`` - construction crashed immediately with
 	``AttributeError: ... no __dict__ for setting new attributes``, even for the simplest, empty-list
-	case. Fixed by adding the missing base class to both, mirroring ``PortGroup``."""
+	case. Fixed by adding the missing base class to both, mirroring ``PortGroup``.
+
+	Regression test (``__str__``): all three built their string via
+	``p._identifier for p in self._xItems``, but interface items come in two incompatible shapes -
+	``NamedEntityMixin``-based (singular ``_identifier`` - the four ``Generic*`` subprogram/package/
+	type items) vs. ``MultipleNamedEntityMixin``-based (plural ``_identifiers`` - every
+	``Constant``/``Signal``/``Variable``/``File``-derived item, i.e. every ``Port*``/``Parameter*``
+	item and ``GenericConstantInterfaceItem``, since a single declaration can name several objects at
+	once: ``port (p1, p2 : in bit);``). ``PortGroup``/``ParameterGroup.__str__`` crashed for
+	essentially any realistic content, and ``GenericGroup.__str__`` crashed the moment a
+	``GenericConstantInterfaceItem`` was included or a group mixed both item shapes. Fixed via the
+	shared ``_identifiersOf()`` helper, which flattens either shape into a plain tuple of names."""
 
 	def test_GenericGroup(self) -> None:
-		"""``str()`` happens to work here only because ``GenericTypeInterfaceItem`` is one of the four
-		``NamedEntityMixin``-based (singular ``_identifier``) generic item kinds - see
-		``test_GenericGroup_StrCrashesForObjectBasedItems`` for the far more common case where it
-		doesn't."""
 		item = GenericTypeInterfaceItem("T")
 		group = GenericGroup([item], name="generics")
 
 		self.assertEqual(1, len(group))
 		self.assertEqual([item], list(group))
-		self.assertIn("generics", str(group))
+		self.assertEqual("GenericGroup generics (1) - generics: T)", str(group))
 
 	def test_GenericGroup_Empty(self) -> None:
 		group = GenericGroup([])
 
 		self.assertEqual(0, len(group))
+		self.assertEqual("GenericGroup None (0) - generics: )", str(group))
 
-	def test_GenericGroup_StrCrashesForObjectBasedItems(self) -> None:
-		"""Regression-tracking test, not a fix: see Findings.md. ``GenericConstantInterfaceItem`` (and
-		every ``Port*``/``Parameter*`` item - see the two tests below) is ``MultipleNamedEntityMixin``-
-		based (plural ``_identifiers``), but ``GenericGroup.__str__`` reads the singular
-		``_identifier``, which doesn't exist on this kind of item."""
-		item = GenericConstantInterfaceItem(["G"], Mode.In, _subtype("positive"))
-		group = GenericGroup([item])
+	def test_GenericGroup_MixedItemShapes(self) -> None:
+		"""``generic (type T; G : positive := 8);`` - a single generic clause legally mixes a
+		``NamedEntityMixin``-based item (``GenericTypeInterfaceItem``) with a
+		``MultipleNamedEntityMixin``-based one (``GenericConstantInterfaceItem``)."""
+		typeItem = GenericTypeInterfaceItem("T")
+		constantItem = GenericConstantInterfaceItem(["G"], Mode.In, _subtype("positive"))
+		group = GenericGroup([typeItem, constantItem])
 
-		with self.assertRaises(AttributeError):
-			str(group)
+		self.assertEqual("GenericGroup None (2) - generics: T, G)", str(group))
 
 	def test_PortGroup(self) -> None:
 		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
@@ -297,16 +304,14 @@ class Groups(TestCase):
 
 		self.assertEqual(1, len(group))
 		self.assertEqual([item], list(group))
+		self.assertEqual("PortGroup: ports (1) - ports: p)", str(group))
 
-	def test_PortGroup_StrCrashes(self) -> None:
-		"""Regression-tracking test, not a fix: see Findings.md - ports are always
-		``MultipleNamedEntityMixin``-based, so ``PortGroup.__str__`` (reading singular
-		``_identifier``) crashes for essentially any realistic content."""
-		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
+	def test_PortGroup_MultipleIdentifiersPerItem(self) -> None:
+		"""``port (p1, p2 : in bit);`` - one declaration, two port names."""
+		item = PortSimpleSignalInterfaceItem(["p1", "p2"], Mode.In, _subtype())
 		group = PortGroup([item])
 
-		with self.assertRaises(AttributeError):
-			str(group)
+		self.assertEqual("PortGroup: None (1) - ports: p1, p2)", str(group))
 
 	def test_ParameterGroup(self) -> None:
 		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
@@ -314,21 +319,12 @@ class Groups(TestCase):
 
 		self.assertEqual(1, len(group))
 		self.assertEqual([item], list(group))
+		self.assertEqual("ParameterGroup parameters (1) - parameters: f)", str(group))
 
 	def test_ParameterGroup_Empty(self) -> None:
 		group = ParameterGroup([])
 
 		self.assertEqual(0, len(group))
-
-	def test_ParameterGroup_StrCrashes(self) -> None:
-		"""Regression-tracking test, not a fix: see Findings.md - parameters are always
-		``MultipleNamedEntityMixin``-based, so ``ParameterGroup.__str__`` (reading singular
-		``_identifier``) crashes for essentially any realistic content."""
-		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
-		group = ParameterGroup([item])
-
-		with self.assertRaises(AttributeError):
-			str(group)
 
 	def test_InterfaceGroup_NoName(self) -> None:
 		group = InterfaceGroup()


### PR DESCRIPTION
## Summary

Items 4-7 from the follow-up TODO list after #139/#140. Design decisions for each were discussed and
confirmed (some revised) before finalizing - see the PR conversation/commit message for the full
back-and-forth. Updated after review: `TypeConversion`/`WhenElseExpression` now use `SubtypeSymbol`
and `@readonly` per feedback (see below).

- **`Expression.TernaryExpression`** - the constructor never accepted or set its three operands at
  all, and `__str__` indexed past the end of its `_FORMAT` tuple. Fixed: constructor now takes
  `(firstOperand, secondOperand, thirdOperand)`, wiring `Parent` for each. Deliberately exposes **no**
  public `FirstOperand`/`SecondOperand`/`ThirdOperand` - unlike `Unary`/`BinaryExpression` (where the
  generic name already *is* the domain name for every consumer), a ternary's three operands mean
  different things per concrete expression, so `WhenElseExpression` (`thenValue when condition else
  elseValue`) gets its own `__init__` and its own `@readonly` `ThenValue`/`Condition`/`ElseValue`
  properties instead of duplicating a generic and a specific name for the same value. `_FORMAT` is
  marked `# FIXME: needs ClassVar[...] when pyTooling gets fixed.`

- **`Expression.TypeConversion`** had no field for the target type at all, so `str()` always crashed.
  Added `_targetSubtype`/`TargetSubtype` (named more specifically than just `Subtype`, since
  `TypeConversion` already has its own `operand` to disambiguate from), typed as `SubtypeSymbol`
  (added to `pyVHDLModel/Symbol.py`, mirroring `PackageSymbol`) rather than the generic `Symbol` base,
  and exposed via `@readonly`. pyGHDL.dom never constructs this class today (confirmed via grep) -
  the translation-side follow-up is tracked separately, not attempted here.

- **`Interface.GenericGroup`/`PortGroup`/`ParameterGroup.__str__`** crashed depending on item mix
  (interface items come in two incompatible identifier shapes - singular `NamedEntityMixin` vs.
  plural `MultipleNamedEntityMixin`, since one declaration can name several objects:
  `port (p1, p2 : in bit);`). Fixed narrowly via a shared `_identifiersOf()` helper
  (`isinstance`-based) that flattens either shape into a plain tuple of names. A bigger redesign (give
  `NamedEntityMixin`/`MultipleNamedEntityMixin` a real `__str__` so groups can just delegate to
  `str(item)`) was identified but deliberately deferred to its own branch - touches two mixins
  inherited by dozens of unrelated classes, so it needs its own review pass.

- **`Regions.ConcurrentDeclarationRegionMixin.Functions`/`.Procedures`** silently collided on
  overloaded subprograms sharing a name (flat dict, second overwrites first). A textual-signature
  approach was tried and rejected as unreliable (aliased/case-differing subtype names would be
  misjudged as distinct, and symbol resolution happening after indexing could change the comparison
  basis). Simplified instead to `Dict[str, List[Function]]`/`Dict[str, List[Procedure]]` -
  collision-avoidance only, marked with `# FIXME` at both call sites: overloads are collected, not
  actually resolved by signature. Real overload resolution needs type-compatibility matching, not
  string comparison - tracked as a substantial follow-up feature.

This branch was forked from `dev` before #140 merged, so it doesn't include that PR's changes
(`QualifiedExpression.Subtyped` rename, `DesignUnitWithContextMixin` exception message,
`_blocks`/`_generates`/`_hierarchy` cleanup) - independent, non-overlapping work.

## Test plan

- [x] `pytest tests/unit` - 355 passed
- [x] pyGHDL.dom pyunit suite - 123 passed, 5 skipped, 16 xfailed (none of the four changed
      constructors/behaviours are currently reachable from its translation dispatch, grepped - no
      cross-repo fallout)
