### PR TITLE
Namespaces for sequential declaration regions, and for generics/ports/parameters

### DIFF
--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -37,6 +37,7 @@ Base-classes for the VHDL language model.
 from enum                  import unique, Enum
 from typing                import Type, Tuple, List, Iterable, Optional as Nullable, Union, cast
 
+from pyTooling.Common      import getFullyQualifiedName
 from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType
 
@@ -305,7 +306,9 @@ def identifiersOf(item) -> Tuple[str, ...]:
 	elif isinstance(item, NamedEntityMixin):
 		return (item._identifier, )
 
-	raise TypeError(f"Item '{item!r}' is neither a NamedEntityMixin nor a MultipleNamedEntityMixin.")
+	ex = TypeError(f"Item '{item}' is neither a NamedEntityMixin nor a MultipleNamedEntityMixin.")
+	ex.add_note(f"Got type '{getFullyQualifiedName(item)}'.")
+	raise ex
 
 
 @export
@@ -330,7 +333,9 @@ def normalizedIdentifiersOf(item) -> Tuple[str, ...]:
 	elif isinstance(item, NamedEntityMixin):
 		return (item._normalizedIdentifier, )
 
-	raise TypeError(f"Item '{item!r}' is neither a NamedEntityMixin nor a MultipleNamedEntityMixin.")
+	ex = TypeError(f"Item '{item}' is neither a NamedEntityMixin nor a MultipleNamedEntityMixin.")
+	ex.add_note(f"Got type '{getFullyQualifiedName(item)}'.")
+	raise ex
 
 
 @export

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -282,6 +282,58 @@ class MultipleNamedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
+def identifiersOf(item) -> Tuple[str, ...]:
+	"""
+	Return an item's identifier(s), regardless of how many names its declaration carries.
+
+	VHDL entities come in two shapes: singularly named ones deriving from :class:`NamedEntityMixin`
+	(``generic (type T)``, ``GenericProcedureInterfaceItem``, ...) and plurally named ones deriving from
+	:class:`MultipleNamedEntityMixin`, where one declaration names several items at once
+	(``port (p1, p2 : in bit)``, and every ``Constant``/``Signal``/``Variable``/``File``-derived item).
+
+	:param item:      A singularly or plurally named entity.
+	:returns:         The item's identifiers.
+	:raises TypeError: If the item is neither singularly nor plurally named.
+
+	.. seealso::
+
+	   :func:`normalizedIdentifiersOf`
+	     The same, but normalized (lower case) - use that for dictionary keys and name resolution.
+	"""
+	if isinstance(item, MultipleNamedEntityMixin):
+		return item._identifiers
+	elif isinstance(item, NamedEntityMixin):
+		return (item._identifier, )
+
+	raise TypeError(f"Item '{item!r}' is neither a NamedEntityMixin nor a MultipleNamedEntityMixin.")
+
+
+@export
+def normalizedIdentifiersOf(item) -> Tuple[str, ...]:
+	"""
+	Return an item's normalized (lower case) identifier(s).
+
+	This is the form used as dictionary keys and for name resolution, because VHDL identifiers are
+	case-insensitive.
+
+	:param item:      A singularly or plurally named entity.
+	:returns:         The item's normalized identifiers.
+	:raises TypeError: If the item is neither singularly nor plurally named.
+
+	.. seealso::
+
+	   :func:`identifiersOf`
+	     The same, but as written in the source - use that for rendering.
+	"""
+	if isinstance(item, MultipleNamedEntityMixin):
+		return item._normalizedIdentifiers
+	elif isinstance(item, NamedEntityMixin):
+		return (item._normalizedIdentifier, )
+
+	raise TypeError(f"Item '{item!r}' is neither a NamedEntityMixin nor a MultipleNamedEntityMixin.")
+
+
+@export
 class LabeledEntityMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A ``LabeledEntityMixin`` is a mixin class for all VHDL entities that can have labels.

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -369,6 +369,13 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 		self._namespace.ParentNamespace = parent._namespace
 
 
+	def IndexDeclaredItems(self) -> None:
+		"""A block's ports share the declarative region of its declarative part."""
+		self._IndexPortItems()
+
+		super().IndexDeclaredItems()
+
+
 @export
 class GenerateBranch(ModelEntity, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin):
 	"""

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -41,7 +41,7 @@ from pyTooling.MetaClasses   import ExtendedType
 
 from pyVHDLModel.Base        import ModelEntity, LabeledEntityMixin, DocumentedEntityMixin, Range, BaseChoice, BaseCase, IfBranchMixin
 from pyVHDLModel.Base        import ElsifBranchMixin, ElseBranchMixin, AssertStatementMixin, BlockStatementMixin, WaveformElement, ChoicesMixin
-from pyVHDLModel.Regions     import ConcurrentDeclarationRegionMixin
+from pyVHDLModel.Regions     import ConcurrentDeclarationRegionMixin, SequentialDeclarationRegionMixin
 from pyVHDLModel.Namespace   import Namespace
 from pyVHDLModel.Name        import Name
 from pyVHDLModel.Symbol      import ComponentInstantiationSymbol, EntityInstantiationSymbol, ArchitectureSymbol, ConfigurationInstantiationSymbol
@@ -53,7 +53,7 @@ from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignm
 from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
 from pyVHDLModel.Common      import ExpressionMixin, SelectedWaveformsMixin
-from pyVHDLModel.Sequential  import SequentialStatement, SequentialStatementsMixin, SequentialDeclarationsMixin
+from pyVHDLModel.Sequential  import SequentialStatement, SequentialStatementsMixin
 
 
 ExpressionUnion = Union[
@@ -269,7 +269,7 @@ class ConfigurationInstantiation(Instantiation):
 
 
 @export
-class ProcessStatement(ConcurrentStatement, SequentialDeclarationsMixin, SequentialStatementsMixin, DocumentedEntityMixin):
+class ProcessStatement(ConcurrentStatement, SequentialDeclarationRegionMixin, SequentialStatementsMixin, DocumentedEntityMixin):
 	"""
 	Represents a process statement with sensitivity list, sequential declaration region and sequential statements.
 
@@ -296,7 +296,7 @@ class ProcessStatement(ConcurrentStatement, SequentialDeclarationsMixin, Sequent
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		super().__init__(label, parent)
-		SequentialDeclarationsMixin.__init__(self, declaredItems)
+		SequentialDeclarationRegionMixin.__init__(self, self._normalizedLabel, declaredItems)
 		SequentialStatementsMixin.__init__(self, statements)
 		DocumentedEntityMixin.__init__(self, documentation)
 
@@ -307,6 +307,14 @@ class ProcessStatement(ConcurrentStatement, SequentialDeclarationsMixin, Sequent
 			for signalSymbol in sensitivityList:
 				self._sensitivityList.append(signalSymbol)
 				# signalSymbol._parent = self  # FIXME: currently str are provided
+
+	@ConcurrentStatement.Parent.setter
+	def Parent(self, parent: ModelEntity) -> None:
+		ConcurrentStatement.Parent.fset(self, parent)
+
+		# Connect the process' namespace to the enclosing declaration region's namespace, so a declaration
+		# inside the process hides a same-named one from the architecture, block or generate around it.
+		self._namespace.ParentNamespace = parent._namespace
 
 	@property
 	def SensitivityList(self) -> List[Name]:

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -48,7 +48,7 @@ from pyVHDLModel.Symbol      import ComponentInstantiationSymbol, EntityInstanti
 from pyVHDLModel.Symbol      import SignalSymbol
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Association import AssociationItem, ParameterAssociationItem
-from pyVHDLModel.Interface   import PortInterfaceItemMixin
+from pyVHDLModel.Interface   import PortInterfaceItemMixin, WithPortsMixin
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignmentMixin, AllowBlackboxMixin
 from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
@@ -335,9 +335,7 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 
 
 @export
-class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, LabeledEntityMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, DocumentedEntityMixin, AllowBlackboxMixin):
-	_portItems: List[PortInterfaceItemMixin]
-
+class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, LabeledEntityMixin, WithPortsMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, DocumentedEntityMixin, AllowBlackboxMixin):
 	_namespace: Namespace
 
 	def __init__(
@@ -358,27 +356,17 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 
 		BlockStatementMixin.__init__(self)
 		LabeledEntityMixin.__init__(self, label)
+		WithPortsMixin.__init__(self, portItems)
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
 		ConcurrentStatementsMixin.__init__(self, statements)
 		DocumentedEntityMixin.__init__(self, documentation)
 		AllowBlackboxMixin.__init__(self, allowBlackbox)
-
-		# TODO: extract to mixin
-		self._portItems = []
-		if portItems is not None:
-			for item in portItems:
-				self._portItems.append(item)
-				item.Parent = self
 
 	@ConcurrentStatement.Parent.setter
 	def Parent(self, parent: ModelEntity) -> None:
 		ConcurrentStatement.Parent.fset(self, parent)
 
 		self._namespace.ParentNamespace = parent._namespace
-
-	@property
-	def PortItems(self) -> List[PortInterfaceItemMixin]:
-		return self._portItems
 
 
 @export

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -501,6 +501,13 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, Concur
 		return f"{lib}.{self._identifier}"
 
 
+	def IndexDeclaredItems(self) -> None:
+		"""A generic package's generics share the declarative region of its declarative part."""
+		self._IndexGenericItems()
+
+		super().IndexDeclaredItems()
+
+
 @export
 class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarationRegionMixin):
 	"""
@@ -607,6 +614,14 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, WithPor
 		archs = ', '.join(self._architectures.keys()) if self._architectures else "%"
 
 		return f"{lib}.{self._identifier}({archs})"
+
+
+	def IndexDeclaredItems(self) -> None:
+		"""An entity's generics and ports share the declarative region of its declarative part."""
+		self._IndexGenericItems()
+		self._IndexPortItems()
+
+		super().IndexDeclaredItems()
 
 
 @export

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -41,30 +41,11 @@ from pyTooling.MetaClasses  import ExtendedType
 
 from pyVHDLModel.Symbol     import Symbol, SubtypeSymbol, ModeViewSymbol
 from pyVHDLModel.Base       import ModelEntity, DocumentedEntityMixin, NamedEntityMixin, OptionallyNamedEntityMixin
-from pyVHDLModel.Base       import MultipleNamedEntityMixin
+from pyVHDLModel.Base       import MultipleNamedEntityMixin, identifiersOf
 from pyVHDLModel.Base       import ExpressionUnion, Mode
 from pyVHDLModel.Object     import Constant, Signal, Variable, File
 from pyVHDLModel.Subprogram import Procedure, Function
 from pyVHDLModel.Type       import Type
-
-
-def _identifiersOf(item) -> Tuple[str, ...]:
-	"""
-	Returns an item's identifier(s) as a tuple, regardless of whether it's ``NamedEntityMixin``-based
-	(a single ``Identifier``: ``GenericTypeInterfaceItem``, ``GenericProcedureInterfaceItem``,
-	``GenericFunctionInterfaceItem``, ``GenericPackageInterfaceItem``) or ``MultipleNamedEntityMixin``-
-	based (plural ``Identifiers``: every ``Constant``/``Signal``/``Variable``/``File``-derived item,
-	since a single declaration can name several objects at once, e.g. ``port (p1, p2 : in bit);``).
-
-	Narrowly-scoped fix; a bigger redesign is under consideration (a real ``__str__`` on
-	``NamedEntityMixin``/``MultipleNamedEntityMixin`` themselves, so a group's own ``__str__`` could
-	just delegate to ``str(item)`` instead of reaching into identifier shape at all) - deferred to its
-	own branch rather than done here.
-	"""
-	if isinstance(item, MultipleNamedEntityMixin):
-		return item.Identifiers
-
-	return (item.Identifier,)
 
 
 @export
@@ -563,7 +544,7 @@ class GenericGroup(InterfaceGroup, WithGenericsMixin):
 		return iter(self._genericItems)
 
 	def __str__(self) -> str:
-		names = ", ".join(name for item in self._genericItems for name in _identifiersOf(item))
+		names = ", ".join(name for item in self._genericItems for name in identifiersOf(item))
 		return f"GenericGroup {self._identifier} ({len(self._genericItems)}) - generics: {names})"
 
 
@@ -586,7 +567,7 @@ class PortGroup(InterfaceGroup, WithPortsMixin):
 		return iter(self._portItems)
 
 	def __str__(self) -> str:
-		names = ", ".join(name for item in self._portItems for name in _identifiersOf(item))
+		names = ", ".join(name for item in self._portItems for name in identifiersOf(item))
 		return f"PortGroup: {self._identifier} ({len(self._portItems)}) - ports: {names})"
 
 
@@ -609,5 +590,5 @@ class ParameterGroup(InterfaceGroup, WithParametersMixin):
 		return iter(self._parameterItems)
 
 	def __str__(self) -> str:
-		names = ", ".join(name for item in self._parameterItems for name in _identifiersOf(item))
+		names = ", ".join(name for item in self._parameterItems for name in identifiersOf(item))
 		return f"ParameterGroup {self._identifier} ({len(self._parameterItems)}) - parameters: {names})"

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -41,9 +41,12 @@ from pyTooling.MetaClasses  import ExtendedType
 from pyTooling.Warning      import WarningCollector
 
 from pyVHDLModel.Exception  import NotImplementedWarning
+from pyVHDLModel.Namespace  import Namespace
 from pyVHDLModel.Object     import Constant, SharedVariable, File, Variable, Signal
-from pyVHDLModel.Subprogram import Subprogram, Function, Procedure
 from pyVHDLModel.Type       import Subtype, FullType
+
+# `pyVHDLModel.Subprogram` imports this module (Subprogram is a sequential declaration region), so
+# `Function`/`Procedure` are quoted in annotations and imported lazily where they're needed at runtime.
 
 
 @export
@@ -62,8 +65,8 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 	_files:           Dict[str, File]                   #: Dictionary of all files declared in this concurrent declaration region.
 	# _subprograms:     Dict[str, List[Subprogram]]  #: Dictionary of all subprograms declared in this concurrent declaration region.
 	# FIXME: overloads are only collected into a list, not matched/resolved by signature.
-	_functions:       Dict[str, List[Function]]         #: Dictionary of all functions declared in this concurrent declaration region, keyed by name; each entry is a list of overloads.
-	_procedures:      Dict[str, List[Procedure]]        #: Dictionary of all procedures declared in this concurrent declaration region, keyed by name; each entry is a list of overloads.
+	_functions:       Dict[str, List['Function']]         #: Dictionary of all functions declared in this concurrent declaration region, keyed by name; each entry is a list of overloads.
+	_procedures:      Dict[str, List['Procedure']]        #: Dictionary of all procedures declared in this concurrent declaration region, keyed by name; each entry is a list of overloads.
 	_components:      Dict[str, Any]                    #: Dictionary of all components declared in this concurrent declaration region.
 
 	def __init__(self, declaredItems: Nullable[Iterable] = None) -> None:
@@ -123,11 +126,11 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 	# 	return self._subprograms
 
 	@readonly
-	def Functions(self) -> Dict[str, List[Function]]:
+	def Functions(self) -> Dict[str, List['Function']]:
 		return self._functions
 
 	@readonly
-	def Procedures(self) -> Dict[str, List[Procedure]]:
+	def Procedures(self) -> Dict[str, List['Procedure']]:
 		return self._procedures
 
 	@readonly
@@ -165,6 +168,7 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		     Iterate all packages in the library and index declared items.
 		"""
 		from pyVHDLModel.DesignUnit import Component
+		from pyVHDLModel.Subprogram import Function, Procedure
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -214,3 +218,147 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 	def _IndexOtherDeclaredItem(self, item) -> None:
 		pass
 		# print(f"_IndexOtherDeclaredItem - {item}\n  ({' -> '.join(t.__name__ for t in type(item).mro())})")
+
+
+@export
+class SequentialDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for sequential declaration regions: process statements and subprogram bodies.
+
+	.. note::
+
+	   VHDL's ``process_declarative_item`` and ``subprogram_declarative_item`` rules are identical, so both
+	   regions share this implementation. Compared to a concurrent region
+	   (:class:`ConcurrentDeclarationRegionMixin`, ``block_declarative_item``), a sequential region can
+	   declare a **variable**, but no signal, shared variable, component or mode view, and none of the
+	   specifications.
+	"""
+
+	_declaredItems: List                          #: List of all declared items in this sequential declaration region.
+	_namespace:     Namespace                     #: The namespace of this sequential declaration region.
+
+	_types:         Dict[str, FullType]           #: Dictionary of all types declared in this sequential declaration region.
+	_subtypes:      Dict[str, Subtype]            #: Dictionary of all subtypes declared in this sequential declaration region.
+	_constants:     Dict[str, Constant]           #: Dictionary of all constants declared in this sequential declaration region.
+	_variables:     Dict[str, Variable]           #: Dictionary of all variables declared in this sequential declaration region.
+	_files:         Dict[str, File]               #: Dictionary of all files declared in this sequential declaration region.
+	# FIXME: overloads are only collected into a list, not matched/resolved by signature.
+	_functions:     Dict[str, List['Function']]   #: Dictionary of all functions declared in this sequential declaration region, keyed by name; each entry is a list of overloads.
+	_procedures:    Dict[str, List['Procedure']]  #: Dictionary of all procedures declared in this sequential declaration region, keyed by name; each entry is a list of overloads.
+
+	def __init__(self, namespaceName: Nullable[str] = None, declaredItems: Nullable[Iterable] = None) -> None:
+		"""
+		Initialize a sequential declaration region.
+
+		:param namespaceName:  Name of this region's namespace, usually the host's label or identifier.
+		:param declaredItems:  The items declared in this region.
+		"""
+		self._namespace = Namespace(namespaceName)
+
+		self._declaredItems = []  # TODO: convert to dict
+		if declaredItems is not None:
+			for item in declaredItems:
+				self._declaredItems.append(item)
+				item.Parent = self
+
+		self._types =      {}
+		self._subtypes =   {}
+		self._constants =  {}
+		self._variables =  {}
+		self._files =      {}
+		self._functions =  {}
+		self._procedures = {}
+
+	@readonly
+	def DeclaredItems(self) -> List:
+		"""Read-only property to access the declared items (:attr:`_declaredItems`)."""
+		return self._declaredItems
+
+	@readonly
+	def Namespace(self) -> Namespace:
+		"""Read-only property to access this region's namespace (:attr:`_namespace`)."""
+		return self._namespace
+
+	@readonly
+	def Types(self) -> Dict[str, FullType]:
+		"""Read-only property to access the declared types (:attr:`_types`)."""
+		return self._types
+
+	@readonly
+	def Subtypes(self) -> Dict[str, Subtype]:
+		"""Read-only property to access the declared subtypes (:attr:`_subtypes`)."""
+		return self._subtypes
+
+	@readonly
+	def Constants(self) -> Dict[str, Constant]:
+		"""Read-only property to access the declared constants (:attr:`_constants`)."""
+		return self._constants
+
+	@readonly
+	def Variables(self) -> Dict[str, Variable]:
+		"""Read-only property to access the declared variables (:attr:`_variables`)."""
+		return self._variables
+
+	@readonly
+	def Files(self) -> Dict[str, File]:
+		"""Read-only property to access the declared files (:attr:`_files`)."""
+		return self._files
+
+	@readonly
+	def Functions(self) -> Dict[str, List['Function']]:
+		"""Read-only property to access the declared functions (:attr:`_functions`)."""
+		return self._functions
+
+	@readonly
+	def Procedures(self) -> Dict[str, List['Procedure']]:
+		"""Read-only property to access the declared procedures (:attr:`_procedures`)."""
+		return self._procedures
+
+	def IndexDeclaredItems(self) -> None:
+		"""
+		Index declared items listed in the sequential declaration region.
+
+		Every declared item is added to :attr:`_namespace`, and additionally to the lookup table matching its
+		kind. Items of an unhandled kind are passed to :meth:`_IndexOtherDeclaredItem`.
+
+		.. seealso::
+
+		   :meth:`ConcurrentDeclarationRegionMixin.IndexDeclaredItems`
+		     The same algorithm for a concurrent declaration region.
+		"""
+		from pyVHDLModel.Subprogram import Function, Procedure
+
+		for item in self._declaredItems:
+			if isinstance(item, FullType):
+				self._types[item._normalizedIdentifier] = item
+				self._namespace._elements[item._normalizedIdentifier] = item
+			elif isinstance(item, Subtype):
+				self._subtypes[item._normalizedIdentifier] = item
+				self._namespace._elements[item._normalizedIdentifier] = item
+			elif isinstance(item, Function):
+				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
+				#        real overload resolution yet).
+				self._functions.setdefault(item._normalizedIdentifier, []).append(item)
+				self._namespace._elements[item._normalizedIdentifier] = item
+			elif isinstance(item, Procedure):
+				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
+				#        real overload resolution yet).
+				self._procedures.setdefault(item._normalizedIdentifier, []).append(item)
+				self._namespace._elements[item._normalizedIdentifier] = item
+			elif isinstance(item, Constant):
+				for normalizedIdentifier in item._normalizedIdentifiers:
+					self._constants[normalizedIdentifier] = item
+					self._namespace._elements[normalizedIdentifier] = item
+			elif isinstance(item, Variable):
+				for normalizedIdentifier in item._normalizedIdentifiers:
+					self._variables[normalizedIdentifier] = item
+					self._namespace._elements[normalizedIdentifier] = item
+			elif isinstance(item, File):
+				for normalizedIdentifier in item._normalizedIdentifiers:
+					self._files[normalizedIdentifier] = item
+					self._namespace._elements[normalizedIdentifier] = item
+			else:
+				self._IndexOtherDeclaredItem(item)
+
+	def _IndexOtherDeclaredItem(self, item) -> None:
+		pass

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -40,6 +40,7 @@ from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
 from pyTooling.Warning      import WarningCollector
 
+from pyVHDLModel.Base       import MultipleNamedEntityMixin
 from pyVHDLModel.Exception  import NotImplementedWarning
 from pyVHDLModel.Namespace  import Namespace
 from pyVHDLModel.Object     import Constant, SharedVariable, File, Variable, Signal
@@ -47,6 +48,54 @@ from pyVHDLModel.Type       import Subtype, FullType
 
 # `pyVHDLModel.Subprogram` imports this module (Subprogram is a sequential declaration region), so
 # `Function`/`Procedure` are quoted in annotations and imported lazily where they're needed at runtime.
+
+
+
+def _NormalizedIdentifiersOf(item) -> Iterable[str]:
+	"""
+	Return an item's normalized identifier(s).
+
+	Interface items come in two shapes: a plural :class:`~pyVHDLModel.Base.MultipleNamedEntityMixin`
+	(``port (a, b : in bit)``) and a singular :class:`~pyVHDLModel.Base.NamedEntityMixin`
+	(``generic (type T)``).
+
+	:param item: The declared or interface item.
+	:returns:    The item's normalized identifiers.
+	"""
+	if isinstance(item, MultipleNamedEntityMixin):
+		return item._normalizedIdentifiers
+
+	return (item._normalizedIdentifier, )
+
+
+def _IndexInterfaceItemsInto(region) -> None:
+	"""
+	Add a declaration region's generics, ports and parameters to its namespace.
+
+	An interface item shares the declarative region of the declarative part next to it: VHDL rejects
+	``port (g : in bit)`` beside ``generic (g : integer)``, ``signal x`` beside ``port (x : in bit)``, and a
+	subprogram variable named like one of its parameters - all as "identifier already used for a
+	declaration". So they belong in the *same* namespace, not a separate one.
+
+	Interface items are only added to the namespace; :attr:`WithGenericsMixin.GenericItems` and friends
+	already expose them as ordered lists, so no extra lookup table is needed.
+
+	.. note::
+
+	   The lists are looked up by name rather than via ``isinstance`` against
+	   :class:`~pyVHDLModel.Interface.WithGenericsMixin` and friends, because not every host can inherit
+	   those mixins: :mod:`pyVHDLModel.Interface` needs :class:`~pyVHDLModel.Subprogram.Procedure` and
+	   :class:`~pyVHDLModel.Subprogram.Function` as real base classes for its generic subprogram interface
+	   items, so :mod:`pyVHDLModel.Subprogram` may never import it and declares its own
+	   ``_genericItems``/``_parameterItems``. Reading the canonical field names covers both cases without
+	   importing :mod:`pyVHDLModel.Interface` at all.
+
+	:param region: The declaration region whose interface items are to be indexed.
+	"""
+	for attributeName in ("_genericItems", "_portItems", "_parameterItems"):
+		for item in getattr(region, attributeName, None) or ():
+			for normalizedIdentifier in _NormalizedIdentifiersOf(item):
+				region._namespace._elements[normalizedIdentifier] = item
 
 
 @export
@@ -169,6 +218,8 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		"""
 		from pyVHDLModel.DesignUnit import Component
 		from pyVHDLModel.Subprogram import Function, Procedure
+
+		_IndexInterfaceItemsInto(self)
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -327,6 +378,8 @@ class SequentialDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		     The same algorithm for a concurrent declaration region.
 		"""
 		from pyVHDLModel.Subprogram import Function, Procedure
+
+		_IndexInterfaceItemsInto(self)
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -40,7 +40,7 @@ from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
 from pyTooling.Warning      import WarningCollector
 
-from pyVHDLModel.Base       import MultipleNamedEntityMixin
+from pyVHDLModel.Base       import normalizedIdentifiersOf
 from pyVHDLModel.Exception  import NotImplementedWarning
 from pyVHDLModel.Namespace  import Namespace
 from pyVHDLModel.Object     import Constant, SharedVariable, File, Variable, Signal
@@ -51,51 +51,25 @@ from pyVHDLModel.Type       import Subtype, FullType
 
 
 
-def _NormalizedIdentifiersOf(item) -> Iterable[str]:
-	"""
-	Return an item's normalized identifier(s).
-
-	Interface items come in two shapes: a plural :class:`~pyVHDLModel.Base.MultipleNamedEntityMixin`
-	(``port (a, b : in bit)``) and a singular :class:`~pyVHDLModel.Base.NamedEntityMixin`
-	(``generic (type T)``).
-
-	:param item: The declared or interface item.
-	:returns:    The item's normalized identifiers.
-	"""
-	if isinstance(item, MultipleNamedEntityMixin):
-		return item._normalizedIdentifiers
-
-	return (item._normalizedIdentifier, )
+def _IndexGenericItems(region) -> None:
+	"""Add a region's generics to its namespace."""
+	for item in region._genericItems:
+		for normalizedIdentifier in normalizedIdentifiersOf(item):
+			region._namespace._elements[normalizedIdentifier] = item
 
 
-def _IndexInterfaceItemsInto(region) -> None:
-	"""
-	Add a declaration region's generics, ports and parameters to its namespace.
+def _IndexPortItems(region) -> None:
+	"""Add a region's ports to its namespace."""
+	for item in region._portItems:
+		for normalizedIdentifier in normalizedIdentifiersOf(item):
+			region._namespace._elements[normalizedIdentifier] = item
 
-	An interface item shares the declarative region of the declarative part next to it: VHDL rejects
-	``port (g : in bit)`` beside ``generic (g : integer)``, ``signal x`` beside ``port (x : in bit)``, and a
-	subprogram variable named like one of its parameters - all as "identifier already used for a
-	declaration". So they belong in the *same* namespace, not a separate one.
 
-	Interface items are only added to the namespace; :attr:`WithGenericsMixin.GenericItems` and friends
-	already expose them as ordered lists, so no extra lookup table is needed.
-
-	.. note::
-
-	   The lists are looked up by name rather than via ``isinstance`` against
-	   :class:`~pyVHDLModel.Interface.WithGenericsMixin` and friends, because not every host can inherit
-	   those mixins: :mod:`pyVHDLModel.Interface` needs :class:`~pyVHDLModel.Subprogram.Procedure` and
-	   :class:`~pyVHDLModel.Subprogram.Function` as real base classes for its generic subprogram interface
-	   items, so :mod:`pyVHDLModel.Subprogram` may never import it and declares its own
-	   ``_genericItems``/``_parameterItems``. Reading the canonical field names covers both cases without
-	   importing :mod:`pyVHDLModel.Interface` at all.
-
-	:param region: The declaration region whose interface items are to be indexed.
-	"""
-	for attributeName in ("_genericItems", "_portItems", "_parameterItems"):
-		for item in getattr(region, attributeName, None) or ():
-			for normalizedIdentifier in _NormalizedIdentifiersOf(item):
-				region._namespace._elements[normalizedIdentifier] = item
+def _IndexParameterItems(region) -> None:
+	"""Add a region's parameters to its namespace."""
+	for item in region._parameterItems:
+		for normalizedIdentifier in normalizedIdentifiersOf(item):
+			region._namespace._elements[normalizedIdentifier] = item
 
 
 @export
@@ -217,9 +191,16 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		     Iterate all packages in the library and index declared items.
 		"""
 		from pyVHDLModel.DesignUnit import Component
+		from pyVHDLModel.Interface  import WithGenericsMixin, WithPortsMixin
 		from pyVHDLModel.Subprogram import Function, Procedure
 
-		_IndexInterfaceItemsInto(self)
+		# An interface item shares the declarative region of the declarative part beside it, so generics and
+		# ports go into this very namespace. Entities have both, generic packages only generics, blocks only
+		# ports.
+		if isinstance(self, WithGenericsMixin):
+			_IndexGenericItems(self)
+		if isinstance(self, WithPortsMixin):
+			_IndexPortItems(self)
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -377,9 +358,15 @@ class SequentialDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		   :meth:`ConcurrentDeclarationRegionMixin.IndexDeclaredItems`
 		     The same algorithm for a concurrent declaration region.
 		"""
-		from pyVHDLModel.Subprogram import Function, Procedure
+		from pyVHDLModel.Subprogram import Function, Procedure, Subprogram
 
-		_IndexInterfaceItemsInto(self)
+		# A subprogram's generics and parameters share its declarative region. `Subprogram` cannot inherit
+		# `WithGenericsMixin`/`WithParametersMixin`: `pyVHDLModel.Interface` needs `Procedure`/`Function` as
+		# real base classes for its generic subprogram interface items, so `pyVHDLModel.Subprogram` may never
+		# import it and declares the two lists itself.
+		if isinstance(self, Subprogram):
+			_IndexGenericItems(self)
+			_IndexParameterItems(self)
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -51,29 +51,50 @@ from pyVHDLModel.Type       import Subtype, FullType
 
 
 
-def _IndexGenericItems(region) -> None:
-	"""Add a region's generics to its namespace."""
-	for item in region._genericItems:
-		for normalizedIdentifier in normalizedIdentifiersOf(item):
-			region._namespace._elements[normalizedIdentifier] = item
+@export
+class DeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A base-class for the concurrent and sequential declaration region mixins.
 
+	It carries what both regions share: adding interface items to the region's namespace, and the hook for
+	declared items neither region handles itself.
 
-def _IndexPortItems(region) -> None:
-	"""Add a region's ports to its namespace."""
-	for item in region._portItems:
-		for normalizedIdentifier in normalizedIdentifiersOf(item):
-			region._namespace._elements[normalizedIdentifier] = item
+	An interface item shares the declarative region of the declarative part beside it - VHDL rejects
+	``port (g : in bit)`` beside ``generic (g : integer)``, ``signal x`` beside ``port (x : in bit)``, and a
+	subprogram variable named like one of its parameters, all as "identifier already used for a
+	declaration". So they belong in the region's *own* namespace, not a separate one.
 
+	Which of the three a region has is known statically by the class that declares them, so each derived
+	class calls the ones it needs from its own :meth:`IndexDeclaredItems` before delegating upwards.
+	Interface items are added to the namespace only - ``GenericItems``/``PortItems``/``ParameterItems``
+	already expose them as ordered lists, so no extra lookup table is needed.
+	"""
 
-def _IndexParameterItems(region) -> None:
-	"""Add a region's parameters to its namespace."""
-	for item in region._parameterItems:
-		for normalizedIdentifier in normalizedIdentifiersOf(item):
-			region._namespace._elements[normalizedIdentifier] = item
+	def _IndexGenericItems(self) -> None:
+		"""Add this region's generics to its namespace."""
+		for item in self._genericItems:
+			for normalizedIdentifier in normalizedIdentifiersOf(item):
+				self._namespace._elements[normalizedIdentifier] = item
+
+	def _IndexPortItems(self) -> None:
+		"""Add this region's ports to its namespace."""
+		for item in self._portItems:
+			for normalizedIdentifier in normalizedIdentifiersOf(item):
+				self._namespace._elements[normalizedIdentifier] = item
+
+	def _IndexParameterItems(self) -> None:
+		"""Add this region's parameters to its namespace."""
+		for item in self._parameterItems:
+			for normalizedIdentifier in normalizedIdentifiersOf(item):
+				self._namespace._elements[normalizedIdentifier] = item
+
+	def _IndexOtherDeclaredItem(self, item) -> None:
+		"""Hook for declared items the region doesn't handle itself. Derived classes may override it."""
+		pass
 
 
 @export
-class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
+class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	# FIXME: define list prefix type e.g. via Union
 	_declaredItems:   List                              #: List of all declared items in this concurrent declaration region.
 
@@ -191,16 +212,7 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		     Iterate all packages in the library and index declared items.
 		"""
 		from pyVHDLModel.DesignUnit import Component
-		from pyVHDLModel.Interface  import WithGenericsMixin, WithPortsMixin
 		from pyVHDLModel.Subprogram import Function, Procedure
-
-		# An interface item shares the declarative region of the declarative part beside it, so generics and
-		# ports go into this very namespace. Entities have both, generic packages only generics, blocks only
-		# ports.
-		if isinstance(self, WithGenericsMixin):
-			_IndexGenericItems(self)
-		if isinstance(self, WithPortsMixin):
-			_IndexPortItems(self)
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -247,13 +259,9 @@ class ConcurrentDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 			else:
 				self._IndexOtherDeclaredItem(item)
 
-	def _IndexOtherDeclaredItem(self, item) -> None:
-		pass
-		# print(f"_IndexOtherDeclaredItem - {item}\n  ({' -> '.join(t.__name__ for t in type(item).mro())})")
-
 
 @export
-class SequentialDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
+class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	"""
 	A mixin-class for sequential declaration regions: process statements and subprogram bodies.
 
@@ -358,15 +366,7 @@ class SequentialDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		   :meth:`ConcurrentDeclarationRegionMixin.IndexDeclaredItems`
 		     The same algorithm for a concurrent declaration region.
 		"""
-		from pyVHDLModel.Subprogram import Function, Procedure, Subprogram
-
-		# A subprogram's generics and parameters share its declarative region. `Subprogram` cannot inherit
-		# `WithGenericsMixin`/`WithParametersMixin`: `pyVHDLModel.Interface` needs `Procedure`/`Function` as
-		# real base classes for its generic subprogram interface items, so `pyVHDLModel.Subprogram` may never
-		# import it and declares the two lists itself.
-		if isinstance(self, Subprogram):
-			_IndexGenericItems(self)
-			_IndexParameterItems(self)
+		from pyVHDLModel.Subprogram import Function, Procedure
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -399,6 +399,3 @@ class SequentialDeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 					self._namespace._elements[normalizedIdentifier] = item
 			else:
 				self._IndexOtherDeclaredItem(item)
-
-	def _IndexOtherDeclaredItem(self, item) -> None:
-		pass

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -604,18 +604,3 @@ class WaitStatement(SequentialStatement, ConditionalMixin):
 		return self._timeout
 
 
-@export
-class SequentialDeclarationsMixin(metaclass=ExtendedType, mixin=True):
-	_declaredItems: List
-
-	def __init__(self, declaredItems: Iterable) -> None:
-		# TODO: extract to mixin
-		self._declaredItems = []  # TODO: convert to dict
-		if declaredItems is not None:
-			for item in declaredItems:
-				self._declaredItems.append(item)
-				item.Parent = self
-
-	@property
-	def DeclaredItems(self) -> List:
-		return self._declaredItems

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -42,14 +42,14 @@ from pyTooling.MetaClasses  import ExtendedType
 from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, DocumentedEntityMixin
 from pyVHDLModel.Symbol     import SubtypeSymbol
 from pyVHDLModel.Type       import ProtectedType
+from pyVHDLModel.Regions    import ConcurrentDeclarationRegionMixin, SequentialDeclarationRegionMixin
 from pyVHDLModel.Sequential import SequentialStatement
 
 
 @export
-class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
+class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, SequentialDeclarationRegionMixin):
 	_genericItems:   List['GenericInterfaceItemMixin']
 	_parameterItems: List['ParameterInterfaceItemMixin']
-	_declaredItems:  List
 	_statements:     List[SequentialStatement]
 	_isPure:         bool
 
@@ -67,6 +67,7 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
 		DocumentedEntityMixin.__init__(self, documentation)
+		SequentialDeclarationRegionMixin.__init__(self, self._normalizedIdentifier, declaredItems)
 
 		self._genericItems = []  # TODO: convert to dict
 		if genericItems is not None:
@@ -80,12 +81,6 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 				self._parameterItems.append(item)
 				item.Parent = self
 
-		self._declaredItems = []  # TODO: use mixin class
-		if declaredItems is not None:
-			for item in declaredItems:
-				self._declaredItems.append(item)
-				item.Parent = self
-
 		self._statements = []  # TODO: use mixin class
 		if statements is not None:
 			for item in statements:
@@ -94,6 +89,17 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 		self._isPure = isPure
 
+	@ModelEntity.Parent.setter
+	def Parent(self, parent: ModelEntity) -> None:
+		ModelEntity.Parent.fset(self, parent)
+
+		# Connect the subprogram's namespace to the enclosing declaration region's namespace, so a
+		# declaration inside the subprogram hides a same-named one from the scope around it. A subprogram
+		# can also be a protected type's method, and a protected type is no declaration region, hence the
+		# check.
+		if isinstance(parent, (ConcurrentDeclarationRegionMixin, SequentialDeclarationRegionMixin)):
+			self._namespace.ParentNamespace = parent._namespace
+
 	@readonly
 	def GenericItems(self) -> List['GenericInterfaceItemMixin']:
 		return self._genericItems
@@ -101,10 +107,6 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	@readonly
 	def ParameterItems(self) -> List['ParameterInterfaceItemMixin']:
 		return self._parameterItems
-
-	@readonly
-	def DeclaredItems(self) -> List:
-		return self._declaredItems
 
 	@readonly
 	def Statements(self) -> List[SequentialStatement]:

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -117,6 +117,14 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, Sequentia
 		return self._isPure
 
 
+	def IndexDeclaredItems(self) -> None:
+		"""A subprogram's generics and parameters share the declarative region of its declarative part."""
+		self._IndexGenericItems()
+		self._IndexParameterItems()
+
+		super().IndexDeclaredItems()
+
+
 @export
 class Procedure(Subprogram):
 	def __init__(

--- a/tests/unit/Namespace/Hiding.py
+++ b/tests/unit/Namespace/Hiding.py
@@ -67,7 +67,11 @@ def _signal(identifier: str) -> Signal:
 
 class EntityAndArchitecture(TestCase):
 	"""
-	An architecture's namespace nests inside its entity's.
+	An architecture's namespace nests inside its entity's, which is what makes an entity's ports and
+	declarations *visible* in the architecture.
+
+	Note this pair is a single declarative region in VHDL, so it is not a hiding scenario - see
+	:meth:`test_ArchitectureDeclarationShadowsEntityDeclaration_ButIsIllegalVHDL`.
 
 	That link is established by :meth:`~pyVHDLModel.Library.LinkArchitectures`, not by assigning
 	``Architecture.Parent`` - an architecture's parent is its document, and the entity relation goes
@@ -99,11 +103,24 @@ class EntityAndArchitecture(TestCase):
 	def test_ArchitectureNamespaceNestsInsideEntityNamespace(self) -> None:
 		self.assertIs(self._entity._namespace, self._architecture._namespace.ParentNamespace)
 
-	def test_ArchitectureDeclarationHidesEntityDeclaration(self) -> None:
+	def test_ArchitectureDeclarationShadowsEntityDeclaration_ButIsIllegalVHDL(self) -> None:
+		"""
+		Documents current *model* behaviour, which does **not** match VHDL.
+
+		An entity declaration and its architecture body form a **single** declarative region
+		(LRM 12.1), so re-declaring an entity-level name in the architecture is an error, not hiding.
+		Confirmed against GHDL: ``signal s`` in an architecture whose entity declares ``s`` gives
+		"identifier "s" already used for a declaration" - whereas a *process* variable shadowing an
+		architecture signal only warns (``-Whide``).
+
+		The model represents the entity/architecture pair as two nested namespaces, which gets
+		*visibility* right (see the next test) but silently resolves a duplicate instead of rejecting
+		it. Duplicate-declaration detection is a separate, missing feature - see
+		``pyVHDLModel.Findings.md``.
+		"""
 		found = self._architecture._namespace.FindObject(SignalSymbol(SimpleName("x")))
 
 		self.assertIs(self._architectureSignal, found)
-		self.assertIsNot(self._entitySignal, found)
 
 	def test_ArchitectureInheritsEntityOnlyDeclaration(self) -> None:
 		found = self._architecture._namespace.FindObject(SignalSymbol(SimpleName("entityOnly")))
@@ -111,7 +128,7 @@ class EntityAndArchitecture(TestCase):
 		self.assertIs(self._entityOnlySignal, found)
 
 	def test_EntityStillResolvesItsOwnDeclaration(self) -> None:
-		"""Hiding is one-directional - the outer scope is unaffected by the inner one."""
+		"""Lookup only walks outwards - the outer namespace is unaffected by the inner one."""
 		found = self._entity._namespace.FindObject(SignalSymbol(SimpleName("x")))
 
 		self.assertIs(self._entitySignal, found)

--- a/tests/unit/Namespace/InterfaceItems.py
+++ b/tests/unit/Namespace/InterfaceItems.py
@@ -1,0 +1,204 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Interface items - generics, ports and parameters - resolved through their region's namespace.
+
+An interface item shares the declarative region of the declarative part beside it. Verified against the
+GHDL analyzer: ``port (g : in bit)`` beside ``generic (g : integer)``, ``signal x`` beside
+``port (x : in bit)``, and a subprogram variable named like a parameter are each rejected with
+"identifier already used for a declaration". So they go into the *same* namespace as the declared items,
+not a separate one.
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Base       import Mode
+from pyVHDLModel.Concurrent import ConcurrentBlockStatement, ProcessStatement
+from pyVHDLModel.DesignUnit import Architecture, Entity, Package
+from pyVHDLModel.Interface  import (
+	GenericConstantInterfaceItem,
+	GenericTypeInterfaceItem,
+	ParameterVariableInterfaceItem,
+	PortSimpleSignalInterfaceItem,
+)
+from pyVHDLModel.Name       import SimpleName
+from pyVHDLModel.Object     import Signal
+from pyVHDLModel.Subprogram import Procedure
+from pyVHDLModel.Symbol     import EntitySymbol, SignalSymbol, SimpleSubtypeSymbol, VariableSymbol
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _subtypeSymbol() -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName("natural"))
+
+
+def _port(*identifiers: str) -> PortSimpleSignalInterfaceItem:
+	return PortSimpleSignalInterfaceItem(identifiers, Mode.In, _subtypeSymbol())
+
+
+def _generic(*identifiers: str) -> GenericConstantInterfaceItem:
+	return GenericConstantInterfaceItem(identifiers, Mode.In, _subtypeSymbol())
+
+
+class EntityInterfaceItems(TestCase):
+	def test_PortIsIndexedIntoTheEntityNamespace(self) -> None:
+		port = _port("clk")
+		entity = Entity("ent", portItems=[port])
+		entity.IndexDeclaredItems()
+
+		self.assertIs(port, entity._namespace.Elements()["clk"])
+
+	def test_PortIsResolvable(self) -> None:
+		"""A port signal interface item *is* a `Signal`, so `FindObject` resolves it."""
+		port = _port("clk")
+		entity = Entity("ent", portItems=[port])
+		entity.IndexDeclaredItems()
+
+		found = entity._namespace.FindObject(SignalSymbol(SimpleName("clk")))
+
+		self.assertIs(port, found)
+		self.assertIsInstance(found, Signal)
+
+	def test_EveryIdentifierOfAMultiIdentifierPortIsIndexed(self) -> None:
+		"""``port (clk, rst : in bit)`` is one item with two identifiers."""
+		port = _port("clk", "rst")
+		entity = Entity("ent", portItems=[port])
+		entity.IndexDeclaredItems()
+
+		self.assertIs(port, entity._namespace.Elements()["clk"])
+		self.assertIs(port, entity._namespace.Elements()["rst"])
+
+	def test_GenericIsIndexed(self) -> None:
+		generic = _generic("width")
+		entity = Entity("ent", genericItems=[generic])
+		entity.IndexDeclaredItems()
+
+		self.assertIs(generic, entity._namespace.Elements()["width"])
+
+	def test_SingularGenericTypeIsIndexed(self) -> None:
+		"""``generic (type T)`` is singularly named, unlike every other interface item."""
+		genericType = GenericTypeInterfaceItem("T")
+		entity = Entity("ent", genericItems=[genericType])
+		entity.IndexDeclaredItems()
+
+		self.assertIs(genericType, entity._namespace.Elements()["t"])
+
+	def test_GenericsPortsAndDeclarationsShareOneNamespace(self) -> None:
+		generic = _generic("width")
+		port = _port("clk")
+		signal = Signal(("internal", ), _subtypeSymbol())
+		entity = Entity("ent", genericItems=[generic], portItems=[port], declaredItems=[signal])
+		entity.IndexDeclaredItems()
+
+		self.assertEqual({"width", "clk", "internal"}, set(entity._namespace.Elements().keys()))
+
+	def test_PortIsVisibleInTheArchitecture(self) -> None:
+		"""The whole point: a port name resolves from inside the architecture."""
+		port = _port("clk")
+		entity = Entity("ent", portItems=[port])
+		entity.IndexDeclaredItems()
+
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")))
+		architecture._namespace.ParentNamespace = entity._namespace
+		architecture.IndexDeclaredItems()
+
+		self.assertIs(port, architecture._namespace.FindObject(SignalSymbol(SimpleName("clk"))))
+
+	def test_PortIsVisibleInsideAProcess(self) -> None:
+		port = _port("clk")
+		entity = Entity("ent", portItems=[port])
+		entity.IndexDeclaredItems()
+
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")))
+		architecture._namespace.ParentNamespace = entity._namespace
+		architecture.IndexDeclaredItems()
+
+		process = ProcessStatement("proc")
+		process.Parent = architecture
+
+		self.assertIs(port, process.Namespace.FindObject(SignalSymbol(SimpleName("clk"))))
+
+
+class PackageGenerics(TestCase):
+	def test_GenericIsIndexed(self) -> None:
+		"""A generic package (VHDL-2008) has generics but no ports."""
+		generic = _generic("width")
+		package = Package("gp", genericItems=[generic])
+		package.IndexDeclaredItems()
+
+		self.assertIs(generic, package._namespace.Elements()["width"])
+
+
+class BlockPorts(TestCase):
+	def test_PortIsIndexed(self) -> None:
+		"""``ConcurrentBlockStatement`` hand-rolls its port list rather than using ``WithPortsMixin``."""
+		port = _port("bp")
+		block = ConcurrentBlockStatement("blk", portItems=[port])
+		block.IndexDeclaredItems()
+
+		self.assertIs(port, block._namespace.Elements()["bp"])
+
+
+class SubprogramInterfaceItems(TestCase):
+	"""
+	``Subprogram`` can't inherit ``WithGenericsMixin``/``WithParametersMixin``:
+	:mod:`pyVHDLModel.Interface` needs ``Procedure``/``Function`` as real base classes for its generic
+	subprogram interface items, so :mod:`pyVHDLModel.Subprogram` may never import it. Indexing therefore
+	reads the canonical field names, which covers hand-rolled and mixin-provided lists alike.
+	"""
+
+	def test_ParameterIsIndexed(self) -> None:
+		parameter = ParameterVariableInterfaceItem(("p", ), Mode.In, _subtypeSymbol())
+		procedure = Procedure("helper", parameterItems=[parameter])
+		procedure.IndexDeclaredItems()
+
+		self.assertIs(parameter, procedure.Namespace.Elements()["p"])
+		self.assertIs(parameter, procedure.Namespace.FindObject(VariableSymbol(SimpleName("p"))))
+
+	def test_EveryIdentifierOfAMultiIdentifierParameterIsIndexed(self) -> None:
+		parameter = ParameterVariableInterfaceItem(("p", "q"), Mode.In, _subtypeSymbol())
+		procedure = Procedure("helper", parameterItems=[parameter])
+		procedure.IndexDeclaredItems()
+
+		self.assertIs(parameter, procedure.Namespace.Elements()["p"])
+		self.assertIs(parameter, procedure.Namespace.Elements()["q"])
+
+	def test_GenericAndParameterShareTheNamespace(self) -> None:
+		generic = _generic("g")
+		parameter = ParameterVariableInterfaceItem(("p", ), Mode.In, _subtypeSymbol())
+		procedure = Procedure("helper", genericItems=[generic], parameterItems=[parameter])
+		procedure.IndexDeclaredItems()
+
+		self.assertEqual({"g", "p"}, set(procedure.Namespace.Elements().keys()))

--- a/tests/unit/Namespace/SequentialRegions.py
+++ b/tests/unit/Namespace/SequentialRegions.py
@@ -1,0 +1,235 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Namespaces of *sequential* declaration regions: process statements and subprogram bodies.
+
+VHDL's ``process_declarative_item`` and ``subprogram_declarative_item`` rules are identical, so both use
+``SequentialDeclarationRegionMixin``. Unlike a concurrent region it can declare a **variable**, which is
+the usual thing to hide an outer signal with.
+"""
+from unittest import TestCase
+
+from pyVHDLModel.Concurrent import ConcurrentBlockStatement, ProcessStatement
+from pyVHDLModel.DesignUnit import Architecture
+from pyVHDLModel.Name       import SimpleName
+from pyVHDLModel.Namespace  import ExtendedKeyError
+from pyVHDLModel.Object     import Constant, Signal, Variable
+from pyVHDLModel.Subprogram import Function, Procedure
+from pyVHDLModel.Symbol     import (
+	EntitySymbol,
+	PossibleReference,
+	SignalSymbol,
+	SimpleSubtypeSymbol,
+	Symbol,
+	VariableSymbol,
+)
+from pyVHDLModel.Type       import IntegerType
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _subtypeSymbol() -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName("natural"))
+
+
+def _variable(identifier: str) -> Variable:
+	return Variable((identifier, ), _subtypeSymbol())
+
+
+def _signal(identifier: str) -> Signal:
+	return Signal((identifier, ), _subtypeSymbol())
+
+
+def _architecture(*declaredItems) -> Architecture:
+	architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=list(declaredItems))
+	architecture.IndexDeclaredItems()
+
+	return architecture
+
+
+class ProcessNamespaces(TestCase):
+	def test_NamespaceIsNamedAfterTheLabel(self) -> None:
+		process = ProcessStatement("proc")
+
+		self.assertEqual("proc", process.Namespace.Name)
+
+	def test_UnlabelledProcessHasAnUnnamedNamespace(self) -> None:
+		process = ProcessStatement()
+
+		self.assertIsNone(process.Namespace.Name)
+
+	def test_IndexDeclaredItemsPopulatesVariables(self) -> None:
+		"""A variable is exactly what a concurrent region can *not* declare."""
+		variable = _variable("counter")
+		process = ProcessStatement("proc", declaredItems=[variable])
+		process.IndexDeclaredItems()
+
+		self.assertIs(variable, process.Variables["counter"])
+		self.assertIs(variable, process.Namespace.Elements()["counter"])
+
+	def test_IndexDeclaredItemsPopulatesEveryKind(self) -> None:
+		integerType = IntegerType("nibble", None)
+		constant = Constant(("width", ), _subtypeSymbol())
+		variable = _variable("index")
+		nestedProcedure = Procedure("helper")
+
+		process = ProcessStatement("proc", declaredItems=[integerType, constant, variable, nestedProcedure])
+		process.IndexDeclaredItems()
+
+		self.assertIs(integerType, process.Types["nibble"])
+		self.assertIs(constant, process.Constants["width"])
+		self.assertIs(variable, process.Variables["index"])
+		self.assertIs(nestedProcedure, process.Procedures["helper"][0])
+		self.assertEqual(4, len(process.Namespace.Elements()))
+
+	def test_NamespaceNestsInsideTheArchitecture(self) -> None:
+		architecture = _architecture()
+		process = ProcessStatement("proc")
+		process.Parent = architecture
+
+		self.assertIs(architecture._namespace, process.Namespace.ParentNamespace)
+
+	def test_ProcessVariableHidesArchitectureSignal(self) -> None:
+		architectureSignal = _signal("x")
+		architecture = _architecture(architectureSignal)
+
+		processVariable = _variable("x")
+		process = ProcessStatement("proc", declaredItems=[processVariable])
+		process.Parent = architecture
+		process.IndexDeclaredItems()
+
+		self.assertIs(processVariable, process.Namespace.FindObject(VariableSymbol(SimpleName("x"))))
+		# Hiding is one-directional.
+		self.assertIs(architectureSignal, architecture._namespace.FindObject(SignalSymbol(SimpleName("x"))))
+
+	def test_ProcessInheritsArchitectureDeclaration(self) -> None:
+		architectureSignal = _signal("clk")
+		architecture = _architecture(architectureSignal)
+
+		process = ProcessStatement("proc")
+		process.Parent = architecture
+
+		self.assertIs(architectureSignal, process.Namespace.FindObject(SignalSymbol(SimpleName("clk"))))
+
+	def test_ProcessInsideABlockNestsInsideTheBlock(self) -> None:
+		architecture = _architecture()
+		block = ConcurrentBlockStatement("blk")
+		block.Parent = architecture
+		block.IndexDeclaredItems()
+
+		process = ProcessStatement("proc")
+		process.Parent = block
+
+		self.assertIs(block._namespace, process.Namespace.ParentNamespace)
+
+
+class SubprogramNamespaces(TestCase):
+	def test_NamespaceIsNamedAfterTheIdentifier(self) -> None:
+		procedure = Procedure("DoIt")
+
+		self.assertEqual("doit", procedure.Namespace.Name)
+
+	def test_IndexDeclaredItemsPopulatesVariables(self) -> None:
+		variable = _variable("temp")
+		function = Function("compute", _subtypeSymbol(), declaredItems=[variable])
+		function.IndexDeclaredItems()
+
+		self.assertIs(variable, function.Variables["temp"])
+		self.assertIs(variable, function.Namespace.Elements()["temp"])
+
+	def test_NamespaceNestsInsideTheArchitecture(self) -> None:
+		architecture = _architecture()
+		procedure = Procedure("helper")
+		procedure.Parent = architecture
+
+		self.assertIs(architecture._namespace, procedure.Namespace.ParentNamespace)
+
+	def test_SubprogramVariableHidesArchitectureSignal(self) -> None:
+		architectureSignal = _signal("x")
+		architecture = _architecture(architectureSignal)
+
+		subprogramVariable = _variable("x")
+		procedure = Procedure("helper", declaredItems=[subprogramVariable])
+		procedure.Parent = architecture
+		procedure.IndexDeclaredItems()
+
+		self.assertIs(subprogramVariable, procedure.Namespace.FindObject(VariableSymbol(SimpleName("x"))))
+		self.assertIs(architectureSignal, architecture._namespace.FindObject(SignalSymbol(SimpleName("x"))))
+
+	def test_SubprogramInheritsArchitectureDeclaration(self) -> None:
+		constant = Constant(("width", ), _subtypeSymbol())
+		architecture = _architecture(constant)
+
+		procedure = Procedure("helper")
+		procedure.Parent = architecture
+
+		symbol = Symbol(SimpleName("width"), PossibleReference.Constant)
+
+		self.assertIs(constant, procedure.Namespace.FindObject(symbol))
+
+	def test_NestedSubprogramNestsInsideTheOuterSubprogram(self) -> None:
+		"""A subprogram is itself a sequential declaration region, so subprograms nest."""
+		outerVariable = _variable("outer")
+		inner = Procedure("inner")
+		outer = Procedure("outer", declaredItems=[outerVariable, inner])
+		outer.IndexDeclaredItems()
+
+		self.assertIs(outer._namespace, inner.Namespace.ParentNamespace)
+		self.assertIs(outerVariable, inner.Namespace.FindObject(VariableSymbol(SimpleName("outer"))))
+
+	def test_NestedSubprogramVariableHidesTheOuterOne(self) -> None:
+		outerVariable = _variable("x")
+		innerVariable = _variable("x")
+		inner = Procedure("inner", declaredItems=[innerVariable])
+		outer = Procedure("outer", declaredItems=[outerVariable, inner])
+		outer.IndexDeclaredItems()
+		inner.IndexDeclaredItems()
+
+		self.assertIs(innerVariable, inner.Namespace.FindObject(VariableSymbol(SimpleName("x"))))
+		self.assertIs(outerVariable, outer.Namespace.FindObject(VariableSymbol(SimpleName("x"))))
+
+	def test_UnresolvedNameReportsTheWholeChain(self) -> None:
+		architecture = _architecture()
+		procedure = Procedure("helper")
+		procedure.Parent = architecture
+		process = ProcessStatement("proc")
+		process.Parent = architecture
+
+		with self.assertRaises(ExtendedKeyError) as context:
+			procedure.Namespace.FindObject(VariableSymbol(SimpleName("missing")))
+
+		# The subprogram's namespace and the architecture's are both reported as searched.
+		self.assertEqual(2, len(context.exception.searchedNamespaces))
+		self.assertIn("helper, rtl", str(context.exception))


### PR DESCRIPTION
Closes the first of the two gaps found in #147's review: processes and subprograms are declarative regions, but neither owned a `Namespace`. A variable declared in a process or a nested subprogram couldn't be resolved at all, and couldn't hide a same-named signal from the scope around it.

## One mixin for both, per the grammar

I checked the [EBNF](https://www.sigasi.com/tech/vhdl2017.ebnf/) rather than assuming: **`process_declarative_item` and `subprogram_declarative_item` are byte-identical**, so one mixin genuinely serves both.

Against `block_declarative_item` (the concurrent region), a sequential region **gains** `variable_declaration` and **loses** `signal_declaration`, `shared_variable_declaration`, `component_declaration`, `mode_view_declaration` and all the specifications. So `SequentialDeclarationRegionMixin` indexes types, subtypes, constants, **variables**, files, functions and procedures — no signals, shared variables or components.

That variable support is the point: a variable is the usual thing you'd hide an outer signal with, and the concurrent mixin explicitly can't index one (it raises a `NotImplementedWarning` there).

## What changed

- **`SequentialDeclarationRegionMixin`** replaces `SequentialDeclarationsMixin`, which held only `_declaredItems` and no namespace. Moved into `Regions.py` so both declaration regions sit side by side, and it now owns `_namespace` itself rather than assuming the host provides one.
- **`Subprogram`** uses it too, resolving its long-standing `# TODO: use mixin class`.
- Both hosts connect their namespace to the enclosing region in the **`Parent` setter**, matching how blocks and generates already do it. `Subprogram` guards with an `isinstance` check, because a subprogram can also be a protected type's method — and `ProtectedType`/`ProtectedTypeBody` are *not* declaration regions, so unguarded chaining would crash there.

## The include-order problem, and how it's resolved

`Subprogram` now imports `Regions` for its base class, but `Regions` already imported `Subprogram` for `Function`/`Procedure` — a genuine cycle, and a base class can't be a lazy import.

Broken by making the `Regions → Subprogram` edge non-module-level: `Function`/`Procedure` are **quoted** in annotations and imported lazily inside `IndexDeclaredItems`. Both halves follow existing in-repo precedent — `Type.py` already writes `List[Union['Procedure', 'Function']]`, and `IndexDeclaredItems` already had a lazy `from pyVHDLModel.DesignUnit import Component`.

Quoted forward references are never evaluated eagerly, so this is safe on 3.11–3.13 too, where class-level annotations *are* evaluated at class-creation time. Confirmed with the forced-annotation-evaluation sweep (clean), which is what caught the analogous problem in #146.

## Testing

New `tests/unit/Namespace/SequentialRegions.py` — 16 tests covering namespace naming (label / normalized identifier / `None` for an unlabelled process), indexing of every declarable kind, nesting into an architecture and into a block, a **process variable hiding an architecture signal**, a **subprogram variable hiding an architecture signal**, **subprograms nesting inside subprograms**, and the searched-namespace chain on a failed lookup.

```
415 passed, 69 subtests   (399 before)
```

Verified from a fresh clone. Also **cross-checked against pyGHDL.dom on `paebbels/dom-updates`: 185 passed, 17 xfailed, 0 failed** — the constructor and `Parent`-setter changes don't regress the translation layer. `SequentialDeclarationsMixin` had no users outside this repo (checked pyGHDL too), so removing it breaks nothing there.

> [!NOTE]
> The second gap from #147's review — entity ports/generics never being indexed into the entity's namespace — is untouched here and still open. It's independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)