### PR TITLE
Split Range into SimpleRange and RangeFromName

### DIFF
--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -481,11 +481,35 @@ class ChoicesMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class Range(ModelEntity):
+	"""
+	Base-class for all ranges.
+
+	VHDL's ``range`` rule offers a range denoted by a name (:class:`RangeFromName`) as well as a range
+	given by explicit bounds (:class:`SimpleRange`).
+	"""
+
+
+@export
+class SimpleRange(Range):
+	"""
+	A range with both bounds given as expressions, e.g. ``0 to 7``.
+
+	Named after the ``simple_range`` rule in VHDL's grammar.
+	"""
+
 	_leftBound:  ExpressionUnion
 	_rightBound: ExpressionUnion
 	_direction:  Direction
 
 	def __init__(self, leftBound: ExpressionUnion, rightBound: ExpressionUnion, direction: Direction, parent: Nullable[ModelEntity] = None) -> None:
+		"""
+		Initialize a simple range.
+
+		:param leftBound:  The range's left bound.
+		:param rightBound: The range's right bound.
+		:param direction:  The range's direction (``to`` or ``downto``).
+		:param parent:     The parent model entity.
+		"""
 		super().__init__(parent)
 
 		self._leftBound = leftBound
@@ -496,20 +520,63 @@ class Range(ModelEntity):
 
 		self._direction = direction
 
-	@property
+	@readonly
 	def LeftBound(self) -> ExpressionUnion:
+		"""Read-only property to access the range's left bound (:attr:`_leftBound`)."""
 		return self._leftBound
 
-	@property
+	@readonly
 	def RightBound(self) -> ExpressionUnion:
+		"""Read-only property to access the range's right bound (:attr:`_rightBound`)."""
 		return self._rightBound
 
-	@property
+	@readonly
 	def Direction(self) -> Direction:
+		"""Read-only property to access the range's direction (:attr:`_direction`)."""
 		return self._direction
 
 	def __str__(self) -> str:
 		return f"{self._leftBound!s} {self._direction!s} {self._rightBound!s}"
+
+
+@export
+class RangeFromName(Range):
+	"""
+	A range denoted by a name, so its bounds are inferred from whatever that name references.
+
+	Two forms reach this class, because a parser can't tell them apart beyond "a name, optionally with a
+	range constraint":
+
+	* a range attribute like ``vector'range``, and
+	* a discrete subtype indication like ``bit`` or ``integer range 0 to 7``.
+
+	Both are represented by their :class:`~pyVHDLModel.Symbol.Symbol`, so the bounds become available
+	once that symbol is resolved. A constrained subtype indication keeps its type mark *and* its range
+	constraint, because it's carried by a
+	:class:`~pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol`.
+	"""
+
+	_symbol: 'Symbol'
+
+	def __init__(self, symbol: 'Symbol', parent: Nullable[ModelEntity] = None) -> None:
+		"""
+		Initialize a range denoted by a name.
+
+		:param symbol: The symbol referencing the range attribute or discrete subtype.
+		:param parent: The parent model entity.
+		"""
+		super().__init__(parent)
+
+		self._symbol = symbol
+		symbol.Parent = self
+
+	@readonly
+	def Symbol(self) -> 'Symbol':
+		"""Read-only property to access the referenced symbol (:attr:`_symbol`)."""
+		return self._symbol
+
+	def __str__(self) -> str:
+		return f"{self._symbol!s}"
 
 
 @export

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -493,8 +493,6 @@ class Range(ModelEntity):
 class SimpleRange(Range):
 	"""
 	A range with both bounds given as expressions, e.g. ``0 to 7``.
-
-	Named after the ``simple_range`` rule in VHDL's grammar.
 	"""
 
 	_leftBound:  ExpressionUnion
@@ -544,16 +542,20 @@ class RangeFromName(Range):
 	"""
 	A range denoted by a name, so its bounds are inferred from whatever that name references.
 
-	Two forms reach this class, because a parser can't tell them apart beyond "a name, optionally with a
-	range constraint":
+	The name is represented by a :class:`~pyVHDLModel.Symbol.Symbol`, so the bounds become available once
+	that symbol is resolved. A constrained subtype indication keeps its type mark *and* its range
+	constraint, because it's carried by a :class:`~pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol`.
 
-	* a range attribute like ``vector'range``, and
-	* a discrete subtype indication like ``bit`` or ``integer range 0 to 7``.
+	.. note::
 
-	Both are represented by their :class:`~pyVHDLModel.Symbol.Symbol`, so the bounds become available
-	once that symbol is resolved. A constrained subtype indication keeps its type mark *and* its range
-	constraint, because it's carried by a
-	:class:`~pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol`.
+	   Two forms reach this class, because a parser can't tell them apart beyond "a name, optionally with
+	   a range constraint":
+
+	   * a range attribute like ``vector'range``, and
+	   * a discrete subtype indication like ``bit`` or ``integer range 0 to 7``.
+
+	   VHDL's grammar puts the latter one level up (``discrete_range ::= discrete_subtype_indication |
+	   range``), so representing both as a range deviates from the rule split deliberately.
 	"""
 
 	_symbol: 'Symbol'

--- a/pyVHDLModel/STD.py
+++ b/pyVHDLModel/STD.py
@@ -33,7 +33,7 @@
 
 from pyTooling.Decorators    import export
 
-from pyVHDLModel.Base        import Range, Direction
+from pyVHDLModel.Base        import SimpleRange, Direction
 from pyVHDLModel.Name        import SimpleName
 from pyVHDLModel.Symbol      import SimpleSubtypeSymbol
 from pyVHDLModel.Expression  import EnumerationLiteral, IntegerLiteral, FloatingPointLiteral, PhysicalIntegerLiteral
@@ -117,16 +117,16 @@ class Standard(PredefinedPackage):
 		self._types[severityLevel._normalizedIdentifier] = severityLevel
 		self._declaredItems.append(severityLevel)
 
-		integer = IntegerType("integer", Range(IntegerLiteral(-2**31), IntegerLiteral(2**31 - 1), Direction.To), None)
+		integer = IntegerType("integer", SimpleRange(IntegerLiteral(-2**31), IntegerLiteral(2**31 - 1), Direction.To), None)
 		self._types[integer._normalizedIdentifier] = integer
 		self._declaredItems.append(integer)
 
 		# real
-		real = RealType("real", Range(FloatingPointLiteral(-5.0), FloatingPointLiteral(5.0), Direction.To), None)
+		real = RealType("real", SimpleRange(FloatingPointLiteral(-5.0), FloatingPointLiteral(5.0), Direction.To), None)
 		self._types[real._normalizedIdentifier] = real
 		self._declaredItems.append(real)
 
-		time = PhysicalType("time", Range(IntegerLiteral(-2**63), IntegerLiteral(2**63 - 1), Direction.To), primaryUnit="fs", units=(
+		time = PhysicalType("time", SimpleRange(IntegerLiteral(-2**63), IntegerLiteral(2**63 - 1), Direction.To), primaryUnit="fs", units=(
 			("ps", PhysicalIntegerLiteral(1000, "fs")),
 			("ns", PhysicalIntegerLiteral(1000, "ps")),
 			("us", PhysicalIntegerLiteral(1000, "ns")),
@@ -144,13 +144,13 @@ class Standard(PredefinedPackage):
 
 		natural = Subtype("natural", SimpleSubtypeSymbol(SimpleName("integer")), None)
 		natural._baseType = integer
-		natural._range = Range(IntegerLiteral(0), IntegerLiteral(2**31 - 1), Direction.To)
+		natural._range = SimpleRange(IntegerLiteral(0), IntegerLiteral(2**31 - 1), Direction.To)
 		self._subtypes[natural._normalizedIdentifier] = natural
 		self._declaredItems.append(natural)
 
 		positive = Subtype("positive", SimpleSubtypeSymbol(SimpleName("integer")), None)
 		positive._baseType = integer
-		positive._range = Range(IntegerLiteral(1), IntegerLiteral(2**31 - 1), Direction.To)
+		positive._range = SimpleRange(IntegerLiteral(1), IntegerLiteral(2**31 - 1), Direction.To)
 		self._subtypes[positive._normalizedIdentifier] = positive
 		self._declaredItems.append(positive)
 

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -564,6 +564,19 @@ class RecordElementSymbol(Symbol):
 
 
 @export
+class RangeAttributeSymbol(Symbol):
+	"""A symbol referencing a range attribute, e.g. ``vector'range``."""
+
+	def __init__(self, name: Name) -> None:
+		"""
+		Initialize a range attribute symbol.
+
+		:param name: The attribute name referencing the range.
+		"""
+		super().__init__(name, PossibleReference.RangeAttribute)
+
+
+@export
 class SubtypeSymbol(Symbol):
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.Type | PossibleReference.Subtype)

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -42,7 +42,6 @@ from pyTooling.Graph        import Vertex
 
 from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, MultipleNamedEntityMixin, DocumentedEntityMixin, ExpressionUnion, Range
 from pyVHDLModel.Symbol     import Symbol
-from pyVHDLModel.Name       import Name
 from pyVHDLModel.Expression import EnumerationLiteral, PhysicalIntegerLiteral
 
 
@@ -125,16 +124,23 @@ class ScalarType(FullType):
 class RangedScalarType(ScalarType):
 	"""A ``RangedScalarType`` is a base-class for all scalar types with a range."""
 
-	_range:      Union[Range, Name]
-	_leftBound:  ExpressionUnion
-	_rightBound: ExpressionUnion
+	_range: Range
 
-	def __init__(self, identifier: str, rng: Union[Range, Name], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+		"""
+		Initialize a scalar type with a range.
+
+		:param identifier:    The type's identifier.
+		:param rng:           The type's range.
+		:param documentation: The type's documentation.
+		:param parent:        The parent model entity.
+		"""
 		super().__init__(identifier, documentation, parent)
 		self._range = rng
 
 	@readonly
-	def Range(self) -> Union[Range, Name]:
+	def Range(self) -> Range:
+		"""Read-only property to access the type's range (:attr:`_range`)."""
 		return self._range
 
 
@@ -177,7 +183,7 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 
 @export
 class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
-	def __init__(self, identifier: str, rng: Union[Range, Name], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, documentation, parent)
 
 	def __str__(self) -> str:
@@ -186,7 +192,7 @@ class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
 
 @export
 class RealType(RangedScalarType, NumericTypeMixin):
-	def __init__(self, identifier: str, rng: Union[Range, Name], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, documentation, parent)
 
 	def __str__(self) -> str:
@@ -201,7 +207,7 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 	def __init__(
 		self,
 		identifier: str,
-		rng: Union[Range, Name],
+		rng: Range,
 		primaryUnit: str,
 		units: Iterable[Tuple[str, PhysicalIntegerLiteral]],
 		documentation: Nullable[str] = None,

--- a/tests/unit/Base.py
+++ b/tests/unit/Base.py
@@ -45,11 +45,13 @@ Mixins already fully exercised elsewhere are intentionally not repeated here:
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base        import Direction, Mode, ModelEntity, Range, WaveformElement
+from pyVHDLModel.Base        import Direction, Mode, ModelEntity, Range, RangeFromName, SimpleRange, WaveformElement
 from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral
 from pyVHDLModel.Interface   import InterfaceGroup
 from pyVHDLModel.Sequential  import IfBranch, ElsifBranch, ElseBranch, SequentialReportStatement, SequentialAssertStatement, SequentialCase
 from pyVHDLModel.Concurrent  import ConcurrentBlockStatement
+from pyVHDLModel.Name        import SimpleName
+from pyVHDLModel.Symbol      import ConstrainedScalarSubtypeSymbol, SimpleSubtypeSymbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -208,12 +210,12 @@ class ChoicesMixinHost(TestCase):
 
 
 class Ranges(TestCase):
-	"""``Range`` (``3 downto 0``) - a concrete class defined directly in Base.py, not a mixin."""
+	"""``SimpleRange`` (``3 downto 0``) - a concrete class defined directly in Base.py, not a mixin."""
 
 	def test_Construction(self) -> None:
 		left = IntegerLiteral(3)
 		right = IntegerLiteral(0)
-		range_ = Range(left, right, Direction.DownTo)
+		range_ = SimpleRange(left, right, Direction.DownTo)
 
 		self.assertIs(left, range_.LeftBound)
 		self.assertIs(right, range_.RightBound)
@@ -222,9 +224,42 @@ class Ranges(TestCase):
 		self.assertIs(range_, right.Parent)
 
 	def test_ToString(self) -> None:
-		range_ = Range(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
+		range_ = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
 
 		self.assertEqual("0 to 7", str(range_))
+
+	def test_IsARange(self) -> None:
+		range_ = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
+
+		self.assertIsInstance(range_, Range)
+
+
+class RangesFromName(TestCase):
+	"""``RangeFromName`` (``vector'range``, ``bit``) - a range whose bounds come from a referenced symbol."""
+
+	def test_Construction(self) -> None:
+		symbol = SimpleSubtypeSymbol(SimpleName("bit"))
+		range_ = RangeFromName(symbol)
+
+		self.assertIs(symbol, range_.Symbol)
+		self.assertIs(range_, symbol.Parent)
+		self.assertIsInstance(range_, Range)
+
+	def test_ToStringUnresolved(self) -> None:
+		range_ = RangeFromName(SimpleSubtypeSymbol(SimpleName("bit")))
+
+		# An unresolved symbol renders with a trailing question mark.
+		self.assertEqual("bit?", str(range_))
+
+	def test_ConstrainedSubtypeKeepsTypeMarkAndConstraint(self) -> None:
+		# `integer range 0 to 7` - the type mark must survive alongside the range constraint.
+		constraint = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
+		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"), constraint)
+		range_ = RangeFromName(symbol)
+
+		self.assertIs(symbol, range_.Symbol)
+		self.assertIs(constraint, range_.Symbol.Constraint)
+		self.assertEqual("integer", range_.Symbol.Name.Identifier)
 
 
 class WaveformElements(TestCase):

--- a/tests/unit/Base.py
+++ b/tests/unit/Base.py
@@ -215,23 +215,23 @@ class Ranges(TestCase):
 	def test_Construction(self) -> None:
 		left = IntegerLiteral(3)
 		right = IntegerLiteral(0)
-		range_ = SimpleRange(left, right, Direction.DownTo)
+		rng = SimpleRange(left, right, Direction.DownTo)
 
-		self.assertIs(left, range_.LeftBound)
-		self.assertIs(right, range_.RightBound)
-		self.assertIs(Direction.DownTo, range_.Direction)
-		self.assertIs(range_, left.Parent)
-		self.assertIs(range_, right.Parent)
+		self.assertIs(left, rng.LeftBound)
+		self.assertIs(right, rng.RightBound)
+		self.assertIs(Direction.DownTo, rng.Direction)
+		self.assertIs(rng, left.Parent)
+		self.assertIs(rng, right.Parent)
 
 	def test_ToString(self) -> None:
-		range_ = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
 
-		self.assertEqual("0 to 7", str(range_))
+		self.assertEqual("0 to 7", str(rng))
 
 	def test_IsARange(self) -> None:
-		range_ = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
 
-		self.assertIsInstance(range_, Range)
+		self.assertIsInstance(rng, Range)
 
 
 class RangesFromName(TestCase):
@@ -239,27 +239,27 @@ class RangesFromName(TestCase):
 
 	def test_Construction(self) -> None:
 		symbol = SimpleSubtypeSymbol(SimpleName("bit"))
-		range_ = RangeFromName(symbol)
+		rng = RangeFromName(symbol)
 
-		self.assertIs(symbol, range_.Symbol)
-		self.assertIs(range_, symbol.Parent)
-		self.assertIsInstance(range_, Range)
+		self.assertIs(symbol, rng.Symbol)
+		self.assertIs(rng, symbol.Parent)
+		self.assertIsInstance(rng, Range)
 
 	def test_ToStringUnresolved(self) -> None:
-		range_ = RangeFromName(SimpleSubtypeSymbol(SimpleName("bit")))
+		rng = RangeFromName(SimpleSubtypeSymbol(SimpleName("bit")))
 
 		# An unresolved symbol renders with a trailing question mark.
-		self.assertEqual("bit?", str(range_))
+		self.assertEqual("bit?", str(rng))
 
 	def test_ConstrainedSubtypeKeepsTypeMarkAndConstraint(self) -> None:
 		# `integer range 0 to 7` - the type mark must survive alongside the range constraint.
 		constraint = SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To)
 		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"), constraint)
-		range_ = RangeFromName(symbol)
+		rng = RangeFromName(symbol)
 
-		self.assertIs(symbol, range_.Symbol)
-		self.assertIs(constraint, range_.Symbol.Constraint)
-		self.assertEqual("integer", range_.Symbol.Name.Identifier)
+		self.assertIs(symbol, rng.Symbol)
+		self.assertIs(constraint, rng.Symbol.Constraint)
+		self.assertEqual("integer", rng.Symbol.Name.Identifier)
 
 
 class WaveformElements(TestCase):

--- a/tests/unit/Concurrent.py
+++ b/tests/unit/Concurrent.py
@@ -35,7 +35,7 @@ tests/unit/Assignment.py (conditional/selected signal assignments) or tests/unit
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base        import Direction, Range
+from pyVHDLModel.Base        import Direction, SimpleRange
 from pyVHDLModel.Name        import SimpleName
 from pyVHDLModel.Symbol      import (
 	ComponentInstantiationSymbol, EntityInstantiationSymbol, ArchitectureSymbol,
@@ -249,7 +249,7 @@ class GenerateChoices(TestCase):
 		self.assertEqual("0", str(choice))
 
 	def test_RangedGenerateChoice(self) -> None:
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		choice = RangedGenerateChoice(rng)
 
 		self.assertIs(rng, choice.Range)
@@ -306,7 +306,7 @@ class CaseGenerateStatements(TestCase):
 
 class ForGenerateStatements(TestCase):
 	def test_Construction(self) -> None:
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		statement = ForGenerateStatement("gen", "i", rng)
 
 		self.assertEqual("i", statement.LoopIndex)
@@ -315,7 +315,7 @@ class ForGenerateStatements(TestCase):
 
 	def test_ConnectsNamespaceOnParentAssignment(self) -> None:
 		architecture = Architecture("rtl", _entitySymbol())
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		statement = ForGenerateStatement("gen", "i", rng)
 
 		statement.Parent = architecture
@@ -325,7 +325,7 @@ class ForGenerateStatements(TestCase):
 	def test_IterateInstantiations_And_IndexStatement(self) -> None:
 		componentSymbol = ComponentInstantiationSymbol(SimpleName("comp"))
 		instance = ComponentInstantiation("inst", componentSymbol)
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		statement = ForGenerateStatement("gen", "i", rng, statements=[instance])
 
 		statement.IndexStatement()
@@ -376,7 +376,7 @@ class ConcurrentStatementsMixinIndexing(TestCase):
 		entitySymbol = _entitySymbol()
 		instance = ComponentInstantiation("inst", ComponentInstantiationSymbol(SimpleName("comp")))
 		block = ConcurrentBlockStatement("blk")
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		generate = ForGenerateStatement("gen", "i", rng)
 
 		architecture = Architecture("rtl", entitySymbol, statements=[instance, block, generate])

--- a/tests/unit/Expression.py
+++ b/tests/unit/Expression.py
@@ -39,7 +39,7 @@ table-driven in one ``str()``-formatting test rather than one hand-written test 
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base       import Direction, Range
+from pyVHDLModel.Base       import Direction, SimpleRange
 from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
 from pyVHDLModel.Expression import (
@@ -420,7 +420,7 @@ class AggregateElements(TestCase):
 		self.assertEqual("0 => 1", str(element))
 
 	def test_RangedAggregateElement(self) -> None:
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		expression = IntegerLiteral(1)
 		element = RangedAggregateElement(rng, expression)
 

--- a/tests/unit/Instantiate.py
+++ b/tests/unit/Instantiate.py
@@ -36,7 +36,7 @@ from unittest import TestCase
 from pyTooling.Graph import Graph
 
 from pyVHDLModel import Design, Library, Document, IEEEFlavor, LibraryExistsInDesignError
-from pyVHDLModel.Base import Direction, Range
+from pyVHDLModel.Base import Direction, SimpleRange
 from pyVHDLModel.Name import SelectedName, SimpleName, AllName, AttributeName
 from pyVHDLModel.Object import Constant, Signal
 from pyVHDLModel.Symbol import LibraryReferenceSymbol, PackageReferenceSymbol, PackageMemberReferenceSymbol, SimpleSubtypeSymbol
@@ -357,7 +357,7 @@ class Symbols(TestCase):
 	def test_ConstrainedScalarSubtypeSymbol(self) -> None:
 		"""``signal s : integer range 0 to 15;`` - previously the range constraint was read by
 		pyGHDL.dom but had nowhere to go, since this class was a bare stub."""
-		rng = Range(IntegerLiteral(0), IntegerLiteral(15), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(15), Direction.To)
 		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"), rng)
 
 		self.assertIs(rng, symbol.Constraint)
@@ -515,13 +515,13 @@ class SimpleInstance(TestCase):
 		self.assertEqual("bit", subtype.Identifier)
 
 	def test_Integer(self) -> None:
-		integer = IntegerType("integer", Range(IntegerLiteral(0), IntegerLiteral(7), Direction.To), None)
+		integer = IntegerType("integer", SimpleRange(IntegerLiteral(0), IntegerLiteral(7), Direction.To), None)
 
 		self.assertIsNotNone(integer)
 		self.assertEqual("integer", integer.Identifier)
 
 	def test_Real(self) -> None:
-		real = RealType("real", Range(FloatingPointLiteral(0.0), FloatingPointLiteral(1.0), Direction.To), None)
+		real = RealType("real", SimpleRange(FloatingPointLiteral(0.0), FloatingPointLiteral(1.0), Direction.To), None)
 
 		self.assertIsNotNone(real)
 		self.assertEqual("real", real.Identifier)

--- a/tests/unit/Sequential.py
+++ b/tests/unit/Sequential.py
@@ -35,7 +35,7 @@ tests/unit/Base.py (branches, report/assert statements, choices).
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base        import ModelEntity, Direction, Range
+from pyVHDLModel.Base        import ModelEntity, Direction, SimpleRange
 from pyVHDLModel.Name        import SimpleName
 from pyVHDLModel.Symbol      import SignalSymbol, VariableSymbol, Symbol, PossibleReference
 from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral, PhysicalIntegerLiteral
@@ -144,7 +144,7 @@ class Choices(TestCase):
 		self.assertEqual("0", str(choice))
 
 	def test_RangedChoice(self) -> None:
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		choice = RangedChoice(rng)
 
 		self.assertIs(rng, choice.Range)
@@ -194,7 +194,7 @@ class LoopStatements(TestCase):
 		self.assertEqual(0, len(statement.Statements))
 
 	def test_ForLoopStatement(self) -> None:
-		rng = Range(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
+		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		statement = ForLoopStatement("i", rng)
 
 		self.assertEqual("i", statement.LoopIndex)

--- a/tests/unit/Symbol.py
+++ b/tests/unit/Symbol.py
@@ -39,7 +39,7 @@ itself, the object/function-call symbols with no dedicated property) get their o
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base   import Direction, Range
+from pyVHDLModel.Base   import Direction, SimpleRange
 from pyVHDLModel.Name   import SimpleName, AllName
 from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Symbol import (
@@ -192,7 +192,7 @@ class ConstrainedSubtypeSymbols(TestCase):
 	"""``signal s : integer range 0 to 15;`` / ``std_logic_vector(7 downto 0)`` / record constraints."""
 
 	def test_ScalarConstraint_WithRange(self) -> None:
-		constraint = Range(IntegerLiteral(0), IntegerLiteral(15), Direction.To)
+		constraint = SimpleRange(IntegerLiteral(0), IntegerLiteral(15), Direction.To)
 		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"), constraint)
 
 		self.assertIs(constraint, symbol.Constraint)
@@ -206,7 +206,7 @@ class ConstrainedSubtypeSymbols(TestCase):
 		self.assertIsNone(symbol.Constraint)
 
 	def test_ArrayConstraint(self) -> None:
-		constraint = Range(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)
+		constraint = SimpleRange(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)
 		symbol = ConstrainedArraySubtypeSymbol(SimpleName("std_logic_vector"), [constraint])
 
 		self.assertEqual(1, len(symbol.Constraints))
@@ -214,7 +214,7 @@ class ConstrainedSubtypeSymbols(TestCase):
 
 	def test_RecordConstraint(self) -> None:
 		element = RecordElementSymbol(SimpleName("field"))
-		constraint = Range(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)
+		constraint = SimpleRange(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)
 		symbol = ConstrainedRecordSubtypeSymbol(SimpleName("rec_t"), {element: constraint})
 
 		self.assertEqual(1, len(symbol.Constraints))

--- a/tests/unit/Type.py
+++ b/tests/unit/Type.py
@@ -31,7 +31,7 @@
 """Tests for pyVHDLModel.Type."""
 from unittest import TestCase
 
-from pyVHDLModel.Base       import ModelEntity, Direction, Range
+from pyVHDLModel.Base       import ModelEntity, Direction, SimpleRange
 from pyVHDLModel.Name       import SimpleName, AttributeName
 from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
 from pyVHDLModel.Expression import IntegerLiteral, EnumerationLiteral, PhysicalIntegerLiteral
@@ -54,7 +54,7 @@ def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
 
 
 def _range(left: int = 0, right: int = 15, direction: Direction = Direction.To) -> Range:
-	return Range(IntegerLiteral(left), IntegerLiteral(right), direction)
+	return SimpleRange(IntegerLiteral(left), IntegerLiteral(right), direction)
 
 
 class ParentAndDocumentationWiringAcrossAllLeafTypes(TestCase):


### PR DESCRIPTION
Follows up on the review discussion in [Paebbels/ghdl#14](https://github.com/Paebbels/ghdl/pull/14#discussion_r3651299033): a range denoted by a name had nowhere to go in the model, so pyGHDL.dom was passing a bare `Name` into range-typed slots. Anything reading `.LeftBound`/`.Direction` off such a field would break.

## Grammar

Checked against the [machine-readable VHDL-2019 EBNF](https://www.sigasi.com/tech/vhdl2017.ebnf/):

```
range              ::= range_attribute_name | simple_range | range_expression
simple_range       ::= simple_expression direction simple_expression
discrete_range     ::= discrete_subtype_indication | range
subtype_indication ::= [ resolution_indication ] type_mark [ constraint ]
```

The model had only the `simple_range` form.

## Change

`Range` becomes the base-class:

- **`SimpleRange`** carries the previous bounds/direction implementation, named after the grammar's `simple_range` rule.
- **`RangeFromName`** wraps a `Symbol`, so bounds are inferred once that symbol is resolved.

`RangeFromName` deliberately covers both the range-attribute form (`vector'range`) and the discrete subtype indication form (`bit`, `integer range 0 to 7`). Strictly, the LRM puts a subtype indication one level up (`discrete_range ::= discrete_subtype_indication | range`), but a parser only ever sees "a name, optionally with a range constraint", and keeping one uniform type at every usage site is worth more here than mirroring the rule split. This is stated in the class docstring.

A constrained subtype indication no longer loses its type mark — it's carried by a `ConstrainedScalarSubtypeSymbol`, which holds the type mark and the range constraint together.

**`RangeAttributeSymbol`** is new. `PossibleReference.RangeAttribute` was declared in the enumeration but no symbol class ever used it; `RangeFromName` needs one for the attribute form.

## `RangedScalarType` migration

`integer_type_definition ::= range_constraint`, and `range_constraint ::= range range` — so an integer/floating/physical type definition is *always* a range, never a subtype indication. Its `Union[Range, Name]` existed only because a range attribute had no `Range` representation; now it does, so the field becomes a plain `Range`.

Its `_leftBound`/`_rightBound` fields are also removed: they were declared but never assigned and had no properties, so with `slots=True` they didn't exist at runtime.

## Testing

361 passed (357 before, +4 for the new classes), covering construction, parent wiring, `__str__`, and that a constrained subtype indication keeps both its type mark and its range constraint.

Companion pyGHDL.dom change in [Paebbels/ghdl#14](https://github.com/Paebbels/ghdl/pull/14) builds these classes from real IIR nodes; it needs this PR merged and released first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)