### PR TITLE
Fix NameError on Python < 3.14 from a stale Range annotation

### DIFF
--- a/tests/unit/Type.py
+++ b/tests/unit/Type.py
@@ -31,9 +31,9 @@
 """Tests for pyVHDLModel.Type."""
 from unittest import TestCase
 
-from pyVHDLModel.Base       import ModelEntity, Direction, SimpleRange
+from pyVHDLModel.Base       import ModelEntity, Direction, RangeFromName, SimpleRange
 from pyVHDLModel.Name       import SimpleName, AttributeName
-from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
+from pyVHDLModel.Symbol     import RangeAttributeSymbol, SimpleSubtypeSymbol
 from pyVHDLModel.Expression import IntegerLiteral, EnumerationLiteral, PhysicalIntegerLiteral
 from pyVHDLModel.Type       import (
 	Subtype, RangedScalarType,
@@ -53,7 +53,7 @@ def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
 	return SimpleSubtypeSymbol(SimpleName(name))
 
 
-def _range(left: int = 0, right: int = 15, direction: Direction = Direction.To) -> Range:
+def _range(left: int = 0, right: int = 15, direction: Direction = Direction.To) -> SimpleRange:
 	return SimpleRange(IntegerLiteral(left), IntegerLiteral(right), direction)
 
 
@@ -152,10 +152,9 @@ class EnumeratedTypes(TestCase):
 
 class IntegerTypes(TestCase):
 	"""Also covers ``RangedScalarType.Range`` (shared, unmodified, by ``IntegerType``/``RealType``/
-	``PhysicalType``): it accepts either a literal ``Range`` or a ``Name`` (an attribute-based range,
-	e.g. ``type t is range r'range;``), matching its ``Union[Range, Name]`` type hint - checked once
-	here since this behaviour genuinely is a single, shared implementation, unlike the constructor-
-	forwarding concern above."""
+	``PhysicalType``): it accepts any ``Range``, so either a ``SimpleRange`` or a ``RangeFromName`` for an
+	attribute-based range like ``type t is range r'range;`` - checked once here since this behaviour
+	genuinely is a single, shared implementation, unlike the constructor-forwarding concern above."""
 
 	def test_WithLiteralRange(self) -> None:
 		rng = _range(0, 15)
@@ -165,7 +164,7 @@ class IntegerTypes(TestCase):
 		self.assertEqual("nibble is range 0 to 15", str(integerType))
 
 	def test_WithAttributeRange(self) -> None:
-		rng = AttributeName("range", SimpleName("r"))
+		rng = RangeFromName(RangeAttributeSymbol(AttributeName("range", SimpleName("r"))))
 		integerType = IntegerType("t", rng)
 
 		self.assertIs(rng, integerType.Range)


### PR DESCRIPTION
Fixes the CI failure on Python 3.11–3.13 after #145:

```
File "tests/unit/Type.py", line 56, in <module>
    def _range(...) -> Range:
NameError: name 'Range' is not defined
```

## Cause

#145 changed `tests/unit/Type.py`'s import from `Range` to `SimpleRange`, but `_range`'s return annotation still said `Range`.

It passed on 3.14 and only there because **PEP 649** makes annotation evaluation lazy by default — the undefined name is never evaluated unless something asks for it. Python 3.11–3.13 evaluate annotations at `def` time, so the module fails on import. My container only has 3.14, which is why local runs were green.

Annotated as `SimpleRange`, which is what the helper actually returns.

## Also fixed: a stale test #145 should have updated

`IntegerTypes.test_WithAttributeRange` still passed a bare `AttributeName` into `IntegerType`'s range parameter — the exact `Union[Range, Name]` shape #145 removed. It kept passing only because type hints aren't enforced at runtime, so it silently asserted the old contract. It now builds a real `RangeFromName(RangeAttributeSymbol(...))`, and the class docstring no longer describes the removed union.

## How I verified across versions without those interpreters

Rather than eyeball it, I forced eager annotation evaluation on 3.14 to reproduce pre-3.14 semantics — walking every module, class and function in `pyVHDLModel` and `tests/unit` and calling `annotationlib.get_annotations(obj, format=Format.VALUE)`. That surfaced exactly one failure, matching CI, and reports clean after the fix.

361 passed locally.

> [!NOTE]
> This class of bug is invisible to a 3.14-only test run. If it's worth guarding against, the same forced-evaluation sweep could run as a CI step on 3.14, or the matrix's lowest version could gate merges. Happy to add either — say which you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)