### PR TITLE
Remove private-notes-file references from test docstrings

### DIFF
--- a/tests/unit/Interface.py
+++ b/tests/unit/Interface.py
@@ -182,8 +182,8 @@ class GenericInterfaceItems(TestCase):
 
 	def test_GenericFunctionInterfaceItem_ConstructionRaises(self) -> None:
 		"""``generic (function func return boolean);`` (VHDL-2008) - regression-tracking test, not a
-		fix: see Findings.md (HIGH PRIORITY - confirmed live via pyGHDL.dom's actual translation
-		dispatch, not just a landmine). ``GenericFunctionInterfaceItem`` has no ``returnType``
+		fix (HIGH PRIORITY - confirmed live via pyGHDL.dom's actual translation dispatch, not just a
+		landmine). ``GenericFunctionInterfaceItem`` has no ``returnType``
 		parameter of its own, so ``super().__init__(identifier, documentation, parent)`` misaligns
 		against ``Function.__init__``'s real signature - ``documentation`` lands in the ``returnType``
 		slot, and ``Function.__init__`` unconditionally does ``returnType.Parent = self``, which


### PR DESCRIPTION
## Summary

Follow-up to a review comment on #140: a test docstring referenced an external findings-tracking
file (used during development, not part of this repository), and a sweep turned up 7 total instances
already merged into `dev` via #139 - in `tests/unit/DesignUnit.py`, `tests/unit/Expression.py`
(x2), and `tests/unit/Interface.py` (x4). Since that history is already merged, this is a separate
cleanup PR rather than an amend.

All 7 docstrings are rewritten to stand on their own, with no functional or test-behaviour changes -
purely removing the reference to a file that lives outside the repo.

## Test plan

- [x] `pytest tests/unit` - 356 passed
