### PR TITLE
Document every class, with VHDL examples

### DIFF
--- a/pyVHDLModel/Association.py
+++ b/pyVHDLModel/Association.py
@@ -61,8 +61,8 @@ class AssociationItem(ModelEntity):
 	.. seealso::
 
 	   * :class:`Generic association item <pyVHDLModel.Association.GenericAssociationItem>`
-	   * :class:`Parameter association item <pyVHDLModel.Association.ParameterAssociationItem>`
 	   * :class:`Port association item <pyVHDLModel.Association.PortAssociationItem>`
+	   * :class:`Parameter association item <pyVHDLModel.Association.ParameterAssociationItem>`
 	"""
 
 	_formal: Nullable[Symbol]

--- a/pyVHDLModel/Association.py
+++ b/pyVHDLModel/Association.py
@@ -57,6 +57,12 @@ ExpressionUnion = Union[
 class AssociationItem(ModelEntity):
 	"""
 	A base-class for all association items.
+
+	.. seealso::
+
+	   * :class:`Generic association item <pyVHDLModel.Association.GenericAssociationItem>`
+	   * :class:`Parameter association item <pyVHDLModel.Association.ParameterAssociationItem>`
+	   * :class:`Port association item <pyVHDLModel.Association.PortAssociationItem>`
 	"""
 
 	_formal: Nullable[Symbol]

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -171,16 +171,16 @@ class NamedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Alias <pyVHDLModel.Declaration.Alias>`
 	   * :class:`Attribute <pyVHDLModel.Declaration.Attribute>`
-	   * :class:`Base type <pyVHDLModel.Type.BaseType>`
-	   * :class:`Component <pyVHDLModel.DesignUnit.Component>`
-	   * :class:`Default clock <pyVHDLModel.PSLModel.DefaultClock>`
+	   * :class:`Alias <pyVHDLModel.Declaration.Alias>`
 	   * :class:`Design unit <pyVHDLModel.DesignUnit.DesignUnit>`
-	   * :class:`Interface package <pyVHDLModel.Interface.InterfacePackage>`
-	   * :class:`Library <pyVHDLModel.Library>`
+	   * :class:`Component <pyVHDLModel.DesignUnit.Component>`
 	   * :class:`Mode view declaration <pyVHDLModel.Interface.ModeViewDeclaration>`
+	   * :class:`Interface package <pyVHDLModel.Interface.InterfacePackage>`
+	   * :class:`Default clock <pyVHDLModel.PSLModel.DefaultClock>`
 	   * :class:`Subprogram <pyVHDLModel.Subprogram.Subprogram>`
+	   * :class:`Base type <pyVHDLModel.Type.BaseType>`
+	   * :class:`Library <pyVHDLModel.Library>`
 	"""
 
 	_identifier:           str  #: The identifier of a model entity.
@@ -371,9 +371,9 @@ class LabeledEntityMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
+	   * :class:`Statement <pyVHDLModel.Common.Statement>`
 	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
 	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
-	   * :class:`Statement <pyVHDLModel.Common.Statement>`
 	"""
 	_label:           Nullable[str]  #: The label of a model entity.
 	_normalizedLabel: Nullable[str]  #: The normalized (lower case) label of a model entity.
@@ -442,13 +442,13 @@ class ConditionalMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Assert statement mixin <pyVHDLModel.Base.AssertStatementMixin>`
 	   * :class:`Conditional branch mixin <pyVHDLModel.Base.ConditionalBranchMixin>`
-	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
+	   * :class:`Assert statement mixin <pyVHDLModel.Base.AssertStatementMixin>`
 	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
+	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
+	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
 	   * :class:`Loop control statement <pyVHDLModel.Sequential.LoopControlStatement>`
 	   * :class:`Wait statement <pyVHDLModel.Sequential.WaitStatement>`
-	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
 	"""
 
 	_condition: ExpressionUnion
@@ -497,8 +497,8 @@ class ConditionalBranchMixin(BranchMixin, ConditionalMixin, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Elsif branch mixin <pyVHDLModel.Base.ElsifBranchMixin>`
 	   * :class:`If branch mixin <pyVHDLModel.Base.IfBranchMixin>`
+	   * :class:`Elsif branch mixin <pyVHDLModel.Base.ElsifBranchMixin>`
 	"""
 	def __init__(self, condition: ExpressionUnion) -> None:
 		super().__init__()
@@ -512,8 +512,8 @@ class IfBranchMixin(ConditionalBranchMixin, mixin=True):
 
 	.. seealso::
 
-	   * :class:`If branch <pyVHDLModel.Sequential.IfBranch>`
 	   * :class:`If generate branch <pyVHDLModel.Concurrent.IfGenerateBranch>`
+	   * :class:`If branch <pyVHDLModel.Sequential.IfBranch>`
 	"""
 
 
@@ -524,8 +524,8 @@ class ElsifBranchMixin(ConditionalBranchMixin, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Elsif branch <pyVHDLModel.Sequential.ElsifBranch>`
 	   * :class:`Elsif generate branch <pyVHDLModel.Concurrent.ElsifGenerateBranch>`
+	   * :class:`Elsif branch <pyVHDLModel.Sequential.ElsifBranch>`
 	"""
 
 
@@ -536,8 +536,8 @@ class ElseBranchMixin(BranchMixin, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Else branch <pyVHDLModel.Sequential.ElseBranch>`
 	   * :class:`Else generate branch <pyVHDLModel.Concurrent.ElseGenerateBranch>`
+	   * :class:`Else branch <pyVHDLModel.Sequential.ElseBranch>`
 	"""
 
 
@@ -631,11 +631,11 @@ class BaseCase(ModelEntity):
 
 	.. seealso::
 
-	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
-	   * :class:`Others selected expression <pyVHDLModel.Common.OthersSelectedExpression>`
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
 	   * :class:`Others selected waveform <pyVHDLModel.Common.OthersSelectedWaveform>`
 	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
-	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
+	   * :class:`Others selected expression <pyVHDLModel.Common.OthersSelectedExpression>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
 	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
 	"""
 
@@ -647,9 +647,9 @@ class ChoicesMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
-	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
 	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
+	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
 	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
 	"""
 
@@ -682,8 +682,8 @@ class Range(ModelEntity):
 
 	.. seealso::
 
-	   * :class:`Range from name <pyVHDLModel.Base.RangeFromName>`
 	   * :class:`Simple range <pyVHDLModel.Base.SimpleRange>`
+	   * :class:`Range from name <pyVHDLModel.Base.RangeFromName>`
 	"""
 
 

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -168,6 +168,19 @@ class NamedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 	Protected variables :attr:`_identifier` and :attr:`_normalizedIdentifier` are available to derived classes as well as
 	two readonly properties :attr:`Identifier` and :attr:`NormalizedIdentifier` for public access.
+
+	.. seealso::
+
+	   * :class:`Alias <pyVHDLModel.Declaration.Alias>`
+	   * :class:`Attribute <pyVHDLModel.Declaration.Attribute>`
+	   * :class:`Base type <pyVHDLModel.Type.BaseType>`
+	   * :class:`Component <pyVHDLModel.DesignUnit.Component>`
+	   * :class:`Default clock <pyVHDLModel.PSLModel.DefaultClock>`
+	   * :class:`Design unit <pyVHDLModel.DesignUnit.DesignUnit>`
+	   * :class:`Interface package <pyVHDLModel.Interface.InterfacePackage>`
+	   * :class:`Library <pyVHDLModel.Library>`
+	   * :class:`Mode view declaration <pyVHDLModel.Interface.ModeViewDeclaration>`
+	   * :class:`Subprogram <pyVHDLModel.Subprogram.Subprogram>`
 	"""
 
 	_identifier:           str  #: The identifier of a model entity.
@@ -208,6 +221,10 @@ class OptionallyNamedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 	Protected variables :attr:`_identifier` and :attr:`_normalizedIdentifier` are available to derived classes as well as
 	two readonly properties :attr:`Identifier` and :attr:`NormalizedIdentifier` for public access.
+
+	.. seealso::
+
+	   * :class:`Interface group <pyVHDLModel.Interface.InterfaceGroup>`
 	"""
 
 	_identifier:           Nullable[str]  #: The identifier of a model entity.
@@ -249,6 +266,12 @@ class MultipleNamedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 	Protected variables :attr:`_identifiers` and :attr:`_normalizedIdentifiers` are available to derived classes as well
 	as two readonly properties :attr:`Identifiers` and :attr:`NormalizedIdentifiers` for public access.
+
+	.. seealso::
+
+	   * :class:`Mode view element <pyVHDLModel.Interface.ModeViewElement>`
+	   * :class:`Obj <pyVHDLModel.Object.Obj>`
+	   * :class:`Record type element <pyVHDLModel.Type.RecordTypeElement>`
 	"""
 
 	_identifiers:           Tuple[str]  #: A list of identifiers.
@@ -345,6 +368,12 @@ class LabeledEntityMixin(metaclass=ExtendedType, mixin=True):
 
 	protected variables :attr:`_label` and :attr:`_normalizedLabel` are available to derived classes as well as two
 	readonly properties :attr:`Label` and :attr:`NormalizedLabel` for public access.
+
+	.. seealso::
+
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`Statement <pyVHDLModel.Common.Statement>`
 	"""
 	_label:           Nullable[str]  #: The label of a model entity.
 	_normalizedLabel: Nullable[str]  #: The normalized (lower case) label of a model entity.
@@ -408,7 +437,19 @@ class DocumentedEntityMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class ConditionalMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``ConditionalMixin`` is a mixin-class for all statements with a condition."""
+	"""
+	A ``ConditionalMixin`` is a mixin-class for all statements with a condition.
+
+	.. seealso::
+
+	   * :class:`Assert statement mixin <pyVHDLModel.Base.AssertStatementMixin>`
+	   * :class:`Conditional branch mixin <pyVHDLModel.Base.ConditionalBranchMixin>`
+	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
+	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
+	   * :class:`Loop control statement <pyVHDLModel.Sequential.LoopControlStatement>`
+	   * :class:`Wait statement <pyVHDLModel.Sequential.WaitStatement>`
+	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
+	"""
 
 	_condition: ExpressionUnion
 
@@ -436,7 +477,14 @@ class ConditionalMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class BranchMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``BranchMixin`` is a mixin-class for all statements with branches."""
+	"""
+	A ``BranchMixin`` is a mixin-class for all statements with branches.
+
+	.. seealso::
+
+	   * :class:`Conditional branch mixin <pyVHDLModel.Base.ConditionalBranchMixin>`
+	   * :class:`Else branch mixin <pyVHDLModel.Base.ElseBranchMixin>`
+	"""
 
 	def __init__(self) -> None:
 		pass
@@ -444,7 +492,14 @@ class BranchMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class ConditionalBranchMixin(BranchMixin, ConditionalMixin, mixin=True):
-	"""A ``BaseBranch`` is a mixin-class for all branch statements with a condition."""
+	"""
+	A ``BaseBranch`` is a mixin-class for all branch statements with a condition.
+
+	.. seealso::
+
+	   * :class:`Elsif branch mixin <pyVHDLModel.Base.ElsifBranchMixin>`
+	   * :class:`If branch mixin <pyVHDLModel.Base.IfBranchMixin>`
+	"""
 	def __init__(self, condition: ExpressionUnion) -> None:
 		super().__init__()
 		ConditionalMixin.__init__(self, condition)
@@ -452,22 +507,50 @@ class ConditionalBranchMixin(BranchMixin, ConditionalMixin, mixin=True):
 
 @export
 class IfBranchMixin(ConditionalBranchMixin, mixin=True):
-	"""A ``BaseIfBranch`` is a mixin-class for all if-branches."""
+	"""
+	A ``BaseIfBranch`` is a mixin-class for all if-branches.
+
+	.. seealso::
+
+	   * :class:`If branch <pyVHDLModel.Sequential.IfBranch>`
+	   * :class:`If generate branch <pyVHDLModel.Concurrent.IfGenerateBranch>`
+	"""
 
 
 @export
 class ElsifBranchMixin(ConditionalBranchMixin, mixin=True):
-	"""A ``BaseElsifBranch`` is a mixin-class for all elsif-branches."""
+	"""
+	A ``BaseElsifBranch`` is a mixin-class for all elsif-branches.
+
+	.. seealso::
+
+	   * :class:`Elsif branch <pyVHDLModel.Sequential.ElsifBranch>`
+	   * :class:`Elsif generate branch <pyVHDLModel.Concurrent.ElsifGenerateBranch>`
+	"""
 
 
 @export
 class ElseBranchMixin(BranchMixin, mixin=True):
-	"""A ``BaseElseBranch`` is a mixin-class for all else-branches."""
+	"""
+	A ``BaseElseBranch`` is a mixin-class for all else-branches.
+
+	.. seealso::
+
+	   * :class:`Else branch <pyVHDLModel.Sequential.ElseBranch>`
+	   * :class:`Else generate branch <pyVHDLModel.Concurrent.ElseGenerateBranch>`
+	"""
 
 
 @export
 class ReportStatementMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``MixinReportStatement`` is a mixin-class for all report and assert statements."""
+	"""
+	A ``MixinReportStatement`` is a mixin-class for all report and assert statements.
+
+	.. seealso::
+
+	   * :class:`Assert statement mixin <pyVHDLModel.Base.AssertStatementMixin>`
+	   * :class:`Sequential report statement <pyVHDLModel.Sequential.SequentialReportStatement>`
+	"""
 
 	_message:  Nullable[ExpressionUnion]
 	_severity: Nullable[ExpressionUnion]
@@ -502,7 +585,14 @@ class ReportStatementMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class AssertStatementMixin(ReportStatementMixin, ConditionalMixin, mixin=True):
-	"""A ``MixinAssertStatement`` is a mixin-class for all assert statements."""
+	"""
+	A ``MixinAssertStatement`` is a mixin-class for all assert statements.
+
+	.. seealso::
+
+	   * :class:`Concurrent assert statement <pyVHDLModel.Concurrent.ConcurrentAssertStatement>`
+	   * :class:`Sequential assert statement <pyVHDLModel.Sequential.SequentialAssertStatement>`
+	"""
 
 	def __init__(self, condition: ExpressionUnion, message: Nullable[ExpressionUnion] = None, severity: Nullable[ExpressionUnion] = None) -> None:
 		super().__init__(message, severity)
@@ -510,7 +600,13 @@ class AssertStatementMixin(ReportStatementMixin, ConditionalMixin, mixin=True):
 
 
 class BlockStatementMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``BlockStatement`` is a mixin-class for all block statements."""
+	"""
+	A ``BlockStatement`` is a mixin-class for all block statements.
+
+	.. seealso::
+
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	"""
 
 	def __init__(self) -> None:
 		pass
@@ -518,19 +614,44 @@ class BlockStatementMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class BaseChoice(ModelEntity):
-	"""A ``Choice`` is a base-class for all choices."""
+	"""
+	A ``Choice`` is a base-class for all choices.
+
+	.. seealso::
+
+	   * :class:`Concurrent choice <pyVHDLModel.Concurrent.ConcurrentChoice>`
+	   * :class:`Sequential choice <pyVHDLModel.Sequential.SequentialChoice>`
+	"""
 
 
 @export
 class BaseCase(ModelEntity):
 	"""
 	A ``Case`` is a base-class for all cases.
+
+	.. seealso::
+
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`Others selected expression <pyVHDLModel.Common.OthersSelectedExpression>`
+	   * :class:`Others selected waveform <pyVHDLModel.Common.OthersSelectedWaveform>`
+	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
+	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
 	"""
 
 
 @export
 class ChoicesMixin(metaclass=ExtendedType, mixin=True):
-	"""A mixin-class for all statements/entities holding a list of :class:`BaseChoice`."""
+	"""
+	A mixin-class for all statements/entities holding a list of :class:`BaseChoice`.
+
+	.. seealso::
+
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
+	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
+	"""
 
 	_choices: List[BaseChoice]
 
@@ -558,6 +679,11 @@ class Range(ModelEntity):
 
 	VHDL's ``range`` rule offers a range denoted by a name (:class:`RangeFromName`) as well as a range
 	given by explicit bounds (:class:`SimpleRange`).
+
+	.. seealso::
+
+	   * :class:`Range from name <pyVHDLModel.Base.RangeFromName>`
+	   * :class:`Simple range <pyVHDLModel.Base.SimpleRange>`
 	"""
 
 
@@ -683,6 +809,12 @@ class WaveformElement(ModelEntity):
 	      s <= '1' after 5 ns;
 	      --   ^^^               <- Expression
 	      --             ^^^^    <- After
+
+	.. seealso::
+
+	   * :class:`Waveform of a simple assignment <pyVHDLModel.Common.WaveformMixin>`
+	   * :class:`Waveform of one conditional branch <pyVHDLModel.Common.ConditionalWaveform>`
+	   * :class:`Waveform of one selected alternative <pyVHDLModel.Common.SelectedWaveform>`
 	"""
 	_expression: ExpressionUnion
 	_after: ExpressionUnion

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -671,6 +671,19 @@ class RangeFromName(Range):
 
 @export
 class WaveformElement(ModelEntity):
+	"""
+	Represents one element of a waveform in a signal assignment.
+
+	A waveform element assigns a value (:data:`Expression`) after an optional delay (:data:`After`).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= '1' after 5 ns;
+	      --   ^^^               <- Expression
+	      --             ^^^^    <- After
+	"""
 	_expression: ExpressionUnion
 	_after: ExpressionUnion
 

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -272,7 +272,7 @@ class ConditionalWaveform(ModelEntity, WaveformMixin, ConditionalMixin):
 @export
 class ConditionalExpression(ModelEntity, ExpressionMixin, ConditionalMixin):
 	"""
-	One branch of a conditional (variable) assignment (VHDL-2008).
+	One branch of a conditional (variable) assignment.
 
 	.. admonition:: Example
 

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -61,6 +61,19 @@ class AllowBlackboxMixin(metaclass=ExtendedType, mixin=True):
 	A mixin-class for language entities that may permit blackboxes.
 
 	The setting is inherited from the parent when not set locally (:data:`AllowBlackbox`).
+
+	.. seealso::
+
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Component <pyVHDLModel.DesignUnit.Component>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`Design <pyVHDLModel.Design>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Generate branch <pyVHDLModel.Concurrent.GenerateBranch>`
+	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
+	   * :class:`Library <pyVHDLModel.Library>`
+	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
 	"""
 	_allowBlackbox: Nullable[bool]  #: Allow blackboxes for components in language entity.
 
@@ -100,6 +113,11 @@ class AllowBlackboxMixin(metaclass=ExtendedType, mixin=True):
 class Statement(ModelEntity, LabeledEntityMixin):
 	"""
 	A ``Statement`` is a base-class for all statements.
+
+	.. seealso::
+
+	   * :class:`Concurrent statement <pyVHDLModel.Concurrent.ConcurrentStatement>`
+	   * :class:`Sequential statement <pyVHDLModel.Sequential.SequentialStatement>`
 	"""
 	def __init__(self, label: Nullable[str] = None, parent=None) -> None:
 		super().__init__(parent)
@@ -113,6 +131,11 @@ class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
 
 	The called procedure is available as :data:`Procedure`, its actual parameters as
 	:data:`ParameterAssociationItems`.
+
+	.. seealso::
+
+	   * :class:`Concurrent procedure call <pyVHDLModel.Concurrent.ConcurrentProcedureCall>`
+	   * :class:`Sequential procedure call <pyVHDLModel.Sequential.SequentialProcedureCall>`
 	"""
 	_procedure:                 Symbol  # TODO: implement a ProcedureSymbol
 	_parameterAssociationItems: List[ParameterAssociationItem]
@@ -149,7 +172,16 @@ class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class AssignmentMixin(metaclass=ExtendedType, mixin=True):
-	"""A mixin-class for all assignment statements."""
+	"""
+	A mixin-class for all assignment statements.
+
+	.. seealso::
+
+	   * :class:`~pyVHDLModel.Sequential.SequentialConditionalVariableAssignment`
+	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
+	   * :class:`Signal assignment mixin <pyVHDLModel.Common.SignalAssignmentMixin>`
+	   * :class:`Variable assignment mixin <pyVHDLModel.Common.VariableAssignmentMixin>`
+	"""
 
 	_target: Symbol
 
@@ -169,7 +201,18 @@ class AssignmentMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class SignalAssignmentMixin(AssignmentMixin, mixin=True):
-	"""A mixin-class for all signal assignment statements."""
+	"""
+	A mixin-class for all signal assignment statements.
+
+	.. seealso::
+
+	   * :class:`Concurrent signal assignment <pyVHDLModel.Concurrent.ConcurrentSignalAssignment>`
+	   * :class:`Sequential conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`
+	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
+	   * :class:`Sequential signal assignment <pyVHDLModel.Sequential.SequentialSignalAssignment>`
+	   * :class:`Signal force assignment <pyVHDLModel.Sequential.SignalForceAssignment>`
+	   * :class:`Signal release assignment <pyVHDLModel.Sequential.SignalReleaseAssignment>`
+	"""
 
 	@readonly
 	def Target(self) -> SignalSymbol:
@@ -183,7 +226,13 @@ class SignalAssignmentMixin(AssignmentMixin, mixin=True):
 
 @export
 class VariableAssignmentMixin(AssignmentMixin, mixin=True):
-	"""A mixin-class for all variable assignment statements."""
+	"""
+	A mixin-class for all variable assignment statements.
+
+	.. seealso::
+
+	   * :class:`Sequential variable assignment <pyVHDLModel.Sequential.SequentialVariableAssignment>`
+	"""
 
 	# FIXME: move to sequential?
 	_expression: ExpressionUnion
@@ -215,7 +264,18 @@ class VariableAssignmentMixin(AssignmentMixin, mixin=True):
 
 @export
 class WaveformMixin(metaclass=ExtendedType, mixin=True):
-	"""A mixin-class for all statements/entities holding a waveform (a list of :class:`WaveformElement`)."""
+	"""
+	A mixin-class for all statements/entities holding a waveform (a list of :class:`WaveformElement`).
+
+	.. seealso::
+
+	   * :class:`Concurrent simple signal assignment <pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment>`
+	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
+	   * :class:`Others selected waveform <pyVHDLModel.Common.OthersSelectedWaveform>`
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
+	   * :class:`Sequential simple signal assignment <pyVHDLModel.Sequential.SequentialSimpleSignalAssignment>`
+	   * :class:`Waveform element <pyVHDLModel.Base.WaveformElement>`
+	"""
 
 	_waveform: List[WaveformElement]
 
@@ -237,7 +297,19 @@ class WaveformMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class ExpressionMixin(metaclass=ExtendedType, mixin=True):
-	"""A mixin-class for all statements/entities holding a single expression."""
+	"""
+	A mixin-class for all statements/entities holding a single expression.
+
+	.. seealso::
+
+	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
+	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
+	   * :class:`Others selected expression <pyVHDLModel.Common.OthersSelectedExpression>`
+	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
+	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
+	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
+	   * :class:`Signal force assignment <pyVHDLModel.Sequential.SignalForceAssignment>`
+	"""
 
 	_expression: ExpressionUnion
 
@@ -270,6 +342,11 @@ class ConditionalWaveform(ModelEntity, WaveformMixin, ConditionalMixin):
 	      s <= '1' when cond else '0';
 	      --   ^^^^^^^^^^^^^             <- this branch: Waveform=['1'], Condition=cond
 	      --                      ^^^    <- final branch (no ``when``): Waveform=['0'], Condition=None
+
+	.. seealso::
+
+	   * :class:`Waveform element <pyVHDLModel.Base.WaveformElement>`
+	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
 	"""
 
 	def __init__(
@@ -298,6 +375,10 @@ class ConditionalExpression(ModelEntity, ExpressionMixin, ConditionalMixin):
 	      v := '1' when cond else '0';
 	      --   ^^^^^^^^^^^^^             <- this branch: Expression='1', Condition=cond
 	      --                      ^^^    <- final branch (no ``when``): Expression='0', Condition=None
+
+	.. seealso::
+
+	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
 	"""
 
 	def __init__(
@@ -316,6 +397,11 @@ class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for all statements holding a list of :class:`ConditionalWaveform` (both the
 	concurrent and sequential forms of a conditional signal assignment).
+
+	.. seealso::
+
+	   * :class:`Concurrent conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
+	   * :class:`Sequential conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`
 	"""
 
 	_conditionalWaveforms: List[ConditionalWaveform]
@@ -350,6 +436,11 @@ class SelectedWaveform(BaseCase, WaveformMixin, ChoicesMixin):
 
 	      with sel select s <= '1' when 0, '0' when others;
 	      --                   ^^^^^^^^^^                     <- this alternative: Choices=[0], Waveform=['1']
+
+	.. seealso::
+
+	   * :class:`Waveform element <pyVHDLModel.Base.WaveformElement>`
+	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
 	"""
 
 	def __init__(
@@ -397,6 +488,10 @@ class SelectedExpression(BaseCase, ExpressionMixin, ChoicesMixin):
 
 	      with sel select v := '1' when 0, '0' when others;
 	      --                   ^^^^^^^^^^                     <- this alternative: Choices=[0], Expression='1'
+
+	.. seealso::
+
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
 	"""
 
 	def __init__(
@@ -436,6 +531,11 @@ class SelectedWaveformsMixin(metaclass=ExtendedType, mixin=True):
 	A mixin-class for all statements holding a list of :class:`SelectedWaveform`/
 	:class:`OthersSelectedWaveform` (both the concurrent and sequential forms of a selected signal
 	assignment).
+
+	.. seealso::
+
+	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
+	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
 	"""
 
 	_selectedWaveforms: List[Union[SelectedWaveform, OthersSelectedWaveform]]
@@ -461,6 +561,10 @@ class SelectedExpressionsMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for all statements holding a list of :class:`SelectedExpression`/
 	:class:`OthersSelectedExpression`.
+
+	.. seealso::
+
+	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
 	"""
 
 	_selectedExpressions: List[Union[SelectedExpression, OthersSelectedExpression]]

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -64,16 +64,16 @@ class AllowBlackboxMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
-	   * :class:`Component <pyVHDLModel.DesignUnit.Component>`
 	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
-	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
-	   * :class:`Design <pyVHDLModel.Design>`
-	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
 	   * :class:`Generate branch <pyVHDLModel.Concurrent.GenerateBranch>`
 	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
-	   * :class:`Library <pyVHDLModel.Library>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
 	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Component <pyVHDLModel.DesignUnit.Component>`
+	   * :class:`Design <pyVHDLModel.Design>`
+	   * :class:`Library <pyVHDLModel.Library>`
 	"""
 	_allowBlackbox: Nullable[bool]  #: Allow blackboxes for components in language entity.
 
@@ -177,10 +177,10 @@ class AssignmentMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`~pyVHDLModel.Sequential.SequentialConditionalVariableAssignment`
-	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
 	   * :class:`Signal assignment mixin <pyVHDLModel.Common.SignalAssignmentMixin>`
 	   * :class:`Variable assignment mixin <pyVHDLModel.Common.VariableAssignmentMixin>`
+	   * :class:`Conditional variable assignment <pyVHDLModel.Sequential.SequentialConditionalVariableAssignment>`
+	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
 	"""
 
 	_target: Symbol
@@ -207,9 +207,9 @@ class SignalAssignmentMixin(AssignmentMixin, mixin=True):
 	.. seealso::
 
 	   * :class:`Concurrent signal assignment <pyVHDLModel.Concurrent.ConcurrentSignalAssignment>`
-	   * :class:`Sequential conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`
-	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
 	   * :class:`Sequential signal assignment <pyVHDLModel.Sequential.SequentialSignalAssignment>`
+	   * :class:`Conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`
+	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
 	   * :class:`Signal force assignment <pyVHDLModel.Sequential.SignalForceAssignment>`
 	   * :class:`Signal release assignment <pyVHDLModel.Sequential.SignalReleaseAssignment>`
 	"""
@@ -269,10 +269,10 @@ class WaveformMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Concurrent simple signal assignment <pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment>`
 	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
-	   * :class:`Others selected waveform <pyVHDLModel.Common.OthersSelectedWaveform>`
 	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
+	   * :class:`Others selected waveform <pyVHDLModel.Common.OthersSelectedWaveform>`
+	   * :class:`Concurrent simple signal assignment <pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment>`
 	   * :class:`Sequential simple signal assignment <pyVHDLModel.Sequential.SequentialSimpleSignalAssignment>`
 	   * :class:`Waveform element <pyVHDLModel.Base.WaveformElement>`
 	"""
@@ -302,12 +302,12 @@ class ExpressionMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
 	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
-	   * :class:`Others selected expression <pyVHDLModel.Common.OthersSelectedExpression>`
 	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
-	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
+	   * :class:`Others selected expression <pyVHDLModel.Common.OthersSelectedExpression>`
+	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
 	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
+	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
 	   * :class:`Signal force assignment <pyVHDLModel.Sequential.SignalForceAssignment>`
 	"""
 
@@ -400,9 +400,8 @@ class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Concurrent conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
-	   * :class:`Sequential conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`
-	"""
+	   * :class:`Conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
+	   * :class:`Conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`	"""
 
 	_conditionalWaveforms: List[ConditionalWaveform]
 
@@ -434,8 +433,8 @@ class SelectedWaveform(BaseCase, WaveformMixin, ChoicesMixin):
 
 	   .. code-block:: VHDL
 
-	      with sel select s <= '1' when 0, '0' when others;
-	      --                   ^^^^^^^^^^                     <- this alternative: Choices=[0], Waveform=['1']
+	      with sel select s <= '1' when '0', '0' when others;
+	      --                   ^^^^^^^^^^^^                     <- this alternative: Choices=['0'], Waveform=['1']
 
 	.. seealso::
 
@@ -465,8 +464,8 @@ class OthersSelectedWaveform(BaseCase, WaveformMixin):
 
 	   .. code-block:: VHDL
 
-	      with sel select s <= '1' when 0, '0' when others;
-	      --                               ^^^^^^^^^^^^^^^    <- the others alternative
+	      with sel select s <= '1' when '0', '0' when others;
+	      --                                 ^^^^^^^^^^^^^^^    <- the others alternative
 	"""
 
 	def __init__(self, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
@@ -486,8 +485,8 @@ class SelectedExpression(BaseCase, ExpressionMixin, ChoicesMixin):
 
 	   .. code-block:: VHDL
 
-	      with sel select v := '1' when 0, '0' when others;
-	      --                   ^^^^^^^^^^                     <- this alternative: Choices=[0], Expression='1'
+	      with sel select v := '1' when '0', '0' when others;
+	      --                   ^^^^^^^^^^^^                     <- this alternative: Choices=['0'], Expression='1'
 
 	.. seealso::
 
@@ -516,8 +515,8 @@ class OthersSelectedExpression(BaseCase, ExpressionMixin):
 
 	   .. code-block:: VHDL
 
-	      with sel select v := '1' when 0, '0' when others;
-	      --                               ^^^^^^^^^^^^^^^    <- the others alternative
+	      with sel select v := '1' when '0', '0' when others;
+	      --                                 ^^^^^^^^^^^^^^^    <- the others alternative
 	"""
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -57,6 +57,11 @@ ExpressionUnion = Union[
 
 @export
 class AllowBlackboxMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language entities that may permit blackboxes.
+
+	The setting is inherited from the parent when not set locally (:data:`AllowBlackbox`).
+	"""
 	_allowBlackbox: Nullable[bool]  #: Allow blackboxes for components in language entity.
 
 	def __init__(self, allowBlackbox: Nullable[bool] = None) -> None:
@@ -103,6 +108,12 @@ class Statement(ModelEntity, LabeledEntityMixin):
 
 @export
 class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for statements calling a procedure.
+
+	The called procedure is available as :data:`Procedure`, its actual parameters as
+	:data:`ParameterAssociationItems`.
+	"""
 	_procedure:                 Symbol  # TODO: implement a ProcedureSymbol
 	_parameterAssociationItems: List[ParameterAssociationItem]
 
@@ -247,15 +258,18 @@ class ExpressionMixin(metaclass=ExtendedType, mixin=True):
 @export
 class ConditionalWaveform(ModelEntity, WaveformMixin, ConditionalMixin):
 	"""
-	One branch of a conditional (waveform) signal assignment.
+	Represents one branch of a conditional signal assignment.
+
+	Each branch pairs a waveform (:data:`Waveform`) with a condition (:data:`Condition`). The final
+	branch has no ``when``, so its condition is ``None``.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      s <= '1' when cond else '0';
-	      --   ^^^^^^^^^^^^         <- this branch: Waveform=['1'], Condition=cond
-	      --                ^^^     <- final branch (no ``when``): Waveform=['0'], Condition=None
+	      --   ^^^^^^^^^^^^^             <- this branch: Waveform=['1'], Condition=cond
+	      --                      ^^^    <- final branch (no ``when``): Waveform=['0'], Condition=None
 	"""
 
 	def __init__(
@@ -272,15 +286,18 @@ class ConditionalWaveform(ModelEntity, WaveformMixin, ConditionalMixin):
 @export
 class ConditionalExpression(ModelEntity, ExpressionMixin, ConditionalMixin):
 	"""
-	One branch of a conditional (variable) assignment.
+	Represents one branch of a conditional variable assignment.
+
+	Each branch pairs an expression (:data:`Expression`) with a condition (:data:`Condition`). The
+	final branch has no ``when``, so its condition is ``None``.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      v := '1' when cond else '0';
-	      --   ^^^^^^^^^^^^         <- this branch: Expression='1', Condition=cond
-	      --                ^^^     <- final branch (no ``when``): Expression='0', Condition=None
+	      --   ^^^^^^^^^^^^^             <- this branch: Expression='1', Condition=cond
+	      --                      ^^^    <- final branch (no ``when``): Expression='0', Condition=None
 	"""
 
 	def __init__(
@@ -322,14 +339,17 @@ class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
 @export
 class SelectedWaveform(BaseCase, WaveformMixin, ChoicesMixin):
 	"""
-	One alternative of a selected (waveform) signal assignment.
+	Represents one alternative of a selected signal assignment.
+
+	Each alternative pairs a waveform (:data:`Waveform`) with the choices selecting it
+	(:data:`Choices`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      with sel select s <= '1' when 0, '0' when others;
-	      --                    ^^^^^^^^      <- this alternative: Choices=[0], Waveform=['1']
+	      --                   ^^^^^^^^^^                     <- this alternative: Choices=[0], Waveform=['1']
 	"""
 
 	def __init__(
@@ -345,7 +365,18 @@ class SelectedWaveform(BaseCase, WaveformMixin, ChoicesMixin):
 
 @export
 class OthersSelectedWaveform(BaseCase, WaveformMixin):
-	"""``with sel select s <= '1' when 0, '0' when others;`` - the ``others`` alternative."""
+	"""
+	Represents the ``others`` alternative of a selected signal assignment.
+
+	It supplies the waveform (:data:`Waveform`) for every choice not named explicitly.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select s <= '1' when 0, '0' when others;
+	      --                               ^^^^^^^^^^^^^^^    <- the others alternative
+	"""
 
 	def __init__(self, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -355,14 +386,17 @@ class OthersSelectedWaveform(BaseCase, WaveformMixin):
 @export
 class SelectedExpression(BaseCase, ExpressionMixin, ChoicesMixin):
 	"""
-	One alternative of a selected (variable) assignment.
+	Represents one alternative of a selected variable assignment.
+
+	Each alternative pairs an expression (:data:`Expression`) with the choices selecting it
+	(:data:`Choices`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      with sel select v := '1' when 0, '0' when others;
-	      --                   ^^^^^^^^      <- this alternative: Choices=[0], Expression='1'
+	      --                   ^^^^^^^^^^                     <- this alternative: Choices=[0], Expression='1'
 	"""
 
 	def __init__(
@@ -378,7 +412,18 @@ class SelectedExpression(BaseCase, ExpressionMixin, ChoicesMixin):
 
 @export
 class OthersSelectedExpression(BaseCase, ExpressionMixin):
-	"""``with sel select v := '1' when 0, '0' when others;`` - the ``others`` alternative."""
+	"""
+	Represents the ``others`` alternative of a selected variable assignment.
+
+	It supplies the expression (:data:`Expression`) for every choice not named explicitly.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      with sel select v := '1' when 0, '0' when others;
+	      --                               ^^^^^^^^^^^^^^^    <- the others alternative
+	"""
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -391,13 +391,15 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 	"""
 	Represents a concurrent procedure call.
 
+	Like every concurrent statement, it can carry an optional label (:data:`Label`).
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	        proc_lbl : proc(clk, open);
-	      --^^^^^^^^                      <- Label
-	      --           ^^^^^^^^^^^^^^^    <- the call
+	        proc_lbl : proc(clock, open);
+	      --^^^^^^^^                        <- Label (optional)
+	      --           ^^^^^^^^^^^^^^^^^    <- the call
 
 	.. seealso::
 
@@ -431,13 +433,18 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 	      --^^^                            <- Label
 	          port (bp : in bit);
 	      --        ^^^^^^^^^^^            <- PortItems
-	          port map (bp => clk);
+	          port map (bp => clock);
 	          signal inner : bit := '0';
 	      --  ^^^^^^^^^^^^^^^^^^^^^^^^^^   <- DeclaredItems
 	        begin
 	          inner <= bp;
 	      --  ^^^^^^^^^^^^                 <- Statements
 	        end block;
+
+	.. note::
+
+	   The block's *port map aspect* (``port map (bp => clock);`` above) is not represented by the
+	   model yet - there is no field for the association items, so it has no marker.
 
 	.. seealso::
 

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -73,13 +73,13 @@ class ConcurrentStatement(Statement):
 
 	.. seealso::
 
-	   * :class:`Concurrent assert statement <pyVHDLModel.Concurrent.ConcurrentAssertStatement>`
-	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
-	   * :class:`Concurrent procedure call <pyVHDLModel.Concurrent.ConcurrentProcedureCall>`
-	   * :class:`Concurrent signal assignment <pyVHDLModel.Concurrent.ConcurrentSignalAssignment>`
-	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
 	   * :class:`Instantiation <pyVHDLModel.Concurrent.Instantiation>`
 	   * :class:`Process statement <pyVHDLModel.Concurrent.ProcessStatement>`
+	   * :class:`Concurrent procedure call <pyVHDLModel.Concurrent.ConcurrentProcedureCall>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
+	   * :class:`Concurrent signal assignment <pyVHDLModel.Concurrent.ConcurrentSignalAssignment>`
+	   * :class:`Concurrent assert statement <pyVHDLModel.Concurrent.ConcurrentAssertStatement>`
 	"""
 
 
@@ -90,12 +90,12 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
 	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
-	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
-	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
-	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	   * :class:`Generate branch <pyVHDLModel.Concurrent.GenerateBranch>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
 
 	   .. todo:: concurrent declaration region
 	"""
@@ -153,8 +153,8 @@ class Instantiation(ConcurrentStatement):
 	.. seealso::
 
 	   * :class:`Component instantiation <pyVHDLModel.Concurrent.ComponentInstantiation>`
-	   * :class:`Configuration instantiation <pyVHDLModel.Concurrent.ConfigurationInstantiation>`
 	   * :class:`Entity instantiation <pyVHDLModel.Concurrent.EntityInstantiation>`
+	   * :class:`Configuration instantiation <pyVHDLModel.Concurrent.ConfigurationInstantiation>`
 	"""
 
 	_genericAssociationItems: List[AssociationItem]
@@ -395,9 +395,9 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 
 	   .. code-block:: VHDL
 
-	      proc_lbl : proc(clk, open);
-	    --^^^^^^^^                      <- Label
-	    --           ^^^^^^^^^^^^^^^    <- the call
+	        proc_lbl : proc(clk, open);
+	      --^^^^^^^^                      <- Label
+	      --           ^^^^^^^^^^^^^^^    <- the call
 
 	.. seealso::
 
@@ -419,21 +419,25 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 	"""
 	Represents a block statement.
 
-	A block groups concurrent statements and may declare its own items. It can also have a port
-	clause (:data:`PortItems`), which makes it a hierarchy level of its own.
+	A block groups concurrent statements (:data:`Statements`) and may declare its own items
+	(:data:`DeclaredItems`). It always forms a hierarchy level; independently of that, it may also
+	have a port clause (:data:`PortItems`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      blk : block
-	    --^^^                            <- Label
-	        port (bp : in bit);
-	      --      ^^^^^^^^^^^            <- PortItems
-	        signal inner : bit := '0';
-	      --^^^^^^^^^^^^^^^^^^^^^^^^^^   <- DeclaredItems
-	      begin
-	      end block;
+	        blk : block
+	      --^^^                            <- Label
+	          port (bp : in bit);
+	      --        ^^^^^^^^^^^            <- PortItems
+	          port map (bp => clk);
+	          signal inner : bit := '0';
+	      --  ^^^^^^^^^^^^^^^^^^^^^^^^^^   <- DeclaredItems
+	        begin
+	          inner <= bp;
+	      --  ^^^^^^^^^^^^                 <- Statements
+	        end block;
 
 	.. seealso::
 
@@ -486,9 +490,9 @@ class GenerateBranch(ModelEntity, ConcurrentDeclarationRegionMixin, ConcurrentSt
 
 	.. seealso::
 
-	   * :class:`If-generate branch <pyVHDLModel.Concurrent.IfGenerateBranch>`
-	   * :class:`Elsif-generate branch <pyVHDLModel.Concurrent.ElsifGenerateBranch>`
-	   * :class:`Else-generate branch <pyVHDLModel.Concurrent.ElseGenerateBranch>`
+	   * :class:`If generate branch <pyVHDLModel.Concurrent.IfGenerateBranch>`
+	   * :class:`Elsif generate branch <pyVHDLModel.Concurrent.ElsifGenerateBranch>`
+	   * :class:`Else generate branch <pyVHDLModel.Concurrent.ElseGenerateBranch>`
 	"""
 
 	_alternativeLabel:           Nullable[str]
@@ -643,9 +647,9 @@ class GenerateStatement(ConcurrentStatement, AllowBlackboxMixin):
 
 	.. seealso::
 
+	   * :class:`If generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
 	   * :class:`Case generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
 	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
-	   * :class:`If generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
 	"""
 
 	def __init__(
@@ -1120,10 +1124,9 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 
 	.. seealso::
 
-	   * :class:`Concurrent conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
-	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
 	   * :class:`Concurrent simple signal assignment <pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment>`
-	"""
+	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
+	   * :class:`Conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`	"""
 	def __init__(self, label: str, target: SignalSymbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
@@ -1138,9 +1141,9 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin
 
 	   .. code-block:: VHDL
 
-	      q <= '1';
-	    --^           <- Target
-	    --     ^^^    <- the waveform
+	        q <= '1';
+	      --^           <- Target
+	      --     ^^^    <- the waveform
 
 	.. seealso::
 
@@ -1163,9 +1166,9 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment, ExpressionM
 
 	   .. code-block:: VHDL
 
-	      with sel select s <= '1' when 0, '0' when others;
-	      --   ^^^                                            <- SelectExpression
-	      --                   ^^^^^^^^^^                     <- first alternative
+	      with sel select s <= '1' when '0', '0' when others;
+	      --   ^^^                                              <- SelectExpression
+	      --                   ^^^^^^^^^^^^                     <- first alternative
 
 	.. seealso::
 

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -363,6 +363,17 @@ class ProcessStatement(ConcurrentStatement, SequentialDeclarationRegionMixin, Se
 
 @export
 class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
+	"""
+	Represents a concurrent procedure call.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      proc_lbl : proc(clk, open);
+	    --^^^^^^^^                      <- Label
+	    --           ^^^^^^^^^^^^^^^    <- the call
+	"""
 	def __init__(
 		self,
 		label: str,
@@ -376,6 +387,25 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 
 @export
 class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, LabeledEntityMixin, WithPortsMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, DocumentedEntityMixin, AllowBlackboxMixin):
+	"""
+	Represents a block statement.
+
+	A block groups concurrent statements and may declare its own items. It can also have a port
+	clause (:data:`PortItems`), which makes it a hierarchy level of its own.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      blk : block
+	    --^^^                            <- Label
+	        port (bp : in bit);
+	      --      ^^^^^^^^^^^            <- PortItems
+	        signal inner : bit := '0';
+	      --^^^^^^^^^^^^^^^^^^^^^^^^^^   <- DeclaredItems
+	      begin
+	      end block;
+	"""
 	_namespace: Namespace
 
 	def __init__(
@@ -574,13 +604,9 @@ class ElseGenerateBranch(GenerateBranch, ElseBranchMixin):
 @export
 class GenerateStatement(ConcurrentStatement, AllowBlackboxMixin):
 	"""
-	A base-class for all generate statements.
+	Represents the base-class of all generate statements.
 
-	.. seealso::
-
-	   * :class:`If...generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
-	   * :class:`Case...generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
-	   * :class:`For...generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
+	A generate statement replicates or conditionally elaborates concurrent statements.
 	"""
 
 	def __init__(
@@ -723,6 +749,18 @@ class ConcurrentChoice(BaseChoice):
 
 @export
 class IndexedGenerateChoice(ConcurrentChoice):
+	"""
+	Represents a case-generate choice given by a single value.
+
+	The value is available as :data:`Expression`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when 8 =>
+	      --   ^      <- Expression
+	"""
 	_expression: ExpressionUnion
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
@@ -746,6 +784,18 @@ class IndexedGenerateChoice(ConcurrentChoice):
 
 @export
 class RangedGenerateChoice(ConcurrentChoice):
+	"""
+	Represents a case-generate choice given by a range.
+
+	The range is available as :data:`Range`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when 0 to 3 =>
+	      --   ^^^^^^      <- Range
+	"""
 	_range: 'Range'
 
 	def __init__(self, rng: 'Range', parent: Nullable[ModelEntity] = None) -> None:
@@ -769,6 +819,9 @@ class RangedGenerateChoice(ConcurrentChoice):
 
 @export
 class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin, ChoicesMixin):
+	"""
+	Represents the base-class of all alternatives of a case-generate statement.
+	"""
 	_namespace: Namespace
 
 	def __init__(
@@ -798,6 +851,16 @@ class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMi
 
 @export
 class GenerateCase(ConcurrentCase):
+	"""
+	Represents one alternative of a case-generate statement, selected by its choices.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when 8 =>
+	      --   ^      <- Choices
+	"""
 	def __init__(
 		self,
 		choices:          Iterable[ConcurrentChoice],
@@ -815,6 +878,18 @@ class GenerateCase(ConcurrentCase):
 
 @export
 class OthersGenerateCase(ConcurrentCase):
+	"""
+	Represents the ``others`` alternative of a case-generate statement.
+
+	It covers every choice not named explicitly.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when others =>
+	      --   ^^^^^^      <- the choice
+	"""
 	def __str__(self) -> str:
 		return "when others =>"
 
@@ -978,13 +1053,7 @@ class ForGenerateStatement(GenerateStatement, ConcurrentDeclarationRegionMixin, 
 @export
 class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 	"""
-	A base-class for concurrent signal assignments.
-
-	.. seealso::
-
-	   * :class:`~pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment`
-	   * :class:`~pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment`
-	   * :class:`~pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment`
+	Represents the base-class of all concurrent signal assignments.
 	"""
 	def __init__(self, label: str, target: SignalSymbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -993,6 +1062,17 @@ class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 
 @export
 class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin):
+	"""
+	Represents a simple concurrent signal assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      q <= '1';
+	    --^           <- Target
+	    --     ^^^    <- the waveform
+	"""
 	def __init__(self, label: str, target: SignalSymbol, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
 		WaveformMixin.__init__(self, waveform)
@@ -1001,11 +1081,18 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin
 @export
 class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment, ExpressionMixin, SelectedWaveformsMixin):
 	"""
+	Represents a selected concurrent signal assignment.
+
+	The selector and alternatives are available as :data:`SelectExpression` and
+	:data:`SelectedWaveforms`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      with sel select s <= '1' when 0, '0' when others;
+	      --   ^^^                                            <- SelectExpression
+	      --                   ^^^^^^^^^^                     <- first alternative
 	"""
 
 	def __init__(
@@ -1024,11 +1111,17 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment, ExpressionM
 @export
 class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment, ConditionalWaveformsMixin):
 	"""
+	Represents a conditional concurrent signal assignment.
+
+	The branches are available as :data:`ConditionalWaveforms`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      s <= '1' when cond1 else '0' when cond2 else 'Z';
+	      --   ^^^^^^^^^^^^^^                                 <- first branch
+	      --                                           ^^^    <- final branch
 	"""
 
 	def __init__(
@@ -1044,6 +1137,18 @@ class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment, Conditio
 
 @export
 class ConcurrentAssertStatement(ConcurrentStatement, AssertStatementMixin):
+	"""
+	Represents a concurrent assertion statement.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      assert W > 0 report "w" severity note;
+	      --     ^^^^^                             <- Condition
+	      --                  ^^^                  <- Message
+	      --                               ^^^^    <- Severity
+	"""
 	def __init__(
 		self,
 		condition: ExpressionUnion,

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -205,13 +205,18 @@ class Instantiation(ConcurrentStatement):
 @export
 class ComponentInstantiation(Instantiation):
 	"""
-	Represents a component instantiation by referring to a component name.
+	Represents a component instantiation.
+
+	The instantiated component is available as :data:`Component`, the associations as
+	:data:`GenericAssociationItems` and :data:`PortAssociationItems`. The label is mandatory.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      inst : component Counter;
+	        inst : component Counter;
+	      --^^^^                        <- Label
+	      --                 ^^^^^^^    <- Component
 	"""
 
 	_component: ComponentInstantiationSymbol
@@ -242,13 +247,19 @@ class ComponentInstantiation(Instantiation):
 @export
 class EntityInstantiation(Instantiation):
 	"""
-	Represents an entity instantiation by referring to an entity name with optional architecture name.
+	Represents a direct entity instantiation.
+
+	The instantiated entity is available as :data:`Entity` and the optionally selected architecture
+	as :data:`Architecture`. The label is mandatory.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      inst : entity work. Counter;
+	        inst : entity work.Counter(rtl);
+	      --^^^^                               <- Label
+	      --              ^^^^^^^^^^^^         <- Entity
+	      --                           ^^^     <- optional Architecture
 	"""
 
 	_entity: EntityInstantiationSymbol
@@ -294,13 +305,17 @@ class EntityInstantiation(Instantiation):
 @export
 class ConfigurationInstantiation(Instantiation):
 	"""
-	Represents a configuration instantiation by referring to a configuration name.
+	Represents a configuration instantiation.
+
+	The instantiated configuration is available as :data:`Configuration`. The label is mandatory.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      inst : configuration Counter;
+	        inst : configuration Counter;
+	      --^^^^                            <- Label
+	      --                     ^^^^^^^    <- Configuration
 	"""
 
 	_configuration: ConfigurationInstantiationSymbol
@@ -331,17 +346,24 @@ class ConfigurationInstantiation(Instantiation):
 @export
 class ProcessStatement(ConcurrentStatement, SequentialDeclarationRegionMixin, SequentialStatementsMixin, DocumentedEntityMixin):
 	"""
-	Represents a process statement with sensitivity list, sequential declaration region and sequential statements.
+	Represents a process statement.
+
+	A process declares its own items (:data:`DeclaredItems`) and groups sequential statements
+	(:data:`Statements`). It may name a sensitivity list (:data:`SensitivityList`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      proc: process(Clock)
-	        -- sequential declarations
-	      begin
-	        -- sequential statements
-	      end process;
+	        proc : process (clock)
+	      --^^^^                     <- optional Label
+	      --                ^^^^^    <- optional SensitivityList
+	          variable v : bit;
+	      --  ^^^^^^^^^^^^^^^^^      <- DeclaredItems
+	        begin
+	          v := '1';
+	      --  ^^^^^^^^^              <- Statements
+	        end process;
 	"""
 
 	_sensitivityList: List[Name]  # TODO: implement a SignalSymbol
@@ -398,7 +420,7 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 	   .. code-block:: VHDL
 
 	        proc_lbl : proc(clock, open);
-	      --^^^^^^^^                        <- Label (optional)
+	      --^^^^^^^^                        <- optional Label
 	      --           ^^^^^^^^^^^^^^^^^    <- the call
 
 	.. seealso::
@@ -680,19 +702,27 @@ class GenerateStatement(ConcurrentStatement, AllowBlackboxMixin):
 @export
 class IfGenerateStatement(GenerateStatement):
 	"""
-	Represents an if...generate statement.
+	Represents an if-generate statement.
+
+	It has one ``if`` branch (:data:`IfBranch`), any number of ``elsif`` branches
+	(:data:`ElsifBranches`) and an optional ``else`` branch (:data:`ElseBranch`). The label is
+	mandatory and the branch conditions must be static expressions.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      gen: if condition generate
-	        -- ...
-	      elsif condition generate
-	        -- ...
-	      else generate
-	        -- ...
-	      end generate;
+	        gen : if WIDTH > 8 generate
+	      --^^^                           <- Label
+	      --      ^^^^^^^^^^^^^^^^^^^^^   <- IfBranch
+	          q <= '0';
+	        elsif WIDTH > 4 generate
+	      --^^^^^^^^^^^^^^^^^^^^^^^^      <- ElsifBranches[0]
+	          q <= '1';
+	        else generate
+	      --^^^^^^^^^^^^^                 <- ElseBranch
+	          q <= 'Z';
+	        end generate;
 
 	.. seealso::
 
@@ -961,20 +991,23 @@ class OthersGenerateCase(ConcurrentCase):
 @export
 class CaseGenerateStatement(GenerateStatement):
 	"""
-	Represents a case...generate statement.
+	Represents a case-generate statement.
+
+	The expression being tested is available as :data:`SelectExpression`, the alternatives as
+	:data:`Cases`. The label is mandatory and the selector must be a static expression.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      gen: case selector generate
-	        case choice1 =>
-	          -- ...
-	        case choice2 =>
-	          -- ...
-	        case others =>
-	          -- ...
-	      end generate;
+	        gen : case MODE generate
+	      --^^^                          <- Label
+	      --           ^^^^              <- SelectExpression
+	          when 0 => q <= '0';
+	      --  ^^^^^^^^^^^^^^^^^^^        <- Cases[0]
+	          when others => q <= '1';
+	      --  ^^^^^^^^^^^^^^^^^^^^^^^^   <- Cases[1]
+	        end generate;
 
 	.. seealso::
 
@@ -1043,15 +1076,22 @@ class CaseGenerateStatement(GenerateStatement):
 @export
 class ForGenerateStatement(GenerateStatement, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin):
 	"""
-	Represents a for...generate statement.
+	Represents a for-generate statement.
+
+	The loop index is available as :data:`LoopIndex`, the iteration range as :data:`Range` and the
+	generated statements as :data:`Statements`. The label is mandatory.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      gen: for i in 0 to 3 generate
-	        -- ...
-	      end generate;
+	        gen : for i in 0 to 3 generate
+	      --^^^                              <- Label
+	      --          ^                      <- LoopIndex
+	      --               ^^^^^^            <- Range
+	          q(i) <= '0';
+	      --  ^^^^^^^^^^^^                   <- Statements
+	        end generate;
 
 	.. seealso::
 
@@ -1144,13 +1184,16 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin
 	"""
 	Represents a simple concurrent signal assignment.
 
+	The assignment's destination is available as :data:`Target`, its value as :data:`Waveform`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	        q <= '1';
-	      --^           <- Target
-	      --     ^^^    <- the waveform
+	        lbl : q <= '1';
+	      --^^^               <- optional Label
+	      --      ^           <- Target
+	      --           ^^^    <- Waveform
 
 	.. seealso::
 
@@ -1166,16 +1209,20 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment, ExpressionM
 	"""
 	Represents a selected concurrent signal assignment.
 
-	The selector and alternatives are available as :data:`SelectExpression` and
-	:data:`SelectedWaveforms`.
+	The selector is available as :data:`Expression`, the alternatives as :data:`SelectedWaveforms`,
+	a list of :class:`~pyVHDLModel.Common.SelectedWaveform`. The model holds them in a list and has
+	no distinct field per alternative, so the markers below name list elements.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      with sel select s <= '1' when '0', '0' when others;
-	      --   ^^^                                              <- SelectExpression
-	      --                   ^^^^^^^^^^^^                     <- first alternative
+	        lbl : with sel select q <= '1' when '0', '0' when others;
+	      --^^^                                                         <- optional Label
+	      --           ^^^                                              <- Expression
+	      --                      ^                                     <- Target
+	      --                           ^^^^^^^^^^^^                     <- SelectedWaveforms[0]
+	      --                                         ^^^^^^^^^^^^^^^    <- SelectedWaveforms[1]
 
 	.. seealso::
 
@@ -1201,15 +1248,19 @@ class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment, Conditio
 	"""
 	Represents a conditional concurrent signal assignment.
 
-	The branches are available as :data:`ConditionalWaveforms`.
+	The alternatives are available as :data:`ConditionalWaveforms`, a list of
+	:class:`~pyVHDLModel.Common.ConditionalWaveform`. The model holds them in a list and has no
+	distinct field per alternative, so the markers below name list elements.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      s <= '1' when cond1 else '0' when cond2 else 'Z';
-	      --   ^^^^^^^^^^^^^^                                 <- first branch
-	      --                                           ^^^    <- final branch
+	        lbl : q <= '1' when cond else '0';
+	      --^^^                                  <- optional Label
+	      --      ^                              <- Target
+	      --           ^^^^^^^^^^^^^             <- ConditionalWaveforms[0]
+	      --                              ^^^    <- ConditionalWaveforms[1]
 
 	.. seealso::
 
@@ -1233,14 +1284,18 @@ class ConcurrentAssertStatement(ConcurrentStatement, AssertStatementMixin):
 	"""
 	Represents a concurrent assertion statement.
 
+	The checked condition is available as :data:`Condition`, the optional report string as
+	:data:`Message` and the optional severity as :data:`Severity`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      assert W > 0 report "w" severity note;
-	      --     ^^^^^                             <- Condition
-	      --                  ^^^                  <- Message
-	      --                               ^^^^    <- Severity
+	        lbl : assert cond report "bad" severity note;
+	      --^^^                                             <- optional Label
+	      --             ^^^^                               <- Condition
+	      --                         ^^^^^                  <- optional Message
+	      --                                        ^^^^    <- optional Severity
 
 	.. seealso::
 

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -68,7 +68,19 @@ ExpressionUnion = Union[
 
 @export
 class ConcurrentStatement(Statement):
-	"""A base-class for all concurrent statements."""
+	"""
+	A base-class for all concurrent statements.
+
+	.. seealso::
+
+	   * :class:`Concurrent assert statement <pyVHDLModel.Concurrent.ConcurrentAssertStatement>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Concurrent procedure call <pyVHDLModel.Concurrent.ConcurrentProcedureCall>`
+	   * :class:`Concurrent signal assignment <pyVHDLModel.Concurrent.ConcurrentSignalAssignment>`
+	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
+	   * :class:`Instantiation <pyVHDLModel.Concurrent.Instantiation>`
+	   * :class:`Process statement <pyVHDLModel.Concurrent.ProcessStatement>`
+	"""
 
 
 @export
@@ -77,6 +89,13 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 	A mixin-class for all language constructs supporting concurrent statements.
 
 	.. seealso::
+
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
+	   * :class:`Generate branch <pyVHDLModel.Concurrent.GenerateBranch>`
 
 	   .. todo:: concurrent declaration region
 	"""
@@ -130,6 +149,12 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 class Instantiation(ConcurrentStatement):
 	"""
 	A base-class for all (component) instantiations.
+
+	.. seealso::
+
+	   * :class:`Component instantiation <pyVHDLModel.Concurrent.ComponentInstantiation>`
+	   * :class:`Configuration instantiation <pyVHDLModel.Concurrent.ConfigurationInstantiation>`
+	   * :class:`Entity instantiation <pyVHDLModel.Concurrent.EntityInstantiation>`
 	"""
 
 	_genericAssociationItems: List[AssociationItem]
@@ -373,6 +398,10 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 	      proc_lbl : proc(clk, open);
 	    --^^^^^^^^                      <- Label
 	    --           ^^^^^^^^^^^^^^^    <- the call
+
+	.. seealso::
+
+	   * :class:`Sequential counterpart <pyVHDLModel.Sequential.SequentialProcedureCall>`
 	"""
 	def __init__(
 		self,
@@ -405,6 +434,10 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 	      --^^^^^^^^^^^^^^^^^^^^^^^^^^   <- DeclaredItems
 	      begin
 	      end block;
+
+	.. seealso::
+
+	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
 	"""
 	_namespace: Namespace
 
@@ -607,6 +640,12 @@ class GenerateStatement(ConcurrentStatement, AllowBlackboxMixin):
 	Represents the base-class of all generate statements.
 
 	A generate statement replicates or conditionally elaborates concurrent statements.
+
+	.. seealso::
+
+	   * :class:`Case generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
+	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
+	   * :class:`If generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
 	"""
 
 	def __init__(
@@ -650,6 +689,8 @@ class IfGenerateStatement(GenerateStatement):
 	   * :class:`If-generate branch <pyVHDLModel.Concurrent.IfGenerateBranch>`
 	   * :class:`Elsif-generate branch <pyVHDLModel.Concurrent.ElsifGenerateBranch>`
 	   * :class:`Else-generate branch <pyVHDLModel.Concurrent.ElseGenerateBranch>`
+	   * :class:`Case-generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
+	   * :class:`For-generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	"""
 
 	_ifBranch:      IfGenerateBranch
@@ -744,7 +785,14 @@ class IfGenerateStatement(GenerateStatement):
 
 @export
 class ConcurrentChoice(BaseChoice):
-	"""A base-class for all concurrent choices (in case...generate statements)."""
+	"""
+	A base-class for all concurrent choices (in case...generate statements).
+
+	.. seealso::
+
+	   * :class:`Indexed generate choice <pyVHDLModel.Concurrent.IndexedGenerateChoice>`
+	   * :class:`Ranged generate choice <pyVHDLModel.Concurrent.RangedGenerateChoice>`
+	"""
 
 
 @export
@@ -821,6 +869,11 @@ class RangedGenerateChoice(ConcurrentChoice):
 class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, AllowBlackboxMixin, ChoicesMixin):
 	"""
 	Represents the base-class of all alternatives of a case-generate statement.
+
+	.. seealso::
+
+	   * :class:`Generate case <pyVHDLModel.Concurrent.GenerateCase>`
+	   * :class:`Others generate case <pyVHDLModel.Concurrent.OthersGenerateCase>`
 	"""
 	_namespace: Namespace
 
@@ -911,6 +964,11 @@ class CaseGenerateStatement(GenerateStatement):
 	        case others =>
 	          -- ...
 	      end generate;
+
+	.. seealso::
+
+	   * :class:`If-generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
+	   * :class:`For-generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	"""
 
 	_expression: ExpressionUnion
@@ -983,6 +1041,11 @@ class ForGenerateStatement(GenerateStatement, ConcurrentDeclarationRegionMixin, 
 	      gen: for i in 0 to 3 generate
 	        -- ...
 	      end generate;
+
+	.. seealso::
+
+	   * :class:`If-generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
+	   * :class:`Case-generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
 	"""
 
 	_loopIndex: str
@@ -1054,6 +1117,12 @@ class ForGenerateStatement(GenerateStatement, ConcurrentDeclarationRegionMixin, 
 class ConcurrentSignalAssignment(ConcurrentStatement, SignalAssignmentMixin):
 	"""
 	Represents the base-class of all concurrent signal assignments.
+
+	.. seealso::
+
+	   * :class:`Concurrent conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
+	   * :class:`Concurrent selected signal assignment <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
+	   * :class:`Concurrent simple signal assignment <pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment>`
 	"""
 	def __init__(self, label: str, target: SignalSymbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -1072,6 +1141,10 @@ class ConcurrentSimpleSignalAssignment(ConcurrentSignalAssignment, WaveformMixin
 	      q <= '1';
 	    --^           <- Target
 	    --     ^^^    <- the waveform
+
+	.. seealso::
+
+	   * :class:`Sequential counterpart <pyVHDLModel.Sequential.SequentialSimpleSignalAssignment>`
 	"""
 	def __init__(self, label: str, target: SignalSymbol, waveform: Iterable[WaveformElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, target, parent)
@@ -1093,6 +1166,11 @@ class ConcurrentSelectedSignalAssignment(ConcurrentSignalAssignment, ExpressionM
 	      with sel select s <= '1' when 0, '0' when others;
 	      --   ^^^                                            <- SelectExpression
 	      --                   ^^^^^^^^^^                     <- first alternative
+
+	.. seealso::
+
+	   * :class:`Sequential counterpart <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
 	"""
 
 	def __init__(
@@ -1122,6 +1200,11 @@ class ConcurrentConditionalSignalAssignment(ConcurrentSignalAssignment, Conditio
 	      s <= '1' when cond1 else '0' when cond2 else 'Z';
 	      --   ^^^^^^^^^^^^^^                                 <- first branch
 	      --                                           ^^^    <- final branch
+
+	.. seealso::
+
+	   * :class:`Sequential counterpart <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`
+	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
 	"""
 
 	def __init__(
@@ -1148,6 +1231,10 @@ class ConcurrentAssertStatement(ConcurrentStatement, AssertStatementMixin):
 	      --     ^^^^^                             <- Condition
 	      --                  ^^^                  <- Message
 	      --                               ^^^^    <- Severity
+
+	.. seealso::
+
+	   * :class:`Sequential counterpart <pyVHDLModel.Sequential.SequentialAssertStatement>`
 	"""
 	def __init__(
 		self,

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -61,8 +61,8 @@ class EntityAspect(ModelEntity):
 
 	.. seealso::
 
-	   * :class:`Entity aspect configuration <pyVHDLModel.Configuration.EntityAspectConfiguration>`
 	   * :class:`Entity aspect entity <pyVHDLModel.Configuration.EntityAspectEntity>`
+	   * :class:`Entity aspect configuration <pyVHDLModel.Configuration.EntityAspectConfiguration>`
 	   * :class:`Entity aspect open <pyVHDLModel.Configuration.EntityAspectOpen>`
 	"""
 
@@ -232,28 +232,28 @@ class BindingIndication(ModelEntity):
 @export
 class AllInstantiationList(ModelEntity):
 	"""
-	Represents the reserved word ``all`` used as an instantiation list.
+	Represents an instantiation list naming ``all`` instances of a component.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      for all : comp use entity work.sub(behav);
-	      --    ^^^
+	      --  ^^^                                      <- the instantiation list
 	"""
 
 
 @export
 class OthersInstantiationList(ModelEntity):
 	"""
-	Represents the reserved word ``others`` used as an instantiation list.
+	Represents an instantiation list naming all instances not configured elsewhere.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      for others : comp use entity work.sub(behav);
-	      --    ^^^^^^
+	      --  ^^^^^^                                      <- the instantiation list
 	"""
 
 

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -58,6 +58,12 @@ class EntityAspect(ModelEntity):
 
 	      for U1 : comp use entity work.sub(behav);
 	      --                ^^^^^^^^^^^^^^^^^^^^^^
+
+	.. seealso::
+
+	   * :class:`Entity aspect configuration <pyVHDLModel.Configuration.EntityAspectConfiguration>`
+	   * :class:`Entity aspect entity <pyVHDLModel.Configuration.EntityAspectEntity>`
+	   * :class:`Entity aspect open <pyVHDLModel.Configuration.EntityAspectOpen>`
 	"""
 
 

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -64,13 +64,15 @@ class EntityAspect(ModelEntity):
 @export
 class EntityAspectEntity(EntityAspect):
 	"""
+	Represents an entity aspect naming an entity, optionally with an architecture.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      for U1 : comp use entity work.sub(behav);
-	      --                       ^^^^^^^^  ^^^^^
-	      --                       Entity    Architecture (optional)
+	      use entity work.e_rest(rtl);
+	      --         ^^^^^^^^^^^         <- Entity
+	      --                     ^^^     <- Architecture
 	"""
 
 	_entity:       EntitySymbol
@@ -113,12 +115,14 @@ class EntityAspectEntity(EntityAspect):
 @export
 class EntityAspectConfiguration(EntityAspect):
 	"""
+	Represents an entity aspect naming a configuration.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      for U1 : comp use configuration work.cfg;
-	      --                              ^^^^^^^
+	      use configuration work.cfg;
+	      --                ^^^^^^^^    <- Configuration
 	"""
 
 	_configuration: ConfigurationSymbol
@@ -142,23 +146,24 @@ class EntityAspectConfiguration(EntityAspect):
 @export
 class EntityAspectOpen(EntityAspect):
 	"""
+	Represents an open entity aspect, leaving the binding unspecified.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      for U1 : comp use open;
+	      use open;
+	      --  ^^^^    <- the aspect
 	"""
 
 
 @export
 class BindingIndication(ModelEntity):
 	"""
-	.. admonition:: Example
+	Represents a binding indication: which design entity a component is bound to.
 
-	   .. code-block:: VHDL
-
-	      for U1 : comp use entity work.sub(behav) generic map (...) port map (...);
-	      --                ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^
+	The entity aspect is available as :data:`EntityAspect`, together with the generic and port maps
+	(:data:`GenericAssociations`, :data:`PortAssociations`).
 	"""
 
 	_entityAspect:            Nullable[EntityAspect]
@@ -324,15 +329,16 @@ class ComponentConfiguration(ModelEntity):
 @export
 class BlockConfiguration(ModelEntity):
 	"""
+	Represents the configuration of one block: an architecture, a block statement or a generate body.
+
+	Nested configurations are available as :data:`ConfigurationItems`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      for rtl
-	      --  ^^^ Block specification
-	        for U1 : comp
-	        -- ...
-	        end for;
+	      --  ^^^    <- Block
 	      end for;
 	"""
 

--- a/pyVHDLModel/Declaration.py
+++ b/pyVHDLModel/Declaration.py
@@ -223,7 +223,7 @@ class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	      alias a : bit_vector(3 downto 0) is s(3 downto 0);
 	      --        ^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^
-	      --        Subtype (optional)         Name
+	      --        optional Subtype           Name
 
 	      alias b is s;
 	      --          ^

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -59,9 +59,9 @@ class Reference(ModelEntity):
 
 	.. seealso::
 
-	   * :class:`~pyVHDLModel.DesignUnit.LibraryClause`
-	   * :class:`~pyVHDLModel.DesignUnit.UseClause`
-	   * :class:`~pyVHDLModel.DesignUnit.ContextReference`
+	   * :class:`Library clause <pyVHDLModel.DesignUnit.LibraryClause>`
+	   * :class:`Use clause <pyVHDLModel.DesignUnit.UseClause>`
+	   * :class:`Context reference <pyVHDLModel.DesignUnit.ContextReference>`
 	"""
 
 	_symbols:       List[Symbol]
@@ -151,11 +151,11 @@ class DesignUnitWithContextMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
-	   * :class:`Configuration <pyVHDLModel.DesignUnit.Configuration>`
-	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
 	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
 	   * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Configuration <pyVHDLModel.DesignUnit.Configuration>`
 	"""
 
 
@@ -168,15 +168,15 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	   * :class:`Primary design units <pyVHDLModel.DesignUnit.PrimaryUnit>`
 
-	     * :class:`~pyVHDLModel.DesignUnit.Context`
-	     * :class:`~pyVHDLModel.DesignUnit.Entity`
-	     * :class:`~pyVHDLModel.DesignUnit.Package`
-	     * :class:`~pyVHDLModel.DesignUnit.Configuration`
+	     * :class:`Context <pyVHDLModel.DesignUnit.Context>`
+	     * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	     * :class:`Package <pyVHDLModel.DesignUnit.Package>`
+	     * :class:`Configuration <pyVHDLModel.DesignUnit.Configuration>`
 
 	   * :class:`Secondary design units <pyVHDLModel.DesignUnit.SecondaryUnit>`
 
-	     * :class:`~pyVHDLModel.DesignUnit.Architecture`
-	     * :class:`~pyVHDLModel.DesignUnit.PackageBody`
+	     * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	     * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
 	"""
 
 	_document: 'Document'                                  #: The VHDL library, the design unit was analyzed into.
@@ -355,11 +355,11 @@ class PrimaryUnit(DesignUnit):
 
 	.. seealso::
 
-	   * :class:`~pyVHDLModel.DesignUnit.Context`
-	   * :class:`~pyVHDLModel.DesignUnit.Entity`
-	   * :class:`~pyVHDLModel.DesignUnit.Package`
-	   * :class:`~pyVHDLModel.DesignUnit.Configuration`
-	   * :class:`PSL primary unit <pyVHDLModel.PSLModel.PSLPrimaryUnit>`
+	   * :class:`Context <pyVHDLModel.DesignUnit.Context>`
+	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Configuration <pyVHDLModel.DesignUnit.Configuration>`
+	   * :class:`PSL primary unit <pyVHDLModel.PSLModel.PSLPrimaryUnit>` (PSL is not supported)
 	"""
 
 
@@ -370,8 +370,8 @@ class SecondaryUnit(DesignUnit):
 
 	.. seealso::
 
-	   * :class:`~pyVHDLModel.DesignUnit.Architecture`
-	   * :class:`~pyVHDLModel.DesignUnit.PackageBody`
+	   * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
 	"""
 
 

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -148,6 +148,14 @@ ContextUnion = Union[
 class DesignUnitWithContextMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for all design units with a context.
+
+	.. seealso::
+
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Configuration <pyVHDLModel.DesignUnit.Configuration>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
+	   * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
 	"""
 
 
@@ -351,6 +359,7 @@ class PrimaryUnit(DesignUnit):
 	   * :class:`~pyVHDLModel.DesignUnit.Entity`
 	   * :class:`~pyVHDLModel.DesignUnit.Package`
 	   * :class:`~pyVHDLModel.DesignUnit.Configuration`
+	   * :class:`PSL primary unit <pyVHDLModel.PSLModel.PSLPrimaryUnit>`
 	"""
 
 
@@ -395,6 +404,11 @@ class Context(PrimaryUnit):
 	      context ctx is
 	        -- ...
 	      end context;
+
+	.. seealso::
+
+	   * :class:`Library clause <pyVHDLModel.DesignUnit.LibraryClause>`
+	   * :class:`Use clause <pyVHDLModel.DesignUnit.UseClause>`
 	"""
 
 	_references:        List[ContextUnion]
@@ -466,6 +480,12 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, Concur
 	      package pkg is
 	        -- ...
 	      end package;
+
+	.. seealso::
+
+	   * :class:`Package instantiation <pyVHDLModel.Instantiation.PackageInstantiation>`
+	   * :class:`Predefined package <pyVHDLModel.Predefined.PredefinedPackage>`
+	   * :class:`Package body implementing it <pyVHDLModel.DesignUnit.PackageBody>`
 	"""
 
 	_packageBody:       Nullable["PackageBody"]
@@ -580,6 +600,11 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarati
 	      package body pkg is
 	        -- ...
 	      end package body;
+
+	.. seealso::
+
+	   * :class:`Predefined package body <pyVHDLModel.Predefined.PredefinedPackageBody>`
+	   * :class:`Package it implements <pyVHDLModel.DesignUnit.Package>`
 	"""
 
 	_package:       PackageSymbol
@@ -643,6 +668,12 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, WithPor
 	      entity ent is
 	        -- ...
 	      end entity;
+
+	.. seealso::
+
+	   * :class:`Architecture implementing it <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Component declaring the same interface <pyVHDLModel.DesignUnit.Component>`
+	   * :class:`Configuration binding it <pyVHDLModel.DesignUnit.Configuration>`
 	"""
 
 	_architectures: Dict[str, 'Architecture']
@@ -713,6 +744,10 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarat
 	      begin
 	        -- ...
 	      end architecture;
+
+	.. seealso::
+
+	   * :class:`Entity it implements <pyVHDLModel.DesignUnit.Entity>`
 	"""
 
 	_entity:        EntitySymbol
@@ -771,6 +806,11 @@ class Component(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, AllowBlack
 	      component ent is
 	        -- ...
 	      end component;
+
+	.. seealso::
+
+	   * :class:`Entity it may be bound to <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Component configuration <pyVHDLModel.Configuration.ComponentConfiguration>`
 	"""
 
 	_isBlackBox:        Nullable[bool]                    #: Component is a blackbox.
@@ -879,6 +919,11 @@ class Configuration(PrimaryUnit, DesignUnitWithContextMixin):
 	          -- ...
 	        end for;
 	      end configuration;
+
+	.. seealso::
+
+	   * :class:`Entity it configures <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Block configuration <pyVHDLModel.Configuration.BlockConfiguration>`
 	"""
 
 	_entity:            EntitySymbol

--- a/pyVHDLModel/Exception.py
+++ b/pyVHDLModel/Exception.py
@@ -43,21 +43,33 @@ from pyVHDLModel.Symbol   import Symbol
 
 @export
 class VHDLModelWarning(Warning):
+	"""
+	Base-class for all warnings raised by pyVHDLModel.
+	"""
 	pass
 
 
 @export
 class NotImplementedWarning(VHDLModelWarning):
+	"""
+	Raised when a language construct is recognised but not yet modelled.
+	"""
 	pass
 
 
 @export
 class VHDLModelCriticalWarning(Warning):
+	"""
+	Base-class for warnings that likely indicate a defect in the model or its input.
+	"""
 	pass
 
 
 @export
 class BlackboxWarning(VHDLModelCriticalWarning):
+	"""
+	Raised when a component could not be bound and is treated as a blackbox.
+	"""
 	pass
 
 

--- a/pyVHDLModel/Exception.py
+++ b/pyVHDLModel/Exception.py
@@ -45,6 +45,10 @@ from pyVHDLModel.Symbol   import Symbol
 class VHDLModelWarning(Warning):
 	"""
 	Base-class for all warnings raised by pyVHDLModel.
+
+	.. seealso::
+
+	   * :class:`Not implemented warning <pyVHDLModel.Exception.NotImplementedWarning>`
 	"""
 	pass
 
@@ -61,6 +65,10 @@ class NotImplementedWarning(VHDLModelWarning):
 class VHDLModelCriticalWarning(Warning):
 	"""
 	Base-class for warnings that likely indicate a defect in the model or its input.
+
+	.. seealso::
+
+	   * :class:`Blackbox warning <pyVHDLModel.Exception.BlackboxWarning>`
 	"""
 	pass
 
@@ -75,7 +83,22 @@ class BlackboxWarning(VHDLModelCriticalWarning):
 
 @export
 class VHDLModelException(Exception):
-	"""Base-class for all exceptions (errors) raised by pyVHDLModel."""
+	"""
+	Base-class for all exceptions (errors) raised by pyVHDLModel.
+
+	.. seealso::
+
+	   * :class:`Architecture exists in library error <pyVHDLModel.Exception.ArchitectureExistsInLibraryError>`
+	   * :class:`Configuration exists in library error <pyVHDLModel.Exception.ConfigurationExistsInLibraryError>`
+	   * :class:`Context exists in library error <pyVHDLModel.Exception.ContextExistsInLibraryError>`
+	   * :class:`Entity exists in library error <pyVHDLModel.Exception.EntityExistsInLibraryError>`
+	   * :class:`Library exists in design error <pyVHDLModel.Exception.LibraryExistsInDesignError>`
+	   * :class:`Library not registered error <pyVHDLModel.Exception.LibraryNotRegisteredError>`
+	   * :class:`Library registered to foreign design error <pyVHDLModel.Exception.LibraryRegisteredToForeignDesignError>`
+	   * :class:`Package body exists error <pyVHDLModel.Exception.PackageBodyExistsError>`
+	   * :class:`Package exists in library error <pyVHDLModel.Exception.PackageExistsInLibraryError>`
+	   * :class:`Referenced library not existing error <pyVHDLModel.Exception.ReferencedLibraryNotExistingError>`
+	"""
 
 
 @export

--- a/pyVHDLModel/Exception.py
+++ b/pyVHDLModel/Exception.py
@@ -64,7 +64,7 @@ class NotImplementedWarning(VHDLModelWarning):
 @export
 class VHDLModelCriticalWarning(Warning):
 	"""
-	Base-class for warnings that likely indicate a defect in the model or its input.
+	Base-class for critical warnings that likely indicate a defect in the model or its input.
 
 	.. seealso::
 
@@ -88,15 +88,15 @@ class VHDLModelException(Exception):
 
 	.. seealso::
 
+	   * :class:`Library exists in design error <pyVHDLModel.Exception.LibraryExistsInDesignError>`
+	   * :class:`Registered to foreign design error <pyVHDLModel.Exception.LibraryRegisteredToForeignDesignError>`
+	   * :class:`Library not registered error <pyVHDLModel.Exception.LibraryNotRegisteredError>`
+	   * :class:`Entity exists in library error <pyVHDLModel.Exception.EntityExistsInLibraryError>`
 	   * :class:`Architecture exists in library error <pyVHDLModel.Exception.ArchitectureExistsInLibraryError>`
+	   * :class:`Package exists in library error <pyVHDLModel.Exception.PackageExistsInLibraryError>`
+	   * :class:`Package body exists error <pyVHDLModel.Exception.PackageBodyExistsError>`
 	   * :class:`Configuration exists in library error <pyVHDLModel.Exception.ConfigurationExistsInLibraryError>`
 	   * :class:`Context exists in library error <pyVHDLModel.Exception.ContextExistsInLibraryError>`
-	   * :class:`Entity exists in library error <pyVHDLModel.Exception.EntityExistsInLibraryError>`
-	   * :class:`Library exists in design error <pyVHDLModel.Exception.LibraryExistsInDesignError>`
-	   * :class:`Library not registered error <pyVHDLModel.Exception.LibraryNotRegisteredError>`
-	   * :class:`Library registered to foreign design error <pyVHDLModel.Exception.LibraryRegisteredToForeignDesignError>`
-	   * :class:`Package body exists error <pyVHDLModel.Exception.PackageBodyExistsError>`
-	   * :class:`Package exists in library error <pyVHDLModel.Exception.PackageExistsInLibraryError>`
 	   * :class:`Referenced library not existing error <pyVHDLModel.Exception.ReferencedLibraryNotExistingError>`
 	"""
 

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -635,7 +635,7 @@ class InverseExpression(UnaryExpression):
 @export
 class UnaryAndExpression(UnaryExpression):
 	"""
-	Represents a ``and`` reduction expression (VHDL-2008).
+	Represents a ``and`` reduction expression.
 
 	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
 
@@ -653,7 +653,7 @@ class UnaryAndExpression(UnaryExpression):
 @export
 class UnaryNandExpression(UnaryExpression):
 	"""
-	Represents a ``nand`` reduction expression (VHDL-2008).
+	Represents a ``nand`` reduction expression.
 
 	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
 
@@ -671,7 +671,7 @@ class UnaryNandExpression(UnaryExpression):
 @export
 class UnaryOrExpression(UnaryExpression):
 	"""
-	Represents a ``or`` reduction expression (VHDL-2008).
+	Represents a ``or`` reduction expression.
 
 	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
 
@@ -689,7 +689,7 @@ class UnaryOrExpression(UnaryExpression):
 @export
 class UnaryNorExpression(UnaryExpression):
 	"""
-	Represents a ``nor`` reduction expression (VHDL-2008).
+	Represents a ``nor`` reduction expression.
 
 	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
 
@@ -707,7 +707,7 @@ class UnaryNorExpression(UnaryExpression):
 @export
 class UnaryXorExpression(UnaryExpression):
 	"""
-	Represents a ``xor`` reduction expression (VHDL-2008).
+	Represents a ``xor`` reduction expression.
 
 	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
 
@@ -725,7 +725,7 @@ class UnaryXorExpression(UnaryExpression):
 @export
 class UnaryXnorExpression(UnaryExpression):
 	"""
-	Represents a ``xnor`` reduction expression (VHDL-2008).
+	Represents a ``xnor`` reduction expression.
 
 	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
 
@@ -1343,7 +1343,7 @@ class LessEqualExpression(RelationalExpression):
 @export
 class MatchingRelationalExpression(RelationalExpression):
 	"""
-	Represents the base-class of all matching relational expressions (VHDL-2008).
+	Represents the base-class of all matching relational expressions.
 
 	Matching operators return a ``bit``/``std_ulogic`` rather than a ``boolean``. Both operands are available as
 	:data:`LeftOperand` and :data:`RightOperand`.
@@ -1354,7 +1354,7 @@ class MatchingRelationalExpression(RelationalExpression):
 @export
 class MatchingEqualExpression(MatchingRelationalExpression):
 	"""
-	Represents a matching equality expression (``?=``, VHDL-2008).
+	Represents a matching equality expression (``?=``).
 
 	Unlike ``=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
 	and :data:`RightOperand`.
@@ -1374,7 +1374,7 @@ class MatchingEqualExpression(MatchingRelationalExpression):
 @export
 class MatchingUnequalExpression(MatchingRelationalExpression):
 	"""
-	Represents a matching inequality expression (``?/=``, VHDL-2008).
+	Represents a matching inequality expression (``?/=``).
 
 	Unlike ``/=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
 	:data:`LeftOperand` and :data:`RightOperand`.
@@ -1394,7 +1394,7 @@ class MatchingUnequalExpression(MatchingRelationalExpression):
 @export
 class MatchingGreaterThanExpression(MatchingRelationalExpression):
 	"""
-	Represents a matching greater-than expression (``?>``, VHDL-2008).
+	Represents a matching greater-than expression (``?>``).
 
 	Unlike ``>``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
 	and :data:`RightOperand`.
@@ -1414,7 +1414,7 @@ class MatchingGreaterThanExpression(MatchingRelationalExpression):
 @export
 class MatchingGreaterEqualExpression(MatchingRelationalExpression):
 	"""
-	Represents a matching greater-or-equal expression (``?>=``, VHDL-2008).
+	Represents a matching greater-or-equal expression (``?>=``).
 
 	Unlike ``>=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
 	:data:`LeftOperand` and :data:`RightOperand`.
@@ -1434,7 +1434,7 @@ class MatchingGreaterEqualExpression(MatchingRelationalExpression):
 @export
 class MatchingLessThanExpression(MatchingRelationalExpression):
 	"""
-	Represents a matching less-than expression (``?<``, VHDL-2008).
+	Represents a matching less-than expression (``?<``).
 
 	Unlike ``<``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
 	and :data:`RightOperand`.
@@ -1454,7 +1454,7 @@ class MatchingLessThanExpression(MatchingRelationalExpression):
 @export
 class MatchingLessEqualExpression(MatchingRelationalExpression):
 	"""
-	Represents a matching less-or-equal expression (``?<=``, VHDL-2008).
+	Represents a matching less-or-equal expression (``?<=``).
 
 	Unlike ``<=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
 	:data:`LeftOperand` and :data:`RightOperand`.
@@ -1718,7 +1718,7 @@ class TernaryExpression(BaseExpression):
 @export
 class WhenElseExpression(TernaryExpression):
 	"""
-	Represents a conditional expression (VHDL-2008).
+	Represents a conditional expression.
 
 	A conditional expression selects between two values (:data:`ThenValue`, :data:`ElseValue`) based on
 	a condition (:data:`Condition`). It is usable anywhere an expression is expected - distinct from

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -60,14 +60,14 @@ class BaseExpression(ModelEntity):
 
 	.. seealso::
 
-	   * :class:`Aggregate <pyVHDLModel.Expression.Aggregate>`
-	   * :class:`Allocation <pyVHDLModel.Expression.Allocation>`
-	   * :class:`Binary expression <pyVHDLModel.Expression.BinaryExpression>`
-	   * :class:`Function call <pyVHDLModel.Expression.FunctionCall>`
 	   * :class:`Literal <pyVHDLModel.Expression.Literal>`
+	   * :class:`Unary expression <pyVHDLModel.Expression.UnaryExpression>`
+	   * :class:`Binary expression <pyVHDLModel.Expression.BinaryExpression>`
 	   * :class:`Qualified expression <pyVHDLModel.Expression.QualifiedExpression>`
 	   * :class:`Ternary expression <pyVHDLModel.Expression.TernaryExpression>`
-	   * :class:`Unary expression <pyVHDLModel.Expression.UnaryExpression>`
+	   * :class:`Function call <pyVHDLModel.Expression.FunctionCall>`
+	   * :class:`Allocation <pyVHDLModel.Expression.Allocation>`
+	   * :class:`Aggregate <pyVHDLModel.Expression.Aggregate>`
 	"""
 
 
@@ -80,12 +80,12 @@ class Literal(BaseExpression):
 
 	.. seealso::
 
-	   * :class:`Bit string literal <pyVHDLModel.Expression.BitStringLiteral>`
-	   * :class:`Character literal <pyVHDLModel.Expression.CharacterLiteral>`
-	   * :class:`Enumeration literal <pyVHDLModel.Expression.EnumerationLiteral>`
 	   * :class:`Null literal <pyVHDLModel.Expression.NullLiteral>`
+	   * :class:`Enumeration literal <pyVHDLModel.Expression.EnumerationLiteral>`
 	   * :class:`Numeric literal <pyVHDLModel.Expression.NumericLiteral>`
+	   * :class:`Character literal <pyVHDLModel.Expression.CharacterLiteral>`
 	   * :class:`String literal <pyVHDLModel.Expression.StringLiteral>`
+	   * :class:`Bit string literal <pyVHDLModel.Expression.BitStringLiteral>`
 	"""
 
 
@@ -150,8 +150,8 @@ class NumericLiteral(Literal):
 
 	.. seealso::
 
-	   * :class:`Floating point literal <pyVHDLModel.Expression.FloatingPointLiteral>`
 	   * :class:`Integer literal <pyVHDLModel.Expression.IntegerLiteral>`
+	   * :class:`Floating point literal <pyVHDLModel.Expression.FloatingPointLiteral>`
 	   * :class:`Physical literal <pyVHDLModel.Expression.PhysicalLiteral>`
 	"""
 
@@ -239,8 +239,8 @@ class PhysicalLiteral(NumericLiteral):
 
 	.. seealso::
 
-	   * :class:`Physical floating literal <pyVHDLModel.Expression.PhysicalFloatingLiteral>`
 	   * :class:`Physical integer literal <pyVHDLModel.Expression.PhysicalIntegerLiteral>`
+	   * :class:`Physical floating literal <pyVHDLModel.Expression.PhysicalFloatingLiteral>`
 	"""
 	_unitName: str
 
@@ -423,9 +423,9 @@ class BitStringLiteral(Literal):
 	.. seealso::
 
 	   * :class:`Binary bit string literal <pyVHDLModel.Expression.BinaryBitStringLiteral>`
+	   * :class:`Octal bit string literal <pyVHDLModel.Expression.OctalBitStringLiteral>`
 	   * :class:`Decimal bit string literal <pyVHDLModel.Expression.DecimalBitStringLiteral>`
 	   * :class:`Hexadecimal bit string literal <pyVHDLModel.Expression.HexadecimalBitStringLiteral>`
-	   * :class:`Octal bit string literal <pyVHDLModel.Expression.OctalBitStringLiteral>`
 	"""
 	_value:       str
 	_binaryValue: str
@@ -576,8 +576,8 @@ class ParenthesisExpression: #(Protocol):
 
 	.. seealso::
 
-	   * :class:`Qualified expression <pyVHDLModel.Expression.QualifiedExpression>`
 	   * :class:`Sub expression <pyVHDLModel.Expression.SubExpression>`
+	   * :class:`Qualified expression <pyVHDLModel.Expression.QualifiedExpression>`
 	"""
 	__slots__ = ()  # FIXME: use ExtendedType?
 
@@ -632,9 +632,9 @@ class NegationExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      res := -a;
-	      --     ^^    <- the expression
-	      --      ^    <- Operand
+	      res := - operand;
+	      --     ^^^^^^^^^    <- the expression
+	      --       ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("-", "")
 
@@ -642,7 +642,7 @@ class NegationExpression(UnaryExpression):
 @export
 class IdentityExpression(UnaryExpression):
 	"""
-	Represents a identity (unary plus) expression.
+	Represents an identity (unary plus) expression.
 
 	The operand is available as :data:`Operand`.
 
@@ -650,9 +650,9 @@ class IdentityExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      res := +a;
-	      --     ^^    <- the expression
-	      --      ^    <- Operand
+	      res := + operand;
+	      --     ^^^^^^^^^    <- the expression
+	      --       ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("+", "")
 
@@ -668,9 +668,9 @@ class InverseExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := not f;
-	      --      ^^^^^    <- the expression
-	      --          ^    <- Operand
+	      bres := not boperand;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --          ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("not ", "")
 
@@ -680,15 +680,16 @@ class UnaryAndExpression(UnaryExpression):
 	"""
 	Represents a ``and`` reduction expression.
 
-	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+	A reduction operator folds all elements of an array into a single value.
+	The operand is available as :data:`Operand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := and v;
-	      --      ^^^^^    <- the expression
-	      --          ^    <- Operand
+	      sres := and voperand;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --          ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("and ", "")
 
@@ -698,15 +699,16 @@ class UnaryNandExpression(UnaryExpression):
 	"""
 	Represents a ``nand`` reduction expression.
 
-	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+	A reduction operator folds all elements of an array into a single value.
+	The operand is available as :data:`Operand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := nand v;
-	      --      ^^^^^^    <- the expression
-	      --           ^    <- Operand
+	      sres := nand voperand;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --           ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("nand ", "")
 
@@ -716,15 +718,16 @@ class UnaryOrExpression(UnaryExpression):
 	"""
 	Represents a ``or`` reduction expression.
 
-	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+	A reduction operator folds all elements of an array into a single value.
+	The operand is available as :data:`Operand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := or v;
-	      --      ^^^^    <- the expression
-	      --         ^    <- Operand
+	      sres := or voperand;
+	      --      ^^^^^^^^^^^    <- the expression
+	      --         ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("or ", "")
 
@@ -734,15 +737,16 @@ class UnaryNorExpression(UnaryExpression):
 	"""
 	Represents a ``nor`` reduction expression.
 
-	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+	A reduction operator folds all elements of an array into a single value.
+	The operand is available as :data:`Operand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := nor v;
-	      --      ^^^^^    <- the expression
-	      --          ^    <- Operand
+	      sres := nor voperand;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --          ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("nor ", "")
 
@@ -752,15 +756,16 @@ class UnaryXorExpression(UnaryExpression):
 	"""
 	Represents a ``xor`` reduction expression.
 
-	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+	A reduction operator folds all elements of an array into a single value.
+	The operand is available as :data:`Operand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := xor v;
-	      --      ^^^^^    <- the expression
-	      --          ^    <- Operand
+	      sres := xor voperand;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --          ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("xor ", "")
 
@@ -770,15 +775,16 @@ class UnaryXnorExpression(UnaryExpression):
 	"""
 	Represents a ``xnor`` reduction expression.
 
-	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+	A reduction operator folds all elements of an array into a single value.
+	The operand is available as :data:`Operand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := xnor v;
-	      --      ^^^^^^    <- the expression
-	      --           ^    <- Operand
+	      sres := xnor voperand;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --           ^^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("xnor ", "")
 
@@ -786,7 +792,7 @@ class UnaryXnorExpression(UnaryExpression):
 @export
 class AbsoluteExpression(UnaryExpression):
 	"""
-	Represents a absolute value expression (``abs``).
+	Represents an absolute value expression (``abs``).
 
 	The operand is available as :data:`Operand`.
 
@@ -794,9 +800,9 @@ class AbsoluteExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      res := abs a;
-	      --     ^^^^^    <- the expression
-	      --     ^        <- Operand
+	      res := abs operand;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --         ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("abs ", "")
 
@@ -814,9 +820,9 @@ class TypeConversion(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      res := integer(r);
-	      --     ^^^^^^^       <- TargetSubtype
-	      --^                  <- Operand
+	      res := integer(realval);
+	      --     ^^^^^^^             <- TargetSubtype
+	      --             ^^^^^^^     <- Operand
 	"""
 
 	_targetSubtype: SubtypeSymbol
@@ -851,9 +857,9 @@ class SubExpression(UnaryExpression, ParenthesisExpression):
 
 	   .. code-block:: VHDL
 
-	      res := (a + b);
-	      --     ^^^^^^^    <- the sub-expression
-	      --      ^^^^^     <- Operand
+	      res := (lhs + rhs);
+	      --     ^^^^^^^^^^^    <- the sub-expression
+	      --      ^^^^^^^^^     <- Operand
 	"""
 	_FORMAT = ("(", ")")
 
@@ -867,10 +873,10 @@ class BinaryExpression(BaseExpression):
 
 	.. seealso::
 
-	   * :class:`Adding expression <pyVHDLModel.Expression.AddingExpression>`
-	   * :class:`Logical expression <pyVHDLModel.Expression.LogicalExpression>`
-	   * :class:`Multiplying expression <pyVHDLModel.Expression.MultiplyingExpression>`
 	   * :class:`Range expression <pyVHDLModel.Expression.RangeExpression>`
+	   * :class:`Adding expression <pyVHDLModel.Expression.AddingExpression>`
+	   * :class:`Multiplying expression <pyVHDLModel.Expression.MultiplyingExpression>`
+	   * :class:`Logical expression <pyVHDLModel.Expression.LogicalExpression>`
 	   * :class:`Relational expression <pyVHDLModel.Expression.RelationalExpression>`
 	   * :class:`Shift expression <pyVHDLModel.Expression.ShiftExpression>`
 	"""
@@ -991,8 +997,8 @@ class AddingExpression(BinaryExpression):
 	.. seealso::
 
 	   * :class:`Addition expression <pyVHDLModel.Expression.AdditionExpression>`
-	   * :class:`Concatenation expression <pyVHDLModel.Expression.ConcatenationExpression>`
 	   * :class:`Subtraction expression <pyVHDLModel.Expression.SubtractionExpression>`
+	   * :class:`Concatenation expression <pyVHDLModel.Expression.ConcatenationExpression>`
 	"""
 
 
@@ -1007,10 +1013,10 @@ class AdditionExpression(AddingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a + b;
-	      --     ^^^^^    <- the expression
-	      --     ^        <- LeftOperand
-	      --         ^    <- RightOperand
+	      res := lhs + rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " + ", "")
 
@@ -1026,10 +1032,10 @@ class SubtractionExpression(AddingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a - b;
-	      --     ^^^^^    <- the expression
-	      --     ^        <- LeftOperand
-	      --         ^    <- RightOperand
+	      res := lhs - rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " - ", "")
 
@@ -1045,10 +1051,10 @@ class ConcatenationExpression(AddingExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v & w;
-	      --      ^^^^^    <- the expression
-	      --^              <- LeftOperand
-	      --          ^    <- RightOperand
+	      vres := vlhs & vrhs;
+	      --      ^^^^^^^^^^^    <- the expression
+	      --      ^^^^           <- LeftOperand
+	      --             ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " & ", "")
 
@@ -1062,11 +1068,11 @@ class MultiplyingExpression(BinaryExpression):
 
 	.. seealso::
 
-	   * :class:`Division expression <pyVHDLModel.Expression.DivisionExpression>`
-	   * :class:`Exponentiation expression <pyVHDLModel.Expression.ExponentiationExpression>`
-	   * :class:`Modulo expression <pyVHDLModel.Expression.ModuloExpression>`
 	   * :class:`Multiply expression <pyVHDLModel.Expression.MultiplyExpression>`
+	   * :class:`Division expression <pyVHDLModel.Expression.DivisionExpression>`
 	   * :class:`Remainder expression <pyVHDLModel.Expression.RemainderExpression>`
+	   * :class:`Modulo expression <pyVHDLModel.Expression.ModuloExpression>`
+	   * :class:`Exponentiation expression <pyVHDLModel.Expression.ExponentiationExpression>`
 	"""
 
 
@@ -1081,10 +1087,10 @@ class MultiplyExpression(MultiplyingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a * b;
-	      --     ^^^^^    <- the expression
-	      --     ^        <- LeftOperand
-	      --         ^    <- RightOperand
+	      res := lhs * rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " * ", "")
 
@@ -1100,10 +1106,10 @@ class DivisionExpression(MultiplyingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a / b;
-	      --     ^^^^^    <- the expression
-	      --     ^        <- LeftOperand
-	      --         ^    <- RightOperand
+	      res := lhs / rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " / ", "")
 
@@ -1119,10 +1125,10 @@ class RemainderExpression(MultiplyingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a rem b;
-	      --     ^^^^^^^    <- the expression
-	      --     ^          <- LeftOperand
-	      --           ^    <- RightOperand
+	      res := lhs rem rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " rem ", "")
 
@@ -1138,10 +1144,10 @@ class ModuloExpression(MultiplyingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a mod b;
-	      --     ^^^^^^^    <- the expression
-	      --     ^          <- LeftOperand
-	      --           ^    <- RightOperand
+	      res := lhs mod rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " mod ", "")
 
@@ -1157,10 +1163,10 @@ class ExponentiationExpression(MultiplyingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := a ** 2;
-	      --     ^^^^^^    <- the expression
-	      --     ^         <- LeftOperand
-	      --          ^    <- RightOperand
+	      res := lhs ** 2;
+	      --     ^^^^^^^^    <- the expression
+	      --     ^^^         <- LeftOperand
+	      --            ^    <- RightOperand
 	"""
 	_FORMAT = ("", "**", "")
 
@@ -1176,10 +1182,10 @@ class LogicalExpression(BinaryExpression):
 
 	   * :class:`And expression <pyVHDLModel.Expression.AndExpression>`
 	   * :class:`Nand expression <pyVHDLModel.Expression.NandExpression>`
-	   * :class:`Nor expression <pyVHDLModel.Expression.NorExpression>`
 	   * :class:`Or expression <pyVHDLModel.Expression.OrExpression>`
-	   * :class:`Xnor expression <pyVHDLModel.Expression.XnorExpression>`
+	   * :class:`Nor expression <pyVHDLModel.Expression.NorExpression>`
 	   * :class:`Xor expression <pyVHDLModel.Expression.XorExpression>`
+	   * :class:`Xnor expression <pyVHDLModel.Expression.XnorExpression>`
 	"""
 
 
@@ -1194,10 +1200,10 @@ class AndExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := f and g;
-	      --      ^^^^^^^    <- the expression
-	      --      ^          <- LeftOperand
-	      --            ^    <- RightOperand
+	      bres := blhs and brhs;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^             <- LeftOperand
+	      --               ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " and ", "")
 
@@ -1213,10 +1219,10 @@ class NandExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := f nand g;
-	      --      ^^^^^^^^    <- the expression
-	      --      ^           <- LeftOperand
-	      --             ^    <- RightOperand
+	      bres := blhs nand brhs;
+	      --      ^^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^              <- LeftOperand
+	      --                ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " nand ", "")
 
@@ -1232,10 +1238,10 @@ class OrExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := f or g;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --           ^    <- RightOperand
+	      bres := blhs or brhs;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --      ^^^^            <- LeftOperand
+	      --              ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " or ", "")
 
@@ -1251,10 +1257,10 @@ class NorExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := f nor g;
-	      --      ^^^^^^^    <- the expression
-	      --      ^          <- LeftOperand
-	      --            ^    <- RightOperand
+	      bres := blhs nor brhs;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^             <- LeftOperand
+	      --               ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " nor ", "")
 
@@ -1270,10 +1276,10 @@ class XorExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := f xor g;
-	      --      ^^^^^^^    <- the expression
-	      --      ^          <- LeftOperand
-	      --            ^    <- RightOperand
+	      bres := blhs xor brhs;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^             <- LeftOperand
+	      --               ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " xor ", "")
 
@@ -1289,10 +1295,10 @@ class XnorExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := f xnor g;
-	      --      ^^^^^^^^    <- the expression
-	      --      ^           <- LeftOperand
-	      --             ^    <- RightOperand
+	      bres := blhs xnor brhs;
+	      --      ^^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^              <- LeftOperand
+	      --                ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " xnor ", "")
 
@@ -1307,12 +1313,12 @@ class RelationalExpression(BinaryExpression):
 	.. seealso::
 
 	   * :class:`Equal expression <pyVHDLModel.Expression.EqualExpression>`
-	   * :class:`Greater equal expression <pyVHDLModel.Expression.GreaterEqualExpression>`
-	   * :class:`Greater than expression <pyVHDLModel.Expression.GreaterThanExpression>`
-	   * :class:`Less equal expression <pyVHDLModel.Expression.LessEqualExpression>`
-	   * :class:`Less than expression <pyVHDLModel.Expression.LessThanExpression>`
-	   * :class:`Matching relational expression <pyVHDLModel.Expression.MatchingRelationalExpression>`
 	   * :class:`Unequal expression <pyVHDLModel.Expression.UnequalExpression>`
+	   * :class:`Greater than expression <pyVHDLModel.Expression.GreaterThanExpression>`
+	   * :class:`Greater equal expression <pyVHDLModel.Expression.GreaterEqualExpression>`
+	   * :class:`Less than expression <pyVHDLModel.Expression.LessThanExpression>`
+	   * :class:`Less equal expression <pyVHDLModel.Expression.LessEqualExpression>`
+	   * :class:`Matching relational expression <pyVHDLModel.Expression.MatchingRelationalExpression>`
 	"""
 
 
@@ -1327,10 +1333,10 @@ class EqualExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := a = b;
-	      --      ^^^^^    <- the expression
-	      --      ^        <- LeftOperand
-	      --^              <- RightOperand
+	      bres := lhs = rhs;
+	      --      ^^^^^^^^^    <- the expression
+	      --      ^^^          <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " = ", "")
 
@@ -1346,10 +1352,10 @@ class UnequalExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := a /= b;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --^               <- RightOperand
+	      bres := lhs /= rhs;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^           <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " /= ", "")
 
@@ -1365,10 +1371,10 @@ class GreaterThanExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := a > b;
-	      --      ^^^^^    <- the expression
-	      --      ^        <- LeftOperand
-	      --^              <- RightOperand
+	      bres := lhs > rhs;
+	      --      ^^^^^^^^^    <- the expression
+	      --      ^^^          <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " > ", "")
 
@@ -1384,10 +1390,10 @@ class GreaterEqualExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := a >= b;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --^               <- RightOperand
+	      bres := lhs >= rhs;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^           <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " >= ", "")
 
@@ -1403,10 +1409,10 @@ class LessThanExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := a < b;
-	      --      ^^^^^    <- the expression
-	      --      ^        <- LeftOperand
-	      --^              <- RightOperand
+	      bres := lhs < rhs;
+	      --      ^^^^^^^^^    <- the expression
+	      --      ^^^          <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " < ", "")
 
@@ -1422,10 +1428,10 @@ class LessEqualExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := a <= b;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --^               <- RightOperand
+	      bres := lhs <= rhs;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^           <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " <= ", "")
 
@@ -1441,11 +1447,11 @@ class MatchingRelationalExpression(RelationalExpression):
 	.. seealso::
 
 	   * :class:`Matching equal expression <pyVHDLModel.Expression.MatchingEqualExpression>`
-	   * :class:`Matching greater equal expression <pyVHDLModel.Expression.MatchingGreaterEqualExpression>`
-	   * :class:`Matching greater than expression <pyVHDLModel.Expression.MatchingGreaterThanExpression>`
-	   * :class:`Matching less equal expression <pyVHDLModel.Expression.MatchingLessEqualExpression>`
-	   * :class:`Matching less than expression <pyVHDLModel.Expression.MatchingLessThanExpression>`
 	   * :class:`Matching unequal expression <pyVHDLModel.Expression.MatchingUnequalExpression>`
+	   * :class:`Matching greater than expression <pyVHDLModel.Expression.MatchingGreaterThanExpression>`
+	   * :class:`Matching greater equal expression <pyVHDLModel.Expression.MatchingGreaterEqualExpression>`
+	   * :class:`Matching less than expression <pyVHDLModel.Expression.MatchingLessThanExpression>`
+	   * :class:`Matching less equal expression <pyVHDLModel.Expression.MatchingLessEqualExpression>`
 	"""
 	pass
 
@@ -1455,17 +1461,17 @@ class MatchingEqualExpression(MatchingRelationalExpression):
 	"""
 	Represents a matching equality expression (``?=``).
 
-	Unlike ``=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
-	and :data:`RightOperand`.
+	Unlike ``=``, a matching operator returns a ``bit``/``std_ulogic``.
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := v ?= w;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --           ^    <- RightOperand
+	      sres := vlhs ?= vrhs;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --      ^^^^            <- LeftOperand
+	      --              ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?= ", "")
 
@@ -1475,17 +1481,17 @@ class MatchingUnequalExpression(MatchingRelationalExpression):
 	"""
 	Represents a matching inequality expression (``?/=``).
 
-	Unlike ``/=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
-	:data:`LeftOperand` and :data:`RightOperand`.
+	Unlike ``/=``, a matching operator returns a ``bit``/``std_ulogic``.
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := v ?/= w;
-	      --      ^^^^^^^    <- the expression
-	      --      ^          <- LeftOperand
-	      --            ^    <- RightOperand
+	      sres := vlhs ?/= vrhs;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^             <- LeftOperand
+	      --               ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?/= ", "")
 
@@ -1495,17 +1501,17 @@ class MatchingGreaterThanExpression(MatchingRelationalExpression):
 	"""
 	Represents a matching greater-than expression (``?>``).
 
-	Unlike ``>``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
-	and :data:`RightOperand`.
+	Unlike ``>``, a matching operator returns a ``bit``/``std_ulogic``.
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := v ?> w;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --           ^    <- RightOperand
+	      sres := vlhs ?> vrhs;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --      ^^^^            <- LeftOperand
+	      --              ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?> ", "")
 
@@ -1515,17 +1521,17 @@ class MatchingGreaterEqualExpression(MatchingRelationalExpression):
 	"""
 	Represents a matching greater-or-equal expression (``?>=``).
 
-	Unlike ``>=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
-	:data:`LeftOperand` and :data:`RightOperand`.
+	Unlike ``>=``, a matching operator returns a ``bit``/``std_ulogic``.
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := v ?>= w;
-	      --      ^^^^^^^    <- the expression
-	      --      ^          <- LeftOperand
-	      --            ^    <- RightOperand
+	      sres := vlhs ?>= vrhs;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^             <- LeftOperand
+	      --               ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?>= ", "")
 
@@ -1535,17 +1541,17 @@ class MatchingLessThanExpression(MatchingRelationalExpression):
 	"""
 	Represents a matching less-than expression (``?<``).
 
-	Unlike ``<``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
-	and :data:`RightOperand`.
+	Unlike ``<``, a matching operator returns a ``bit``/``std_ulogic``.
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := v ?< w;
-	      --      ^^^^^^    <- the expression
-	      --      ^         <- LeftOperand
-	      --           ^    <- RightOperand
+	      sres := vlhs ?< vrhs;
+	      --      ^^^^^^^^^^^^    <- the expression
+	      --      ^^^^            <- LeftOperand
+	      --              ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?< ", "")
 
@@ -1555,17 +1561,17 @@ class MatchingLessEqualExpression(MatchingRelationalExpression):
 	"""
 	Represents a matching less-or-equal expression (``?<=``).
 
-	Unlike ``<=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
-	:data:`LeftOperand` and :data:`RightOperand`.
+	Unlike ``<=``, a matching operator returns a ``bit``/``std_ulogic``.
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      sres := v ?<= w;
-	      --      ^^^^^^^    <- the expression
-	      --      ^          <- LeftOperand
-	      --            ^    <- RightOperand
+	      sres := vlhs ?<= vrhs;
+	      --      ^^^^^^^^^^^^^    <- the expression
+	      --      ^^^^             <- LeftOperand
+	      --               ^^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?<= ", "")
 
@@ -1579,9 +1585,9 @@ class ShiftExpression(BinaryExpression):
 
 	.. seealso::
 
-	   * :class:`Rotate expression <pyVHDLModel.Expression.RotateExpression>`
-	   * :class:`Shift arithmetic expression <pyVHDLModel.Expression.ShiftArithmeticExpression>`
 	   * :class:`Shift logic expression <pyVHDLModel.Expression.ShiftLogicExpression>`
+	   * :class:`Shift arithmetic expression <pyVHDLModel.Expression.ShiftArithmeticExpression>`
+	   * :class:`Rotate expression <pyVHDLModel.Expression.RotateExpression>`
 	"""
 
 
@@ -1594,8 +1600,8 @@ class ShiftLogicExpression(ShiftExpression):
 
 	.. seealso::
 
-	   * :class:`Shift left logic expression <pyVHDLModel.Expression.ShiftLeftLogicExpression>`
 	   * :class:`Shift right logic expression <pyVHDLModel.Expression.ShiftRightLogicExpression>`
+	   * :class:`Shift left logic expression <pyVHDLModel.Expression.ShiftLeftLogicExpression>`
 	"""
 	pass
 
@@ -1609,8 +1615,8 @@ class ShiftArithmeticExpression(ShiftExpression):
 
 	.. seealso::
 
-	   * :class:`Shift left arithmetic expression <pyVHDLModel.Expression.ShiftLeftArithmeticExpression>`
 	   * :class:`Shift right arithmetic expression <pyVHDLModel.Expression.ShiftRightArithmeticExpression>`
+	   * :class:`Shift left arithmetic expression <pyVHDLModel.Expression.ShiftLeftArithmeticExpression>`
 	"""
 	pass
 
@@ -1624,8 +1630,8 @@ class RotateExpression(ShiftExpression):
 
 	.. seealso::
 
-	   * :class:`Rotate left expression <pyVHDLModel.Expression.RotateLeftExpression>`
 	   * :class:`Rotate right expression <pyVHDLModel.Expression.RotateRightExpression>`
+	   * :class:`Rotate left expression <pyVHDLModel.Expression.RotateLeftExpression>`
 	"""
 	pass
 
@@ -1641,10 +1647,10 @@ class ShiftRightLogicExpression(ShiftLogicExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v srl 1;
-	      --      ^^^^^^^    <- the expression
-	      --^                <- LeftOperand
-	      --            ^    <- RightOperand
+	      vres := vlhs srl 1;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^^          <- LeftOperand
+	      --               ^    <- RightOperand
 	"""
 	_FORMAT = ("", " srl ", "")
 
@@ -1660,10 +1666,10 @@ class ShiftLeftLogicExpression(ShiftLogicExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v sll 1;
-	      --      ^^^^^^^    <- the expression
-	      --^                <- LeftOperand
-	      --            ^    <- RightOperand
+	      vres := vlhs sll 1;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^^          <- LeftOperand
+	      --               ^    <- RightOperand
 	"""
 	_FORMAT = ("", " sll ", "")
 
@@ -1679,10 +1685,10 @@ class ShiftRightArithmeticExpression(ShiftArithmeticExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v sra 1;
-	      --      ^^^^^^^    <- the expression
-	      --^                <- LeftOperand
-	      --            ^    <- RightOperand
+	      vres := vlhs sra 1;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^^          <- LeftOperand
+	      --               ^    <- RightOperand
 	"""
 	_FORMAT = ("", " sra ", "")
 
@@ -1698,10 +1704,10 @@ class ShiftLeftArithmeticExpression(ShiftArithmeticExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v sla 1;
-	      --      ^^^^^^^    <- the expression
-	      --^                <- LeftOperand
-	      --            ^    <- RightOperand
+	      vres := vlhs sla 1;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^^          <- LeftOperand
+	      --               ^    <- RightOperand
 	"""
 	_FORMAT = ("", " sla ", "")
 
@@ -1717,10 +1723,10 @@ class RotateRightExpression(RotateExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v ror 1;
-	      --      ^^^^^^^    <- the expression
-	      --^                <- LeftOperand
-	      --            ^    <- RightOperand
+	      vres := vlhs ror 1;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^^          <- LeftOperand
+	      --               ^    <- RightOperand
 	"""
 	_FORMAT = ("", " ror ", "")
 
@@ -1736,10 +1742,10 @@ class RotateLeftExpression(RotateExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v rol 1;
-	      --      ^^^^^^^    <- the expression
-	      --^                <- LeftOperand
-	      --            ^    <- RightOperand
+	      vres := vlhs rol 1;
+	      --      ^^^^^^^^^^    <- the expression
+	      --      ^^^^          <- LeftOperand
+	      --               ^    <- RightOperand
 	"""
 	_FORMAT = ("", " rol ", "")
 
@@ -1920,8 +1926,8 @@ class Allocation(BaseExpression):
 
 	.. seealso::
 
-	   * :class:`Qualified expression allocation <pyVHDLModel.Expression.QualifiedExpressionAllocation>`
 	   * :class:`Subtype allocation <pyVHDLModel.Expression.SubtypeAllocation>`
+	   * :class:`Qualified expression allocation <pyVHDLModel.Expression.QualifiedExpressionAllocation>`
 	"""
 	pass
 
@@ -2005,11 +2011,11 @@ class AggregateElement(ModelEntity):
 
 	.. seealso::
 
+	   * :class:`Simple aggregate element <pyVHDLModel.Expression.SimpleAggregateElement>`
 	   * :class:`Indexed aggregate element <pyVHDLModel.Expression.IndexedAggregateElement>`
+	   * :class:`Ranged aggregate element <pyVHDLModel.Expression.RangedAggregateElement>`
 	   * :class:`Named aggregate element <pyVHDLModel.Expression.NamedAggregateElement>`
 	   * :class:`Others aggregate element <pyVHDLModel.Expression.OthersAggregateElement>`
-	   * :class:`Ranged aggregate element <pyVHDLModel.Expression.RangedAggregateElement>`
-	   * :class:`Simple aggregate element <pyVHDLModel.Expression.SimpleAggregateElement>`
 	"""
 
 	_expression: ExpressionUnion

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -417,8 +417,8 @@ class BitStringLiteral(Literal):
 
 	   .. code-block:: VHDL
 
-	      vres := b"10100000";
-	      --      ^^^^^^^^^^^    <- Value
+	      res := b"10100000";
+	      --     ^^^^^^^^^^^    <- Value
 
 	.. seealso::
 
@@ -512,8 +512,8 @@ class BinaryBitStringLiteral(BitStringLiteral):
 
 	   .. code-block:: VHDL
 
-	      vres := b"10100000";
-	      --      ^^^^^^^^^^^    <- Value
+	      res := b"10100000";
+	      --     ^^^^^^^^^^^    <- Value
 	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Binary
 
@@ -544,8 +544,8 @@ class DecimalBitStringLiteral(BitStringLiteral):
 
 	   .. code-block:: VHDL
 
-	      vres := d"160";
-	      --      ^^^^^^    <- Value
+	      res := d"160";
+	      --     ^^^^^^    <- Value
 	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Decimal
 
@@ -561,8 +561,8 @@ class HexadecimalBitStringLiteral(BitStringLiteral):
 
 	   .. code-block:: VHDL
 
-	      vres := x"A0";
-	      --      ^^^^^    <- Value
+	      res := x"A0";
+	      --     ^^^^^    <- Value
 	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Hexadecimal
 
@@ -668,9 +668,9 @@ class InverseExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := not boperand;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --          ^^^^^^^^    <- Operand
+	      res := not operand;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --         ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("not ", "")
 
@@ -687,9 +687,9 @@ class UnaryAndExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := and voperand;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --          ^^^^^^^^    <- Operand
+	      res := and operand;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --         ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("and ", "")
 
@@ -706,9 +706,9 @@ class UnaryNandExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := nand voperand;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --           ^^^^^^^^    <- Operand
+	      res := nand operand;
+	      --     ^^^^^^^^^^^^    <- the expression
+	      --          ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("nand ", "")
 
@@ -725,9 +725,9 @@ class UnaryOrExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := or voperand;
-	      --      ^^^^^^^^^^^    <- the expression
-	      --         ^^^^^^^^    <- Operand
+	      res := or operand;
+	      --     ^^^^^^^^^^    <- the expression
+	      --        ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("or ", "")
 
@@ -744,9 +744,9 @@ class UnaryNorExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := nor voperand;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --          ^^^^^^^^    <- Operand
+	      res := nor operand;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --         ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("nor ", "")
 
@@ -763,9 +763,9 @@ class UnaryXorExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := xor voperand;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --          ^^^^^^^^    <- Operand
+	      res := xor operand;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --         ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("xor ", "")
 
@@ -782,9 +782,9 @@ class UnaryXnorExpression(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := xnor voperand;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --           ^^^^^^^^    <- Operand
+	      res := xnor operand;
+	      --     ^^^^^^^^^^^^    <- the expression
+	      --          ^^^^^^^    <- Operand
 	"""
 	_FORMAT = ("xnor ", "")
 
@@ -820,9 +820,9 @@ class TypeConversion(UnaryExpression):
 
 	   .. code-block:: VHDL
 
-	      res := integer(realval);
-	      --     ^^^^^^^             <- TargetSubtype
-	      --             ^^^^^^^     <- Operand
+	      res := integer(val);
+	      --     ^^^^^^^         <- TargetSubtype
+	      --             ^^^     <- Operand
 	"""
 
 	_targetSubtype: SubtypeSymbol
@@ -958,10 +958,10 @@ class AscendingRangeExpression(RangeExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v(0 to 3);
-	      --        ^^^^^^     <- the range
-	      --        ^          <- LeftOperand
-	      --             ^     <- RightOperand
+	      res := v(0 to 3);
+	      --       ^^^^^^     <- the range
+	      --       ^          <- LeftOperand
+	      --            ^     <- RightOperand
 	"""
 	_direction = Direction.To
 	_FORMAT = ("", " to ", "")
@@ -978,10 +978,10 @@ class DescendingRangeExpression(RangeExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := v(7 downto 4);
-	      --        ^^^^^^^^^^     <- the range
-	      --        ^              <- LeftOperand
-	      --                 ^     <- RightOperand
+	      res := v(7 downto 4);
+	      --       ^^^^^^^^^^     <- the range
+	      --       ^              <- LeftOperand
+	      --                ^     <- RightOperand
 	"""
 	_direction = Direction.DownTo
 	_FORMAT = ("", " downto ", "")
@@ -1051,10 +1051,10 @@ class ConcatenationExpression(AddingExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs & vrhs;
-	      --      ^^^^^^^^^^^    <- the expression
-	      --      ^^^^           <- LeftOperand
-	      --             ^^^^    <- RightOperand
+	      res := lhs & rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " & ", "")
 
@@ -1163,10 +1163,10 @@ class ExponentiationExpression(MultiplyingExpression):
 
 	   .. code-block:: VHDL
 
-	      res := lhs ** 2;
-	      --     ^^^^^^^^    <- the expression
-	      --     ^^^         <- LeftOperand
-	      --            ^    <- RightOperand
+	      res := lhs ** rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", "**", "")
 
@@ -1200,10 +1200,10 @@ class AndExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := blhs and brhs;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^             <- LeftOperand
-	      --               ^^^^    <- RightOperand
+	      res := lhs and rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " and ", "")
 
@@ -1219,10 +1219,10 @@ class NandExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := blhs nand brhs;
-	      --      ^^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^              <- LeftOperand
-	      --                ^^^^    <- RightOperand
+	      res := lhs nand rhs;
+	      --     ^^^^^^^^^^^^    <- the expression
+	      --     ^^^             <- LeftOperand
+	      --              ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " nand ", "")
 
@@ -1238,10 +1238,10 @@ class OrExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := blhs or brhs;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --      ^^^^            <- LeftOperand
-	      --              ^^^^    <- RightOperand
+	      res := lhs or rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " or ", "")
 
@@ -1257,10 +1257,10 @@ class NorExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := blhs nor brhs;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^             <- LeftOperand
-	      --               ^^^^    <- RightOperand
+	      res := lhs nor rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " nor ", "")
 
@@ -1276,10 +1276,10 @@ class XorExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := blhs xor brhs;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^             <- LeftOperand
-	      --               ^^^^    <- RightOperand
+	      res := lhs xor rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " xor ", "")
 
@@ -1295,10 +1295,10 @@ class XnorExpression(LogicalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := blhs xnor brhs;
-	      --      ^^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^              <- LeftOperand
-	      --                ^^^^    <- RightOperand
+	      res := lhs xnor rhs;
+	      --     ^^^^^^^^^^^^    <- the expression
+	      --     ^^^             <- LeftOperand
+	      --              ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " xnor ", "")
 
@@ -1333,10 +1333,10 @@ class EqualExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := lhs = rhs;
-	      --      ^^^^^^^^^    <- the expression
-	      --      ^^^          <- LeftOperand
-	      --            ^^^    <- RightOperand
+	      res := lhs = rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " = ", "")
 
@@ -1352,10 +1352,10 @@ class UnequalExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := lhs /= rhs;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^           <- LeftOperand
-	      --             ^^^    <- RightOperand
+	      res := lhs /= rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " /= ", "")
 
@@ -1371,10 +1371,10 @@ class GreaterThanExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := lhs > rhs;
-	      --      ^^^^^^^^^    <- the expression
-	      --      ^^^          <- LeftOperand
-	      --            ^^^    <- RightOperand
+	      res := lhs > rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " > ", "")
 
@@ -1390,10 +1390,10 @@ class GreaterEqualExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := lhs >= rhs;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^           <- LeftOperand
-	      --             ^^^    <- RightOperand
+	      res := lhs >= rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " >= ", "")
 
@@ -1409,10 +1409,10 @@ class LessThanExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := lhs < rhs;
-	      --      ^^^^^^^^^    <- the expression
-	      --      ^^^          <- LeftOperand
-	      --            ^^^    <- RightOperand
+	      res := lhs < rhs;
+	      --     ^^^^^^^^^    <- the expression
+	      --     ^^^          <- LeftOperand
+	      --           ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " < ", "")
 
@@ -1428,10 +1428,10 @@ class LessEqualExpression(RelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      bres := lhs <= rhs;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^           <- LeftOperand
-	      --             ^^^    <- RightOperand
+	      res := lhs <= rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " <= ", "")
 
@@ -1468,10 +1468,10 @@ class MatchingEqualExpression(MatchingRelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := vlhs ?= vrhs;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --      ^^^^            <- LeftOperand
-	      --              ^^^^    <- RightOperand
+	      res := lhs ?= rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?= ", "")
 
@@ -1488,10 +1488,10 @@ class MatchingUnequalExpression(MatchingRelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := vlhs ?/= vrhs;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^             <- LeftOperand
-	      --               ^^^^    <- RightOperand
+	      res := lhs ?/= rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?/= ", "")
 
@@ -1508,10 +1508,10 @@ class MatchingGreaterThanExpression(MatchingRelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := vlhs ?> vrhs;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --      ^^^^            <- LeftOperand
-	      --              ^^^^    <- RightOperand
+	      res := lhs ?> rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?> ", "")
 
@@ -1528,10 +1528,10 @@ class MatchingGreaterEqualExpression(MatchingRelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := vlhs ?>= vrhs;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^             <- LeftOperand
-	      --               ^^^^    <- RightOperand
+	      res := lhs ?>= rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?>= ", "")
 
@@ -1548,10 +1548,10 @@ class MatchingLessThanExpression(MatchingRelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := vlhs ?< vrhs;
-	      --      ^^^^^^^^^^^^    <- the expression
-	      --      ^^^^            <- LeftOperand
-	      --              ^^^^    <- RightOperand
+	      res := lhs ?< rhs;
+	      --     ^^^^^^^^^^    <- the expression
+	      --     ^^^           <- LeftOperand
+	      --            ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?< ", "")
 
@@ -1568,10 +1568,10 @@ class MatchingLessEqualExpression(MatchingRelationalExpression):
 
 	   .. code-block:: VHDL
 
-	      sres := vlhs ?<= vrhs;
-	      --      ^^^^^^^^^^^^^    <- the expression
-	      --      ^^^^             <- LeftOperand
-	      --               ^^^^    <- RightOperand
+	      res := lhs ?<= rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ?<= ", "")
 
@@ -1647,10 +1647,10 @@ class ShiftRightLogicExpression(ShiftLogicExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs srl 1;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^^          <- LeftOperand
-	      --               ^    <- RightOperand
+	      res := lhs srl rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " srl ", "")
 
@@ -1666,10 +1666,10 @@ class ShiftLeftLogicExpression(ShiftLogicExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs sll 1;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^^          <- LeftOperand
-	      --               ^    <- RightOperand
+	      res := lhs sll rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " sll ", "")
 
@@ -1685,10 +1685,10 @@ class ShiftRightArithmeticExpression(ShiftArithmeticExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs sra 1;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^^          <- LeftOperand
-	      --               ^    <- RightOperand
+	      res := lhs sra rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " sra ", "")
 
@@ -1704,10 +1704,10 @@ class ShiftLeftArithmeticExpression(ShiftArithmeticExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs sla 1;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^^          <- LeftOperand
-	      --               ^    <- RightOperand
+	      res := lhs sla rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " sla ", "")
 
@@ -1723,10 +1723,10 @@ class RotateRightExpression(RotateExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs ror 1;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^^          <- LeftOperand
-	      --               ^    <- RightOperand
+	      res := lhs ror rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " ror ", "")
 
@@ -1742,10 +1742,10 @@ class RotateLeftExpression(RotateExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := vlhs rol 1;
-	      --      ^^^^^^^^^^    <- the expression
-	      --      ^^^^          <- LeftOperand
-	      --               ^    <- RightOperand
+	      res := lhs rol rhs;
+	      --     ^^^^^^^^^^^    <- the expression
+	      --     ^^^            <- LeftOperand
+	      --             ^^^    <- RightOperand
 	"""
 	_FORMAT = ("", " rol ", "")
 
@@ -1762,9 +1762,9 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := byte'(others => '0');
-	      --      ^^^^                    <- Subtype
-	      --           ^^^^^^^^^^^^^^^    <- Operand
+	      res := byte'(others => '0');
+	      --     ^^^^                    <- Subtype
+	      --          ^^^^^^^^^^^^^^^    <- Operand
 	"""
 	_operand:  ExpressionUnion
 	_subtype:  Symbol
@@ -2047,8 +2047,8 @@ class SimpleAggregateElement(AggregateElement):
 
 	   .. code-block:: VHDL
 
-	      vres := ('1', '0', '1', '0', '1', '0', '1', '0');
-	      --       ^^^                                        <- Expression
+	      res := ('1', '0', '1', '0', '1', '0', '1', '0');
+	      --      ^^^                                        <- Expression
 	"""
 	def __str__(self) -> str:
 		return str(self._expression)
@@ -2065,9 +2065,9 @@ class IndexedAggregateElement(AggregateElement):
 
 	   .. code-block:: VHDL
 
-	      vres := (0 => '1', others => '0');
-	      --       ^                           <- Index
-	      --            ^^^                    <- Expression
+	      res := (0 => '1', others => '0');
+	      --      ^                           <- Index
+	      --           ^^^                    <- Expression
 	"""
 	_index: int
 
@@ -2100,9 +2100,9 @@ class RangedAggregateElement(AggregateElement):
 
 	   .. code-block:: VHDL
 
-	      vres := (1 to 3 => '0', others => '1');
-	      --       ^^^^^^                           <- Range
-	      --                 ^^^                    <- Expression
+	      res := (1 to 3 => '0', others => '1');
+	      --      ^^^^^^                           <- Range
+	      --                ^^^                    <- Expression
 	"""
 	_range: Range
 
@@ -2175,9 +2175,9 @@ class OthersAggregateElement(AggregateElement):
 
 	   .. code-block:: VHDL
 
-	      vres := (0 => '1', others => '0');
-	      --                 ^^^^^^            <- the choice
-	      --                           ^^^     <- Expression
+	      res := (0 => '1', others => '0');
+	      --                ^^^^^^            <- the choice
+	      --                          ^^^     <- Expression
 	"""
 	def __str__(self) -> str:
 		return "others => {value!s}".format(
@@ -2197,8 +2197,8 @@ class Aggregate(BaseExpression):
 
 	   .. code-block:: VHDL
 
-	      vres := (0 => '1', 1 to 3 => '0', others => '1');
-	      --      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    <- Elements
+	      res := (0 => '1', 1 to 3 => '0', others => '1');
+	      --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    <- Elements
 	"""
 	_elements: List[AggregateElement]
 

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -57,6 +57,17 @@ ExpressionUnion = Union[
 class BaseExpression(ModelEntity):
 	"""
 	Represents the base-class of all expressions.
+
+	.. seealso::
+
+	   * :class:`Aggregate <pyVHDLModel.Expression.Aggregate>`
+	   * :class:`Allocation <pyVHDLModel.Expression.Allocation>`
+	   * :class:`Binary expression <pyVHDLModel.Expression.BinaryExpression>`
+	   * :class:`Function call <pyVHDLModel.Expression.FunctionCall>`
+	   * :class:`Literal <pyVHDLModel.Expression.Literal>`
+	   * :class:`Qualified expression <pyVHDLModel.Expression.QualifiedExpression>`
+	   * :class:`Ternary expression <pyVHDLModel.Expression.TernaryExpression>`
+	   * :class:`Unary expression <pyVHDLModel.Expression.UnaryExpression>`
 	"""
 
 
@@ -66,6 +77,15 @@ class Literal(BaseExpression):
 	Represents the base-class of all literals.
 
 	A literal is an expression denoting a value written directly in the source.
+
+	.. seealso::
+
+	   * :class:`Bit string literal <pyVHDLModel.Expression.BitStringLiteral>`
+	   * :class:`Character literal <pyVHDLModel.Expression.CharacterLiteral>`
+	   * :class:`Enumeration literal <pyVHDLModel.Expression.EnumerationLiteral>`
+	   * :class:`Null literal <pyVHDLModel.Expression.NullLiteral>`
+	   * :class:`Numeric literal <pyVHDLModel.Expression.NumericLiteral>`
+	   * :class:`String literal <pyVHDLModel.Expression.StringLiteral>`
 	"""
 
 
@@ -127,6 +147,12 @@ class NumericLiteral(Literal):
 	Represents the base-class of all numeric literals.
 
 	Integer, floating-point and physical literals are numeric.
+
+	.. seealso::
+
+	   * :class:`Floating point literal <pyVHDLModel.Expression.FloatingPointLiteral>`
+	   * :class:`Integer literal <pyVHDLModel.Expression.IntegerLiteral>`
+	   * :class:`Physical literal <pyVHDLModel.Expression.PhysicalLiteral>`
 	"""
 
 
@@ -210,6 +236,11 @@ class PhysicalLiteral(NumericLiteral):
 	      t <= 10 ns;
 	      --   ^^       <- the value
 	      --      ^^    <- UnitName
+
+	.. seealso::
+
+	   * :class:`Physical floating literal <pyVHDLModel.Expression.PhysicalFloatingLiteral>`
+	   * :class:`Physical integer literal <pyVHDLModel.Expression.PhysicalIntegerLiteral>`
 	"""
 	_unitName: str
 
@@ -388,6 +419,13 @@ class BitStringLiteral(Literal):
 
 	      vres := b"10100000";
 	      --      ^^^^^^^^^^^    <- Value
+
+	.. seealso::
+
+	   * :class:`Binary bit string literal <pyVHDLModel.Expression.BinaryBitStringLiteral>`
+	   * :class:`Decimal bit string literal <pyVHDLModel.Expression.DecimalBitStringLiteral>`
+	   * :class:`Hexadecimal bit string literal <pyVHDLModel.Expression.HexadecimalBitStringLiteral>`
+	   * :class:`Octal bit string literal <pyVHDLModel.Expression.OctalBitStringLiteral>`
 	"""
 	_value:       str
 	_binaryValue: str
@@ -535,6 +573,11 @@ class ParenthesisExpression: #(Protocol):
 	Represents the base-class of expressions wrapped in parentheses.
 
 	The operand is available as :data:`Operand`.
+
+	.. seealso::
+
+	   * :class:`Qualified expression <pyVHDLModel.Expression.QualifiedExpression>`
+	   * :class:`Sub expression <pyVHDLModel.Expression.SubExpression>`
 	"""
 	__slots__ = ()  # FIXME: use ExtendedType?
 
@@ -821,6 +864,15 @@ class BinaryExpression(BaseExpression):
 	Represents the base-class of all binary expressions.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Adding expression <pyVHDLModel.Expression.AddingExpression>`
+	   * :class:`Logical expression <pyVHDLModel.Expression.LogicalExpression>`
+	   * :class:`Multiplying expression <pyVHDLModel.Expression.MultiplyingExpression>`
+	   * :class:`Range expression <pyVHDLModel.Expression.RangeExpression>`
+	   * :class:`Relational expression <pyVHDLModel.Expression.RelationalExpression>`
+	   * :class:`Shift expression <pyVHDLModel.Expression.ShiftExpression>`
 	"""
 
 	_FORMAT: Tuple[str, str, str]
@@ -871,6 +923,11 @@ class RangeExpression(BinaryExpression):
 
 	A range has a direction (:data:`Direction`) and two bounds. Both operands are available as :data:`LeftOperand` and
 	:data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Ascending range expression <pyVHDLModel.Expression.AscendingRangeExpression>`
+	   * :class:`Descending range expression <pyVHDLModel.Expression.DescendingRangeExpression>`
 	"""
 	_direction: Direction
 
@@ -930,6 +987,12 @@ class AddingExpression(BinaryExpression):
 	Represents the base-class of all adding expressions: ``+``, ``-`` and ``&``.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Addition expression <pyVHDLModel.Expression.AdditionExpression>`
+	   * :class:`Concatenation expression <pyVHDLModel.Expression.ConcatenationExpression>`
+	   * :class:`Subtraction expression <pyVHDLModel.Expression.SubtractionExpression>`
 	"""
 
 
@@ -996,6 +1059,14 @@ class MultiplyingExpression(BinaryExpression):
 	Represents the base-class of all multiplying expressions: ``*``, ``/``, ``rem``, ``mod`` and ``**``.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Division expression <pyVHDLModel.Expression.DivisionExpression>`
+	   * :class:`Exponentiation expression <pyVHDLModel.Expression.ExponentiationExpression>`
+	   * :class:`Modulo expression <pyVHDLModel.Expression.ModuloExpression>`
+	   * :class:`Multiply expression <pyVHDLModel.Expression.MultiplyExpression>`
+	   * :class:`Remainder expression <pyVHDLModel.Expression.RemainderExpression>`
 	"""
 
 
@@ -1100,6 +1171,15 @@ class LogicalExpression(BinaryExpression):
 	Represents the base-class of all binary logical expressions.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`And expression <pyVHDLModel.Expression.AndExpression>`
+	   * :class:`Nand expression <pyVHDLModel.Expression.NandExpression>`
+	   * :class:`Nor expression <pyVHDLModel.Expression.NorExpression>`
+	   * :class:`Or expression <pyVHDLModel.Expression.OrExpression>`
+	   * :class:`Xnor expression <pyVHDLModel.Expression.XnorExpression>`
+	   * :class:`Xor expression <pyVHDLModel.Expression.XorExpression>`
 	"""
 
 
@@ -1223,6 +1303,16 @@ class RelationalExpression(BinaryExpression):
 	Represents the base-class of all relational expressions.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Equal expression <pyVHDLModel.Expression.EqualExpression>`
+	   * :class:`Greater equal expression <pyVHDLModel.Expression.GreaterEqualExpression>`
+	   * :class:`Greater than expression <pyVHDLModel.Expression.GreaterThanExpression>`
+	   * :class:`Less equal expression <pyVHDLModel.Expression.LessEqualExpression>`
+	   * :class:`Less than expression <pyVHDLModel.Expression.LessThanExpression>`
+	   * :class:`Matching relational expression <pyVHDLModel.Expression.MatchingRelationalExpression>`
+	   * :class:`Unequal expression <pyVHDLModel.Expression.UnequalExpression>`
 	"""
 
 
@@ -1347,6 +1437,15 @@ class MatchingRelationalExpression(RelationalExpression):
 
 	Matching operators return a ``bit``/``std_ulogic`` rather than a ``boolean``. Both operands are available as
 	:data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Matching equal expression <pyVHDLModel.Expression.MatchingEqualExpression>`
+	   * :class:`Matching greater equal expression <pyVHDLModel.Expression.MatchingGreaterEqualExpression>`
+	   * :class:`Matching greater than expression <pyVHDLModel.Expression.MatchingGreaterThanExpression>`
+	   * :class:`Matching less equal expression <pyVHDLModel.Expression.MatchingLessEqualExpression>`
+	   * :class:`Matching less than expression <pyVHDLModel.Expression.MatchingLessThanExpression>`
+	   * :class:`Matching unequal expression <pyVHDLModel.Expression.MatchingUnequalExpression>`
 	"""
 	pass
 
@@ -1477,6 +1576,12 @@ class ShiftExpression(BinaryExpression):
 	Represents the base-class of all shift and rotate expressions.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Rotate expression <pyVHDLModel.Expression.RotateExpression>`
+	   * :class:`Shift arithmetic expression <pyVHDLModel.Expression.ShiftArithmeticExpression>`
+	   * :class:`Shift logic expression <pyVHDLModel.Expression.ShiftLogicExpression>`
 	"""
 
 
@@ -1486,6 +1591,11 @@ class ShiftLogicExpression(ShiftExpression):
 	Represents the base-class of the logical shift expressions ``srl`` and ``sll``.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Shift left logic expression <pyVHDLModel.Expression.ShiftLeftLogicExpression>`
+	   * :class:`Shift right logic expression <pyVHDLModel.Expression.ShiftRightLogicExpression>`
 	"""
 	pass
 
@@ -1496,6 +1606,11 @@ class ShiftArithmeticExpression(ShiftExpression):
 	Represents the base-class of the arithmetic shift expressions ``sra`` and ``sla``.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Shift left arithmetic expression <pyVHDLModel.Expression.ShiftLeftArithmeticExpression>`
+	   * :class:`Shift right arithmetic expression <pyVHDLModel.Expression.ShiftRightArithmeticExpression>`
 	"""
 	pass
 
@@ -1506,6 +1621,11 @@ class RotateExpression(ShiftExpression):
 	Represents the base-class of the rotate expressions ``ror`` and ``rol``.
 
 	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. seealso::
+
+	   * :class:`Rotate left expression <pyVHDLModel.Expression.RotateLeftExpression>`
+	   * :class:`Rotate right expression <pyVHDLModel.Expression.RotateRightExpression>`
 	"""
 	pass
 
@@ -1678,6 +1798,10 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 class TernaryExpression(BaseExpression):
 	"""
 	Represents the base-class of all ternary expressions.
+
+	.. seealso::
+
+	   * :class:`When else expression <pyVHDLModel.Expression.WhenElseExpression>`
 	"""
 
 	_FORMAT: Tuple[str, str, str, str]  # FIXME: needs ClassVar[...] when pyTooling gets fixed.
@@ -1793,6 +1917,11 @@ class FunctionCall(BaseExpression):
 class Allocation(BaseExpression):
 	"""
 	Represents the base-class of all allocations via ``new``.
+
+	.. seealso::
+
+	   * :class:`Qualified expression allocation <pyVHDLModel.Expression.QualifiedExpressionAllocation>`
+	   * :class:`Subtype allocation <pyVHDLModel.Expression.SubtypeAllocation>`
 	"""
 	pass
 
@@ -1873,6 +2002,14 @@ class AggregateElement(ModelEntity):
 	Represents the base-class of all aggregate elements.
 
 	Every element carries the value assigned to it (:data:`Expression`).
+
+	.. seealso::
+
+	   * :class:`Indexed aggregate element <pyVHDLModel.Expression.IndexedAggregateElement>`
+	   * :class:`Named aggregate element <pyVHDLModel.Expression.NamedAggregateElement>`
+	   * :class:`Others aggregate element <pyVHDLModel.Expression.OthersAggregateElement>`
+	   * :class:`Ranged aggregate element <pyVHDLModel.Expression.RangedAggregateElement>`
+	   * :class:`Simple aggregate element <pyVHDLModel.Expression.SimpleAggregateElement>`
 	"""
 
 	_expression: ExpressionUnion

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -55,22 +55,52 @@ ExpressionUnion = Union[
 
 @export
 class BaseExpression(ModelEntity):
-	"""A ``BaseExpression`` is a base-class for all expressions."""
+	"""
+	Represents the base-class of all expressions.
+	"""
 
 
 @export
 class Literal(BaseExpression):
-	"""A ``Literal`` is a base-class for all literals."""
+	"""
+	Represents the base-class of all literals.
+
+	A literal is an expression denoting a value written directly in the source.
+	"""
 
 
 @export
 class NullLiteral(Literal):
+	"""
+	Represents a ``null`` literal.
+
+	A null literal denotes the null value of an access type.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      p := null;
+	      --   ^^^^    <- the literal
+	"""
 	def __str__(self) -> str:
 		return "null"
 
 
 @export
 class EnumerationLiteral(Literal):
+	"""
+	Represents an enumeration literal.
+
+	The literal's name is available as :data:`Value`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      st <= Idle;
+	      --    ^^^^    <- Value
+	"""
 	_value: str
 
 	def __init__(self, value: str, parent: Nullable[ModelEntity] = None) -> None:
@@ -93,11 +123,27 @@ class EnumerationLiteral(Literal):
 
 @export
 class NumericLiteral(Literal):
-	"""A ``NumericLiteral`` is a base-class for all numeric literals."""
+	"""
+	Represents the base-class of all numeric literals.
+
+	Integer, floating-point and physical literals are numeric.
+	"""
 
 
 @export
 class IntegerLiteral(NumericLiteral):
+	"""
+	Represents an integer literal.
+
+	The literal's value is available as :data:`Value`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a + 42;
+	      --         ^^    <- Value
+	"""
 	_value: int
 
 	def __init__(self, value: int) -> None:
@@ -119,6 +165,18 @@ class IntegerLiteral(NumericLiteral):
 
 @export
 class FloatingPointLiteral(NumericLiteral):
+	"""
+	Represents a floating-point literal.
+
+	The literal's value is available as :data:`Value`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      r <= 3.14;
+	      --   ^^^^    <- Value
+	"""
 	_value: float
 
 	def __init__(self, value: float) -> None:
@@ -140,6 +198,19 @@ class FloatingPointLiteral(NumericLiteral):
 
 @export
 class PhysicalLiteral(NumericLiteral):
+	"""
+	Represents the base-class of all physical literals.
+
+	A physical literal combines a numeric value with a unit name (:data:`UnitName`).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      t <= 10 ns;
+	      --   ^^       <- the value
+	      --      ^^    <- UnitName
+	"""
 	_unitName: str
 
 	def __init__(self, unitName: str) -> None:
@@ -161,6 +232,19 @@ class PhysicalLiteral(NumericLiteral):
 
 @export
 class PhysicalIntegerLiteral(PhysicalLiteral):
+	"""
+	Represents a physical literal with an integer value.
+
+	Value (:data:`Value`) and unit name (:data:`UnitName`) are available separately.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      t <= 10 ns;
+	      --   ^^       <- Value
+	      --      ^^    <- UnitName
+	"""
 	_value: int
 
 	def __init__(self, value: int, unitName: str) -> None:
@@ -179,6 +263,19 @@ class PhysicalIntegerLiteral(PhysicalLiteral):
 
 @export
 class PhysicalFloatingLiteral(PhysicalLiteral):
+	"""
+	Represents a physical literal with a floating-point value.
+
+	Value (:data:`Value`) and unit name (:data:`UnitName`) are available separately.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      t <= 1.5 ns;
+	      --   ^^^       <- Value
+	      --       ^^    <- UnitName
+	"""
 	_value: float
 
 	def __init__(self, value: float, unitName: str) -> None:
@@ -197,6 +294,18 @@ class PhysicalFloatingLiteral(PhysicalLiteral):
 
 @export
 class CharacterLiteral(Literal):
+	"""
+	Represents a character literal.
+
+	The literal's character is available as :data:`Value`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      ch <= 'a';
+	      --    ^^^    <- Value
+	"""
 	_value: str
 
 	def __init__(self, value: str) -> None:
@@ -218,6 +327,18 @@ class CharacterLiteral(Literal):
 
 @export
 class StringLiteral(Literal):
+	"""
+	Represents a string literal.
+
+	The literal's text is available as :data:`Value`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      txt <= "text";
+	      --     ^^^^^^    <- Value
+	"""
 	_value: str
 
 	def __init__(self, value: str) -> None:
@@ -239,6 +360,9 @@ class StringLiteral(Literal):
 
 @export
 class BitStringBase(Flag):
+	"""
+	Represents the base of a bit string literal: binary, octal, decimal or hexadecimal.
+	"""
 	NoBase = 0
 	Binary = 2
 	Octal = 8
@@ -251,6 +375,20 @@ class BitStringBase(Flag):
 @export
 class BitStringLiteral(Literal):
 	# _base:  ClassVar[BitStringBase]
+	"""
+	Represents the base-class of all bit string literals.
+
+	Besides the literal as written (:data:`Value`), the bits are available in binary form
+	(:data:`BinaryValue`, :data:`Bits`), together with the literal's length (:data:`Length`) and
+	whether it is signed (:data:`Signed`).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := b"10100000";
+	      --      ^^^^^^^^^^^    <- Value
+	"""
 	_value:       str
 	_binaryValue: str
 	_bits:        int
@@ -329,26 +467,75 @@ class BitStringLiteral(Literal):
 
 @export
 class BinaryBitStringLiteral(BitStringLiteral):
+	"""
+	Represents a bit string literal written in base 2.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := b"10100000";
+	      --      ^^^^^^^^^^^    <- Value
+	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Binary
 
 
 @export
 class OctalBitStringLiteral(BitStringLiteral):
+	"""
+	Represents a bit string literal written in base 8.
+
+	Each digit contributes three bits.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      nine := o"240";
+	      --      ^^^^^^    <- Value
+	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Octal
 
 
 @export
 class DecimalBitStringLiteral(BitStringLiteral):
+	"""
+	Represents a bit string literal written in base 10.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := d"160";
+	      --      ^^^^^^    <- Value
+	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Decimal
 
 
 @export
 class HexadecimalBitStringLiteral(BitStringLiteral):
+	"""
+	Represents a bit string literal written in base 16.
+
+	Each digit contributes four bits.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := x"A0";
+	      --      ^^^^^    <- Value
+	"""
 	_base: ClassVar[BitStringBase] = BitStringBase.Hexadecimal
 
 
 @export
 class ParenthesisExpression: #(Protocol):
+	"""
+	Represents the base-class of expressions wrapped in parentheses.
+
+	The operand is available as :data:`Operand`.
+	"""
 	__slots__ = ()  # FIXME: use ExtendedType?
 
 	@readonly
@@ -363,7 +550,11 @@ class ParenthesisExpression: #(Protocol):
 
 @export
 class UnaryExpression(BaseExpression):
-	"""A ``UnaryExpression`` is a base-class for all unary expressions."""
+	"""
+	Represents the base-class of all unary expressions.
+
+	The operand is available as :data:`Operand`.
+	"""
 
 	_FORMAT:  Tuple[str, str]
 	_operand: ExpressionUnion
@@ -389,61 +580,201 @@ class UnaryExpression(BaseExpression):
 
 @export
 class NegationExpression(UnaryExpression):
+	"""
+	Represents a negation (unary minus) expression.
+
+	The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := -a;
+	      --     ^^    <- the expression
+	      --      ^    <- Operand
+	"""
 	_FORMAT = ("-", "")
 
 
 @export
 class IdentityExpression(UnaryExpression):
+	"""
+	Represents a identity (unary plus) expression.
+
+	The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := +a;
+	      --     ^^    <- the expression
+	      --      ^    <- Operand
+	"""
 	_FORMAT = ("+", "")
 
 
 @export
 class InverseExpression(UnaryExpression):
+	"""
+	Represents a logical inversion expression (``not``).
+
+	The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := not f;
+	      --      ^^^^^    <- the expression
+	      --          ^    <- Operand
+	"""
 	_FORMAT = ("not ", "")
 
 
 @export
 class UnaryAndExpression(UnaryExpression):
+	"""
+	Represents a ``and`` reduction expression (VHDL-2008).
+
+	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := and v;
+	      --      ^^^^^    <- the expression
+	      --          ^    <- Operand
+	"""
 	_FORMAT = ("and ", "")
 
 
 @export
 class UnaryNandExpression(UnaryExpression):
+	"""
+	Represents a ``nand`` reduction expression (VHDL-2008).
+
+	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := nand v;
+	      --      ^^^^^^    <- the expression
+	      --           ^    <- Operand
+	"""
 	_FORMAT = ("nand ", "")
 
 
 @export
 class UnaryOrExpression(UnaryExpression):
+	"""
+	Represents a ``or`` reduction expression (VHDL-2008).
+
+	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := or v;
+	      --      ^^^^    <- the expression
+	      --         ^    <- Operand
+	"""
 	_FORMAT = ("or ", "")
 
 
 @export
 class UnaryNorExpression(UnaryExpression):
+	"""
+	Represents a ``nor`` reduction expression (VHDL-2008).
+
+	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := nor v;
+	      --      ^^^^^    <- the expression
+	      --          ^    <- Operand
+	"""
 	_FORMAT = ("nor ", "")
 
 
 @export
 class UnaryXorExpression(UnaryExpression):
+	"""
+	Represents a ``xor`` reduction expression (VHDL-2008).
+
+	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := xor v;
+	      --      ^^^^^    <- the expression
+	      --          ^    <- Operand
+	"""
 	_FORMAT = ("xor ", "")
 
 
 @export
 class UnaryXnorExpression(UnaryExpression):
+	"""
+	Represents a ``xnor`` reduction expression (VHDL-2008).
+
+	A reduction operator folds all elements of an array into a single value. The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := xnor v;
+	      --      ^^^^^^    <- the expression
+	      --           ^    <- Operand
+	"""
 	_FORMAT = ("xnor ", "")
 
 
 @export
 class AbsoluteExpression(UnaryExpression):
+	"""
+	Represents a absolute value expression (``abs``).
+
+	The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := abs a;
+	      --     ^^^^^    <- the expression
+	      --     ^        <- Operand
+	"""
 	_FORMAT = ("abs ", "")
 
 
 @export
 class TypeConversion(UnaryExpression):
-	"""``natural(x)`` - a type conversion. Unlike every other :class:`UnaryExpression` subclass, its
-	"operator" is the target type name itself, not a fixed string, so it doesn't participate in the
-	shared ``_FORMAT``-based :meth:`UnaryExpression.__str__` at all - it carries its own
-	:attr:`_targetSubtype` (mirroring :class:`QualifiedExpression`'s ``_subtype``) and overrides
-	``__str__`` accordingly."""
+	"""
+	Represents a type conversion.
+
+	A type conversion converts its operand (:data:`Operand`) to the target subtype
+	(:data:`TargetSubtype`). Unlike every other :class:`UnaryExpression`, its "operator" is the target
+	type name itself rather than a fixed string, so it carries its own subtype and renders itself.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := integer(r);
+	      --     ^^^^^^^       <- TargetSubtype
+	      --^                  <- Operand
+	"""
 
 	_targetSubtype: SubtypeSymbol
 
@@ -468,12 +799,29 @@ class TypeConversion(UnaryExpression):
 
 @export
 class SubExpression(UnaryExpression, ParenthesisExpression):
+	"""
+	Represents a parenthesized sub-expression.
+
+	The operand is available as :data:`Operand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := (a + b);
+	      --     ^^^^^^^    <- the sub-expression
+	      --      ^^^^^     <- Operand
+	"""
 	_FORMAT = ("(", ")")
 
 
 @export
 class BinaryExpression(BaseExpression):
-	"""A ``BinaryExpression`` is a base-class for all binary expressions."""
+	"""
+	Represents the base-class of all binary expressions.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 
 	_FORMAT: Tuple[str, str, str]
 	_leftOperand:  ExpressionUnion
@@ -518,6 +866,12 @@ class BinaryExpression(BaseExpression):
 
 @export
 class RangeExpression(BinaryExpression):
+	"""
+	Represents the base-class of range expressions.
+
+	A range has a direction (:data:`Direction`) and two bounds. Both operands are available as :data:`LeftOperand` and
+	:data:`RightOperand`.
+	"""
 	_direction: Direction
 
 	@readonly
@@ -532,223 +886,760 @@ class RangeExpression(BinaryExpression):
 
 @export
 class AscendingRangeExpression(RangeExpression):
+	"""
+	Represents an ascending range expression (``to``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v(0 to 3);
+	      --        ^^^^^^     <- the range
+	      --        ^          <- LeftOperand
+	      --             ^     <- RightOperand
+	"""
 	_direction = Direction.To
 	_FORMAT = ("", " to ", "")
 
 
 @export
 class DescendingRangeExpression(RangeExpression):
+	"""
+	Represents a descending range expression (``downto``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v(7 downto 4);
+	      --        ^^^^^^^^^^     <- the range
+	      --        ^              <- LeftOperand
+	      --                 ^     <- RightOperand
+	"""
 	_direction = Direction.DownTo
 	_FORMAT = ("", " downto ", "")
 
 
 @export
 class AddingExpression(BinaryExpression):
-	"""A ``AddingExpression`` is a base-class for all adding expressions."""
+	"""
+	Represents the base-class of all adding expressions: ``+``, ``-`` and ``&``.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 
 
 @export
 class AdditionExpression(AddingExpression):
+	"""
+	Represents an addition expression (``+``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a + b;
+	      --     ^^^^^    <- the expression
+	      --     ^        <- LeftOperand
+	      --         ^    <- RightOperand
+	"""
 	_FORMAT = ("", " + ", "")
 
 
 @export
 class SubtractionExpression(AddingExpression):
+	"""
+	Represents a subtraction expression (``-``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a - b;
+	      --     ^^^^^    <- the expression
+	      --     ^        <- LeftOperand
+	      --         ^    <- RightOperand
+	"""
 	_FORMAT = ("", " - ", "")
 
 
 @export
 class ConcatenationExpression(AddingExpression):
+	"""
+	Represents a concatenation expression (``&``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v & w;
+	      --      ^^^^^    <- the expression
+	      --^              <- LeftOperand
+	      --          ^    <- RightOperand
+	"""
 	_FORMAT = ("", " & ", "")
 
 
 @export
 class MultiplyingExpression(BinaryExpression):
-	"""A ``MultiplyingExpression`` is a base-class for all multiplying expressions."""
+	"""
+	Represents the base-class of all multiplying expressions: ``*``, ``/``, ``rem``, ``mod`` and ``**``.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 
 
 @export
 class MultiplyExpression(MultiplyingExpression):
+	"""
+	Represents a multiplication expression (``*``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a * b;
+	      --     ^^^^^    <- the expression
+	      --     ^        <- LeftOperand
+	      --         ^    <- RightOperand
+	"""
 	_FORMAT = ("", " * ", "")
 
 
 @export
 class DivisionExpression(MultiplyingExpression):
+	"""
+	Represents a division expression (``/``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a / b;
+	      --     ^^^^^    <- the expression
+	      --     ^        <- LeftOperand
+	      --         ^    <- RightOperand
+	"""
 	_FORMAT = ("", " / ", "")
 
 
 @export
 class RemainderExpression(MultiplyingExpression):
+	"""
+	Represents a remainder expression (``rem``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a rem b;
+	      --     ^^^^^^^    <- the expression
+	      --     ^          <- LeftOperand
+	      --           ^    <- RightOperand
+	"""
 	_FORMAT = ("", " rem ", "")
 
 
 @export
 class ModuloExpression(MultiplyingExpression):
+	"""
+	Represents a modulo expression (``mod``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a mod b;
+	      --     ^^^^^^^    <- the expression
+	      --     ^          <- LeftOperand
+	      --           ^    <- RightOperand
+	"""
 	_FORMAT = ("", " mod ", "")
 
 
 @export
 class ExponentiationExpression(MultiplyingExpression):
+	"""
+	Represents an exponentiation expression (``**``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a ** 2;
+	      --     ^^^^^^    <- the expression
+	      --     ^         <- LeftOperand
+	      --          ^    <- RightOperand
+	"""
 	_FORMAT = ("", "**", "")
 
 
 @export
 class LogicalExpression(BinaryExpression):
-	"""A ``LogicalExpression`` is a base-class for all logical expressions."""
+	"""
+	Represents the base-class of all binary logical expressions.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 
 
 @export
 class AndExpression(LogicalExpression):
+	"""
+	Represents a logical ``and`` expression.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := f and g;
+	      --      ^^^^^^^    <- the expression
+	      --      ^          <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " and ", "")
 
 
 @export
 class NandExpression(LogicalExpression):
+	"""
+	Represents a logical ``nand`` expression.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := f nand g;
+	      --      ^^^^^^^^    <- the expression
+	      --      ^           <- LeftOperand
+	      --             ^    <- RightOperand
+	"""
 	_FORMAT = ("", " nand ", "")
 
 
 @export
 class OrExpression(LogicalExpression):
+	"""
+	Represents a logical ``or`` expression.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := f or g;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --           ^    <- RightOperand
+	"""
 	_FORMAT = ("", " or ", "")
 
 
 @export
 class NorExpression(LogicalExpression):
+	"""
+	Represents a logical ``nor`` expression.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := f nor g;
+	      --      ^^^^^^^    <- the expression
+	      --      ^          <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " nor ", "")
 
 
 @export
 class XorExpression(LogicalExpression):
+	"""
+	Represents a logical ``xor`` expression.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := f xor g;
+	      --      ^^^^^^^    <- the expression
+	      --      ^          <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " xor ", "")
 
 
 @export
 class XnorExpression(LogicalExpression):
+	"""
+	Represents a logical ``xnor`` expression.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := f xnor g;
+	      --      ^^^^^^^^    <- the expression
+	      --      ^           <- LeftOperand
+	      --             ^    <- RightOperand
+	"""
 	_FORMAT = ("", " xnor ", "")
 
 
 @export
 class RelationalExpression(BinaryExpression):
-	"""A ``RelationalExpression`` is a base-class for all shifting expressions."""
+	"""
+	Represents the base-class of all relational expressions.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 
 
 @export
 class EqualExpression(RelationalExpression):
+	"""
+	Represents an equality expression (``=``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := a = b;
+	      --      ^^^^^    <- the expression
+	      --      ^        <- LeftOperand
+	      --^              <- RightOperand
+	"""
 	_FORMAT = ("", " = ", "")
 
 
 @export
 class UnequalExpression(RelationalExpression):
+	"""
+	Represents an inequality expression (``/=``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := a /= b;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --^               <- RightOperand
+	"""
 	_FORMAT = ("", " /= ", "")
 
 
 @export
 class GreaterThanExpression(RelationalExpression):
+	"""
+	Represents a greater-than expression (``>``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := a > b;
+	      --      ^^^^^    <- the expression
+	      --      ^        <- LeftOperand
+	      --^              <- RightOperand
+	"""
 	_FORMAT = ("", " > ", "")
 
 
 @export
 class GreaterEqualExpression(RelationalExpression):
+	"""
+	Represents a greater-or-equal expression (``>=``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := a >= b;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --^               <- RightOperand
+	"""
 	_FORMAT = ("", " >= ", "")
 
 
 @export
 class LessThanExpression(RelationalExpression):
+	"""
+	Represents a less-than expression (``<``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := a < b;
+	      --      ^^^^^    <- the expression
+	      --      ^        <- LeftOperand
+	      --^              <- RightOperand
+	"""
 	_FORMAT = ("", " < ", "")
 
 
 @export
 class LessEqualExpression(RelationalExpression):
+	"""
+	Represents a less-or-equal expression (``<=``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      bres := a <= b;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --^               <- RightOperand
+	"""
 	_FORMAT = ("", " <= ", "")
 
 
 @export
 class MatchingRelationalExpression(RelationalExpression):
+	"""
+	Represents the base-class of all matching relational expressions (VHDL-2008).
+
+	Matching operators return a ``bit``/``std_ulogic`` rather than a ``boolean``. Both operands are available as
+	:data:`LeftOperand` and :data:`RightOperand`.
+	"""
 	pass
 
 
 @export
 class MatchingEqualExpression(MatchingRelationalExpression):
+	"""
+	Represents a matching equality expression (``?=``, VHDL-2008).
+
+	Unlike ``=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
+	and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := v ?= w;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --           ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ?= ", "")
 
 
 @export
 class MatchingUnequalExpression(MatchingRelationalExpression):
+	"""
+	Represents a matching inequality expression (``?/=``, VHDL-2008).
+
+	Unlike ``/=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
+	:data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := v ?/= w;
+	      --      ^^^^^^^    <- the expression
+	      --      ^          <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ?/= ", "")
 
 
 @export
 class MatchingGreaterThanExpression(MatchingRelationalExpression):
+	"""
+	Represents a matching greater-than expression (``?>``, VHDL-2008).
+
+	Unlike ``>``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
+	and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := v ?> w;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --           ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ?> ", "")
 
 
 @export
 class MatchingGreaterEqualExpression(MatchingRelationalExpression):
+	"""
+	Represents a matching greater-or-equal expression (``?>=``, VHDL-2008).
+
+	Unlike ``>=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
+	:data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := v ?>= w;
+	      --      ^^^^^^^    <- the expression
+	      --      ^          <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ?>= ", "")
 
 
 @export
 class MatchingLessThanExpression(MatchingRelationalExpression):
+	"""
+	Represents a matching less-than expression (``?<``, VHDL-2008).
+
+	Unlike ``<``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as :data:`LeftOperand`
+	and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := v ?< w;
+	      --      ^^^^^^    <- the expression
+	      --      ^         <- LeftOperand
+	      --           ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ?< ", "")
 
 
 @export
 class MatchingLessEqualExpression(MatchingRelationalExpression):
+	"""
+	Represents a matching less-or-equal expression (``?<=``, VHDL-2008).
+
+	Unlike ``<=``, a matching operator returns a ``bit``/``std_ulogic``. Both operands are available as
+	:data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      sres := v ?<= w;
+	      --      ^^^^^^^    <- the expression
+	      --      ^          <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ?<= ", "")
 
 
 @export
 class ShiftExpression(BinaryExpression):
-	"""A ``ShiftExpression`` is a base-class for all shifting expressions."""
+	"""
+	Represents the base-class of all shift and rotate expressions.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 
 
 @export
 class ShiftLogicExpression(ShiftExpression):
+	"""
+	Represents the base-class of the logical shift expressions ``srl`` and ``sll``.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 	pass
 
 
 @export
 class ShiftArithmeticExpression(ShiftExpression):
+	"""
+	Represents the base-class of the arithmetic shift expressions ``sra`` and ``sla``.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 	pass
 
 
 @export
 class RotateExpression(ShiftExpression):
+	"""
+	Represents the base-class of the rotate expressions ``ror`` and ``rol``.
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+	"""
 	pass
 
 
 @export
 class ShiftRightLogicExpression(ShiftLogicExpression):
+	"""
+	Represents a logical right shift expression (``srl``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v srl 1;
+	      --      ^^^^^^^    <- the expression
+	      --^                <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " srl ", "")
 
 
 @export
 class ShiftLeftLogicExpression(ShiftLogicExpression):
+	"""
+	Represents a logical left shift expression (``sll``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v sll 1;
+	      --      ^^^^^^^    <- the expression
+	      --^                <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " sll ", "")
 
 
 @export
 class ShiftRightArithmeticExpression(ShiftArithmeticExpression):
+	"""
+	Represents an arithmetic right shift expression (``sra``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v sra 1;
+	      --      ^^^^^^^    <- the expression
+	      --^                <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " sra ", "")
 
 
 @export
 class ShiftLeftArithmeticExpression(ShiftArithmeticExpression):
+	"""
+	Represents an arithmetic left shift expression (``sla``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v sla 1;
+	      --      ^^^^^^^    <- the expression
+	      --^                <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " sla ", "")
 
 
 @export
 class RotateRightExpression(RotateExpression):
+	"""
+	Represents a right rotate expression (``ror``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v ror 1;
+	      --      ^^^^^^^    <- the expression
+	      --^                <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " ror ", "")
 
 
 @export
 class RotateLeftExpression(RotateExpression):
+	"""
+	Represents a left rotate expression (``rol``).
+
+	Both operands are available as :data:`LeftOperand` and :data:`RightOperand`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v rol 1;
+	      --      ^^^^^^^    <- the expression
+	      --^                <- LeftOperand
+	      --            ^    <- RightOperand
+	"""
 	_FORMAT = ("", " rol ", "")
 
 
 @export
 class QualifiedExpression(BaseExpression, ParenthesisExpression):
+	"""
+	Represents a qualified expression.
+
+	A qualified expression states the subtype (:data:`Subtype`) of its operand (:data:`Operand`),
+	resolving which of several overloaded meanings is intended.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := byte'(others => '0');
+	      --      ^^^^                    <- Subtype
+	      --           ^^^^^^^^^^^^^^^    <- Operand
+	"""
 	_operand:  ExpressionUnion
 	_subtype:  Symbol
 
@@ -786,16 +1677,7 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 @export
 class TernaryExpression(BaseExpression):
 	"""
-	A ``TernaryExpression`` is a base-class for all ternary expressions.
-
-	The three operands are deliberately *not* exposed as public properties here: unlike
-	:class:`UnaryExpression`/:class:`BinaryExpression` (where "the operand"/"left operand"/"right
-	operand" are already the natural domain names for every consumer), a ternary's three operands
-	play a different semantic role depending on the concrete expression - e.g.
-	:class:`WhenElseExpression`'s are really "then value"/"condition"/"else value". Each concrete
-	subclass is expected to expose its own, appropriately-named properties over the shared
-	``_firstOperand``/``_secondOperand``/``_thirdOperand`` fields, rather than duplicating a
-	generic and a specific name for the same value.
+	Represents the base-class of all ternary expressions.
 	"""
 
 	_FORMAT: Tuple[str, str, str, str]  # FIXME: needs ClassVar[...] when pyTooling gets fixed.
@@ -836,9 +1718,21 @@ class TernaryExpression(BaseExpression):
 @export
 class WhenElseExpression(TernaryExpression):
 	"""
-	``thenValue when condition else elseValue`` (VHDL-2008 conditional expression, usable anywhere an
-	expression is expected - distinct from :class:`~pyVHDLModel.Common.ConditionalExpression`, which
-	models the cascading when/else list used in a conditional *assignment*).
+	Represents a conditional expression (VHDL-2008).
+
+	A conditional expression selects between two values (:data:`ThenValue`, :data:`ElseValue`) based on
+	a condition (:data:`Condition`). It is usable anywhere an expression is expected - distinct from
+	:class:`~pyVHDLModel.Common.ConditionalExpression`, which models the cascading ``when``/``else``
+	list of a conditional *assignment*.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := a when f else b;
+	      --     ^                  <- ThenValue
+	      --            ^           <- Condition
+	      --                   ^    <- ElseValue
 	"""
 
 	_FORMAT = ("", " when ", " else ", "")
@@ -882,16 +1776,41 @@ class WhenElseExpression(TernaryExpression):
 
 @export
 class FunctionCall(BaseExpression):
+	"""
+	Represents a call to a function.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      res := maximum(a, b);
+	      --     ^^^^^^^^^^^^^    <- the call
+	"""
 	pass
 
 
 @export
 class Allocation(BaseExpression):
+	"""
+	Represents the base-class of all allocations via ``new``.
+	"""
 	pass
 
 
 @export
 class SubtypeAllocation(Allocation):
+	"""
+	Represents an allocation of a subtype via ``new``.
+
+	The allocated subtype is available as :data:`Subtype`. The allocated object is default-initialized.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      p := new integer;
+	      --       ^^^^^^^    <- Subtype
+	"""
 	_subtype: Symbol
 
 	def __init__(self, subtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
@@ -915,6 +1834,18 @@ class SubtypeAllocation(Allocation):
 
 @export
 class QualifiedExpressionAllocation(Allocation):
+	"""
+	Represents an allocation initialized by a qualified expression.
+
+	The qualified expression providing the initial value is available as :data:`QualifiedExpression`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      p := new integer'(5);
+	      --       ^^^^^^^^^^^    <- QualifiedExpression
+	"""
 	_qualifiedExpression: QualifiedExpression
 
 	def __init__(self, qualifiedExpression: QualifiedExpression, parent: Nullable[ModelEntity] = None) -> None:
@@ -938,7 +1869,11 @@ class QualifiedExpressionAllocation(Allocation):
 
 @export
 class AggregateElement(ModelEntity):
-	"""A ``AggregateElement`` is a base-class for all aggregate elements."""
+	"""
+	Represents the base-class of all aggregate elements.
+
+	Every element carries the value assigned to it (:data:`Expression`).
+	"""
 
 	_expression: ExpressionUnion
 
@@ -960,12 +1895,37 @@ class AggregateElement(ModelEntity):
 
 @export
 class SimpleAggregateElement(AggregateElement):
+	"""
+	Represents an aggregate element given by position.
+
+	A positional element has no choice of its own; only its value (:data:`Expression`).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := ('1', '0', '1', '0', '1', '0', '1', '0');
+	      --       ^^^                                        <- Expression
+	"""
 	def __str__(self) -> str:
 		return str(self._expression)
 
 
 @export
 class IndexedAggregateElement(AggregateElement):
+	"""
+	Represents an aggregate element chosen by an index.
+
+	The index is available as :data:`Index`, the assigned value as :data:`Expression`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := (0 => '1', others => '0');
+	      --       ^                           <- Index
+	      --            ^^^                    <- Expression
+	"""
 	_index: int
 
 	def __init__(self, index: ExpressionUnion, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
@@ -988,6 +1948,19 @@ class IndexedAggregateElement(AggregateElement):
 
 @export
 class RangedAggregateElement(AggregateElement):
+	"""
+	Represents an aggregate element chosen by a range.
+
+	The range is available as :data:`Range`, the assigned value as :data:`Expression`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := (1 to 3 => '0', others => '1');
+	      --       ^^^^^^                           <- Range
+	      --                 ^^^                    <- Expression
+	"""
 	_range: Range
 
 	def __init__(self, rng: Range, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
@@ -1011,6 +1984,19 @@ class RangedAggregateElement(AggregateElement):
 
 @export
 class NamedAggregateElement(AggregateElement):
+	"""
+	Represents an aggregate element chosen by a name.
+
+	Used for record aggregates, where the choice names a record element (:data:`Name`).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      r := (a => '1', b => '0');
+	      --    ^                      <- Name
+	      --         ^^^               <- Expression
+	"""
 	_name: Symbol
 
 	def __init__(self, name: Symbol, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
@@ -1037,6 +2023,19 @@ class NamedAggregateElement(AggregateElement):
 
 @export
 class OthersAggregateElement(AggregateElement):
+	"""
+	Represents the ``others`` element of an aggregate.
+
+	It supplies the value (:data:`Expression`) for every choice not named explicitly.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := (0 => '1', others => '0');
+	      --                 ^^^^^^            <- the choice
+	      --                           ^^^     <- Expression
+	"""
 	def __str__(self) -> str:
 		return "others => {value!s}".format(
 			value=self._expression,
@@ -1045,6 +2044,19 @@ class OthersAggregateElement(AggregateElement):
 
 @export
 class Aggregate(BaseExpression):
+	"""
+	Represents an aggregate.
+
+	An aggregate composes a value from its elements (:data:`Elements`), each of which associates a
+	choice with a value.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := (0 => '1', 1 to 3 => '0', others => '1');
+	      --      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    <- Elements
+	"""
 	_elements: List[AggregateElement]
 
 	def __init__(self, elements: Iterable[AggregateElement], parent: Nullable[ModelEntity] = None) -> None:

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -49,18 +49,27 @@ from pyVHDLModel.Symbol      import PackageReferenceSymbol, SubprogramReferenceS
 
 @export
 class GenericInstantiationMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for instantiations passing generic actuals.
+	"""
 	def __init__(self) -> None:
 		pass
 
 
 @export
 class GenericEntityInstantiationMixin(GenericInstantiationMixin, mixin=True):
+	"""
+	A mixin-class for instantiations of a design entity.
+	"""
 	def __init__(self) -> None:
 		pass
 
 
 @export
 class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
+	"""
+	A mixin-class for instantiations of a generic subprogram.
+	"""
 	_subprogramReference:     SubprogramReferenceSymbol
 	_genericAssociationItems: List[GenericAssociationItem]
 
@@ -102,11 +111,15 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 @export
 class ProcedureInstantiation(Procedure, SubprogramInstantiationMixin):
 	"""
+	Represents the instantiation of a generic procedure.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      procedure p is new q generic map (...);
+	      procedure p is new gp generic map (N => 1);
+	    --^                                             <- Identifier
+	    --                   ^^                         <- GenericProcedure
 	"""
 
 	def __init__(
@@ -128,22 +141,15 @@ class ProcedureInstantiation(Procedure, SubprogramInstantiationMixin):
 @export
 class FunctionInstantiation(Function, SubprogramInstantiationMixin):
 	"""
+	Represents the instantiation of a generic function.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      function f is new g generic map (...);
-
-	.. note::
-
-	   Unlike an ordinary :class:`~pyVHDLModel.Subprogram.Function`, ``ReturnType`` is ``Nullable`` here:
-	   the LRM grammar never lets a subprogram instantiation write its own return type - it is always and
-	   only known by resolving the referenced uninstantiated subprogram, which requires semantic analysis
-	   this project does not perform. This is deliberately different from :class:`~pyVHDLModel.Object.Obj`
-	   (where a subtype is always present in the source, so making it ``Nullable`` would be wrong): here,
-	   a return type is *never* present in the source, so ``None`` reflects a not-yet-resolved reference,
-	   the same status as any other unresolved :attr:`~pyVHDLModel.Symbol.Symbol.Reference`, rather than a
-	   workaround.
+	      function f is new gf generic map (N => 1);
+	    --^                                            <- Identifier
+	    --                  ^^                         <- GenericFunction
 	"""
 
 	def __init__(
@@ -179,6 +185,17 @@ class FunctionInstantiation(Function, SubprogramInstantiationMixin):
 
 @export
 class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a PackageBase class is needed to share members.
+	"""
+	Represents the instantiation of a generic package.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      package p is new gp generic map (N => 1);
+	    --^                                           <- Identifier
+	    --                 ^^                         <- PackageReference
+	"""
 	_packageReference:        PackageReferenceSymbol
 	_genericAssociationItems: List[GenericAssociationItem]
 

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -51,6 +51,12 @@ from pyVHDLModel.Symbol      import PackageReferenceSymbol, SubprogramReferenceS
 class GenericInstantiationMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for instantiations passing generic actuals.
+
+	.. seealso::
+
+	   * :class:`Generic entity instantiation mixin <pyVHDLModel.Instantiation.GenericEntityInstantiationMixin>`
+	   * :class:`Package instantiation <pyVHDLModel.Instantiation.PackageInstantiation>`
+	   * :class:`Subprogram instantiation mixin <pyVHDLModel.Instantiation.SubprogramInstantiationMixin>`
 	"""
 	def __init__(self) -> None:
 		pass
@@ -69,6 +75,11 @@ class GenericEntityInstantiationMixin(GenericInstantiationMixin, mixin=True):
 class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 	"""
 	A mixin-class for instantiations of a generic subprogram.
+
+	.. seealso::
+
+	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
+	   * :class:`Procedure instantiation <pyVHDLModel.Instantiation.ProcedureInstantiation>`
 	"""
 	_subprogramReference:     SubprogramReferenceSymbol
 	_genericAssociationItems: List[GenericAssociationItem]

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -55,8 +55,8 @@ class GenericInstantiationMixin(metaclass=ExtendedType, mixin=True):
 	.. seealso::
 
 	   * :class:`Generic entity instantiation mixin <pyVHDLModel.Instantiation.GenericEntityInstantiationMixin>`
-	   * :class:`Package instantiation <pyVHDLModel.Instantiation.PackageInstantiation>`
 	   * :class:`Subprogram instantiation mixin <pyVHDLModel.Instantiation.SubprogramInstantiationMixin>`
+	   * :class:`Package instantiation <pyVHDLModel.Instantiation.PackageInstantiation>`
 	"""
 	def __init__(self) -> None:
 		pass
@@ -78,8 +78,8 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
 	   * :class:`Procedure instantiation <pyVHDLModel.Instantiation.ProcedureInstantiation>`
+	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
 	"""
 	_subprogramReference:     SubprogramReferenceSymbol
 	_genericAssociationItems: List[GenericAssociationItem]
@@ -129,8 +129,8 @@ class ProcedureInstantiation(Procedure, SubprogramInstantiationMixin):
 	   .. code-block:: VHDL
 
 	      procedure p is new gp generic map (N => 1);
-	    --^                                             <- Identifier
-	    --                   ^^                         <- GenericProcedure
+	      --        ^                                   <- Identifier
+	      --                 ^^                         <- GenericProcedure
 	"""
 
 	def __init__(
@@ -159,8 +159,8 @@ class FunctionInstantiation(Function, SubprogramInstantiationMixin):
 	   .. code-block:: VHDL
 
 	      function f is new gf generic map (N => 1);
-	    --^                                            <- Identifier
-	    --                  ^^                         <- GenericFunction
+	      --       ^                                   <- Identifier
+	      --                ^^                         <- GenericFunction
 	"""
 
 	def __init__(
@@ -204,8 +204,8 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 	   .. code-block:: VHDL
 
 	      package p is new gp generic map (N => 1);
-	    --^                                           <- Identifier
-	    --                 ^^                         <- PackageReference
+	      --      ^                                   <- Identifier
+	      --               ^^                         <- PackageReference
 	"""
 	_packageReference:        PackageReferenceSymbol
 	_genericAssociationItems: List[GenericAssociationItem]

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -54,6 +54,11 @@ class ModeViewElement(ModelEntity, MultipleNamedEntityMixin):
 	Base-class for one element definition inside a mode view declaration (VHDL-2019). An element may name
 	several fields sharing the same specification (e.g. ``a, b : out;``), hence
 	:class:`~pyVHDLModel.Base.MultipleNamedEntityMixin` is inherited.
+
+	.. seealso::
+
+	   * :class:`Composite mode view element <pyVHDLModel.Interface.CompositeModeViewElement>`
+	   * :class:`Simple mode view element <pyVHDLModel.Interface.SimpleModeViewElement>`
 	"""
 
 	def __init__(self, identifiers: Iterable[str], parent: Nullable[ModelEntity] = None) -> None:
@@ -137,6 +142,12 @@ class ModeViewDeclaration(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	        a : out;
 	        b : in;
 	      end view;
+
+	.. seealso::
+
+	   * :class:`Port declared with a mode view <pyVHDLModel.Interface.PortViewSignalInterfaceItem>`
+	   * :class:`Parameter declared with a mode view <pyVHDLModel.Interface.ParameterViewSignalInterfaceItem>`
+	   * :class:`Reference to a mode view <pyVHDLModel.Symbol.ModeViewSymbol>`
 	"""
 
 	_subtype:  SubtypeSymbol
@@ -188,6 +199,13 @@ class InterfaceItemMixin(metaclass=ExtendedType, mixin=True):
 	A mixin-class marking a declaration as an interface item.
 
 	Interface items appear in generic clauses, port clauses and parameter lists.
+
+	.. seealso::
+
+	   * :class:`Generic interface item mixin <pyVHDLModel.Interface.GenericInterfaceItemMixin>`
+	   * :class:`Parameter interface item mixin <pyVHDLModel.Interface.ParameterInterfaceItemMixin>`
+	   * :class:`Port interface item mixin <pyVHDLModel.Interface.PortInterfaceItemMixin>`
+	   * :class:`Port signal interface item <pyVHDLModel.Interface.PortSignalInterfaceItem>`
 	"""
 
 
@@ -197,6 +215,15 @@ class InterfaceItemWithModeMixin(metaclass=ExtendedType, mixin=True):
 	A mixin-class for interface items declared with a mode.
 
 	The mode is available as :data:`Mode`.
+
+	.. seealso::
+
+	   * :class:`Generic constant interface item <pyVHDLModel.Interface.GenericConstantInterfaceItem>`
+	   * :class:`Parameter constant interface item <pyVHDLModel.Interface.ParameterConstantInterfaceItem>`
+	   * :class:`Parameter simple signal interface item <pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem>`
+	   * :class:`Parameter variable interface item <pyVHDLModel.Interface.ParameterVariableInterfaceItem>`
+	   * :class:`Port interface item mixin <pyVHDLModel.Interface.PortInterfaceItemMixin>`
+	   * :class:`Port simple signal interface item <pyVHDLModel.Interface.PortSimpleSignalInterfaceItem>`
 	"""
 
 	_mode: Mode
@@ -218,6 +245,15 @@ class InterfaceItemWithModeMixin(metaclass=ExtendedType, mixin=True):
 class GenericInterfaceItemMixin(InterfaceItemMixin, mixin=True):
 	"""
 	A mixin-class for all items in a generic clause.
+
+	.. seealso::
+
+	   * :class:`Generic constant interface item <pyVHDLModel.Interface.GenericConstantInterfaceItem>`
+	   * :class:`Generic function interface item <pyVHDLModel.Interface.GenericFunctionInterfaceItem>`
+	   * :class:`Generic package interface item <pyVHDLModel.Interface.GenericPackageInterfaceItem>`
+	   * :class:`Generic procedure interface item <pyVHDLModel.Interface.GenericProcedureInterfaceItem>`
+	   * :class:`Generic subprogram interface item <pyVHDLModel.Interface.GenericSubprogramInterfaceItem>`
+	   * :class:`Generic type interface item <pyVHDLModel.Interface.GenericTypeInterfaceItem>`
 	"""
 
 
@@ -236,6 +272,13 @@ class PortInterfaceItemMixin(InterfaceItemMixin, InterfaceItemWithModeMixin, mix
 class ParameterInterfaceItemMixin(InterfaceItemMixin, mixin=True):
 	"""
 	A mixin-class for all items in a subprogram's parameter list.
+
+	.. seealso::
+
+	   * :class:`Parameter constant interface item <pyVHDLModel.Interface.ParameterConstantInterfaceItem>`
+	   * :class:`Parameter file interface item <pyVHDLModel.Interface.ParameterFileInterfaceItem>`
+	   * :class:`Parameter signal interface item <pyVHDLModel.Interface.ParameterSignalInterfaceItem>`
+	   * :class:`Parameter variable interface item <pyVHDLModel.Interface.ParameterVariableInterfaceItem>`
 	"""
 
 
@@ -343,6 +386,10 @@ class InterfacePackage(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	Represents a package as a generic of a design unit.
 
 	An interface package parameterises a design unit with an instantiated package.
+
+	.. seealso::
+
+	   * :class:`Generic package interface item <pyVHDLModel.Interface.GenericPackageInterfaceItem>`
 	"""
 	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -369,6 +416,11 @@ class PortSignalInterfaceItem(Signal, InterfaceItemMixin):
 
 	A port is declared either with a simple mode (:class:`PortSimpleSignalInterfaceItem`) or with a
 	mode view (:class:`PortViewSignalInterfaceItem`).
+
+	.. seealso::
+
+	   * :class:`Port simple signal interface item <pyVHDLModel.Interface.PortSimpleSignalInterfaceItem>`
+	   * :class:`Port view signal interface item <pyVHDLModel.Interface.PortViewSignalInterfaceItem>`
 	"""
 
 
@@ -387,6 +439,10 @@ class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithMo
 	    --^                    <- Identifiers
 	    --          ^^         <- Mode
 	    --             ^^^     <- Subtype
+
+	.. seealso::
+
+	   * :class:`Port declared with a mode view <pyVHDLModel.Interface.PortViewSignalInterfaceItem>`
 	"""
 
 	def __init__(
@@ -426,6 +482,11 @@ class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
 	  :class:`Symbol`, whether it names a subtype or a mode view) - :attr:`ModeViewIndication` is just a
 	  more specific, aliased name for the same value, not a separate field. An object's subtype can never
 	  be ``None`` - there is no VHDL syntax that omits it.
+
+	.. seealso::
+
+	   * :class:`Mode view declaration <pyVHDLModel.Interface.ModeViewDeclaration>`
+	   * :class:`Port declared with a simple mode <pyVHDLModel.Interface.PortSimpleSignalInterfaceItem>`
 	"""
 
 	def __init__(
@@ -516,6 +577,11 @@ class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin):
 	      --             ^                     <- Identifiers
 	      --                        ^^         <- Mode
 	      --                           ^^^     <- Subtype
+
+	.. seealso::
+
+	   * :class:`Parameter simple signal interface item <pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem>`
+	   * :class:`Parameter view signal interface item <pyVHDLModel.Interface.ParameterViewSignalInterfaceItem>`
 	"""
 
 
@@ -570,6 +636,11 @@ class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
 
 	  See :class:`PortViewSignalInterfaceItem` for why the mode view reference *is* :attr:`Subtype`
 	  (aliased as :attr:`ModeViewIndication`), rather than a separate, possibly-``None`` field.
+
+	.. seealso::
+
+	   * :class:`Mode view declaration <pyVHDLModel.Interface.ModeViewDeclaration>`
+	   * :class:`Parameter declared with a simple mode <pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem>`
 	"""
 
 	def __init__(
@@ -620,6 +691,12 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
 class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for language constructs with a generic clause.
+
+	.. seealso::
+
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Generic group <pyVHDLModel.Interface.GenericGroup>`
+	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
 	"""
 	_genericItems: List[GenericInterfaceItemMixin]
 
@@ -656,6 +733,12 @@ class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
 class WithPortsMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for language constructs with a port clause.
+
+	.. seealso::
+
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Port group <pyVHDLModel.Interface.PortGroup>`
 	"""
 	_portItems: List[PortInterfaceItemMixin]
 
@@ -692,6 +775,10 @@ class WithPortsMixin(metaclass=ExtendedType, mixin=True):
 class WithParametersMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for language constructs with a parameter list.
+
+	.. seealso::
+
+	   * :class:`Parameter group <pyVHDLModel.Interface.ParameterGroup>`
 	"""
 	_parameterItems: List[ParameterInterfaceItemMixin]
 
@@ -730,6 +817,12 @@ class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin, DocumentedEntityMi
 	Represents a group of interface items sharing one clause.
 
 	The group may be named (:data:`Identifier`), which is optional.
+
+	.. seealso::
+
+	   * :class:`Generic group <pyVHDLModel.Interface.GenericGroup>`
+	   * :class:`Parameter group <pyVHDLModel.Interface.ParameterGroup>`
+	   * :class:`Port group <pyVHDLModel.Interface.PortGroup>`
 	"""
 	def __init__(
 		self,
@@ -749,6 +842,11 @@ class GenericGroup(InterfaceGroup, WithGenericsMixin):
 	Represents the generic clause of a design unit.
 
 	The generics are available as :data:`GenericItems`.
+
+	.. seealso::
+
+	   * :class:`Port clause <pyVHDLModel.Interface.PortGroup>`
+	   * :class:`Parameter list <pyVHDLModel.Interface.ParameterGroup>`
 	"""
 	def __init__(
 		self,
@@ -777,6 +875,11 @@ class PortGroup(InterfaceGroup, WithPortsMixin):
 	Represents the port clause of a design unit.
 
 	The ports are available as :data:`PortItems`.
+
+	.. seealso::
+
+	   * :class:`Generic clause <pyVHDLModel.Interface.GenericGroup>`
+	   * :class:`Parameter list <pyVHDLModel.Interface.ParameterGroup>`
 	"""
 	def __init__(
 		self,
@@ -805,6 +908,11 @@ class ParameterGroup(InterfaceGroup, WithParametersMixin):
 	Represents the parameter list of a subprogram.
 
 	The parameters are available as :data:`ParameterItems`.
+
+	.. seealso::
+
+	   * :class:`Generic clause <pyVHDLModel.Interface.GenericGroup>`
+	   * :class:`Port clause <pyVHDLModel.Interface.PortGroup>`
 	"""
 	def __init__(
 		self,

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -57,8 +57,8 @@ class ModeViewElement(ModelEntity, MultipleNamedEntityMixin):
 
 	.. seealso::
 
-	   * :class:`Composite mode view element <pyVHDLModel.Interface.CompositeModeViewElement>`
 	   * :class:`Simple mode view element <pyVHDLModel.Interface.SimpleModeViewElement>`
+	   * :class:`Composite mode view element <pyVHDLModel.Interface.CompositeModeViewElement>`
 	"""
 
 	def __init__(self, identifiers: Iterable[str], parent: Nullable[ModelEntity] = None) -> None:
@@ -203,8 +203,8 @@ class InterfaceItemMixin(metaclass=ExtendedType, mixin=True):
 	.. seealso::
 
 	   * :class:`Generic interface item mixin <pyVHDLModel.Interface.GenericInterfaceItemMixin>`
-	   * :class:`Parameter interface item mixin <pyVHDLModel.Interface.ParameterInterfaceItemMixin>`
 	   * :class:`Port interface item mixin <pyVHDLModel.Interface.PortInterfaceItemMixin>`
+	   * :class:`Parameter interface item mixin <pyVHDLModel.Interface.ParameterInterfaceItemMixin>`
 	   * :class:`Port signal interface item <pyVHDLModel.Interface.PortSignalInterfaceItem>`
 	"""
 
@@ -218,12 +218,12 @@ class InterfaceItemWithModeMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Generic constant interface item <pyVHDLModel.Interface.GenericConstantInterfaceItem>`
-	   * :class:`Parameter constant interface item <pyVHDLModel.Interface.ParameterConstantInterfaceItem>`
-	   * :class:`Parameter simple signal interface item <pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem>`
-	   * :class:`Parameter variable interface item <pyVHDLModel.Interface.ParameterVariableInterfaceItem>`
 	   * :class:`Port interface item mixin <pyVHDLModel.Interface.PortInterfaceItemMixin>`
+	   * :class:`Generic constant interface item <pyVHDLModel.Interface.GenericConstantInterfaceItem>`
 	   * :class:`Port simple signal interface item <pyVHDLModel.Interface.PortSimpleSignalInterfaceItem>`
+	   * :class:`Parameter constant interface item <pyVHDLModel.Interface.ParameterConstantInterfaceItem>`
+	   * :class:`Parameter variable interface item <pyVHDLModel.Interface.ParameterVariableInterfaceItem>`
+	   * :class:`Parameter simple signal interface item <pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem>`
 	"""
 
 	_mode: Mode
@@ -249,11 +249,11 @@ class GenericInterfaceItemMixin(InterfaceItemMixin, mixin=True):
 	.. seealso::
 
 	   * :class:`Generic constant interface item <pyVHDLModel.Interface.GenericConstantInterfaceItem>`
+	   * :class:`Generic type interface item <pyVHDLModel.Interface.GenericTypeInterfaceItem>`
+	   * :class:`Generic subprogram interface item <pyVHDLModel.Interface.GenericSubprogramInterfaceItem>`
+	   * :class:`Generic procedure interface item <pyVHDLModel.Interface.GenericProcedureInterfaceItem>`
 	   * :class:`Generic function interface item <pyVHDLModel.Interface.GenericFunctionInterfaceItem>`
 	   * :class:`Generic package interface item <pyVHDLModel.Interface.GenericPackageInterfaceItem>`
-	   * :class:`Generic procedure interface item <pyVHDLModel.Interface.GenericProcedureInterfaceItem>`
-	   * :class:`Generic subprogram interface item <pyVHDLModel.Interface.GenericSubprogramInterfaceItem>`
-	   * :class:`Generic type interface item <pyVHDLModel.Interface.GenericTypeInterfaceItem>`
 	"""
 
 
@@ -276,9 +276,9 @@ class ParameterInterfaceItemMixin(InterfaceItemMixin, mixin=True):
 	.. seealso::
 
 	   * :class:`Parameter constant interface item <pyVHDLModel.Interface.ParameterConstantInterfaceItem>`
-	   * :class:`Parameter file interface item <pyVHDLModel.Interface.ParameterFileInterfaceItem>`
-	   * :class:`Parameter signal interface item <pyVHDLModel.Interface.ParameterSignalInterfaceItem>`
 	   * :class:`Parameter variable interface item <pyVHDLModel.Interface.ParameterVariableInterfaceItem>`
+	   * :class:`Parameter signal interface item <pyVHDLModel.Interface.ParameterSignalInterfaceItem>`
+	   * :class:`Parameter file interface item <pyVHDLModel.Interface.ParameterFileInterfaceItem>`
 	"""
 
 
@@ -436,9 +436,9 @@ class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithMo
 	   .. code-block:: VHDL
 
 	      port (p : in bit);
-	    --^                    <- Identifiers
-	    --          ^^         <- Mode
-	    --             ^^^     <- Subtype
+	      --    ^              <- Identifiers
+	      --        ^^         <- Mode
+	      --           ^^^     <- Subtype
 
 	.. seealso::
 
@@ -471,17 +471,8 @@ class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
 	   .. code-block:: VHDL
 
 	      port (p : view MyView);
-	    --^                         <- Identifiers
-	    --               ^^^^^^     <- ModeViewIndication
-
-	. note::
-
-	  VHDL's grammar treats a mode view indication as occupying the same structural position as an
-	  ordinary subtype indication (``mode_indication ::= simple_mode_indication | mode_view_indication``).
-	  Accordingly, the mode view reference *is* this object's :attr:`Subtype` (a :class:`Symbol` is a
-	  :class:`Symbol`, whether it names a subtype or a mode view) - :attr:`ModeViewIndication` is just a
-	  more specific, aliased name for the same value, not a separate field. An object's subtype can never
-	  be ``None`` - there is no VHDL syntax that omits it.
+	      --    ^                   <- Identifiers
+	      --             ^^^^^^     <- ModeViewIndication
 
 	.. seealso::
 
@@ -517,10 +508,10 @@ class ParameterConstantInterfaceItem(Constant, ParameterInterfaceItemMixin, Inte
 
 	   .. code-block:: VHDL
 
-	      function fun(constant c : in integer) return integer;
-	      -- ^                                                    <- Identifiers
-	      --                        ^^                            <- Mode
-	      --                           ^^^^^^^                    <- Subtype
+	      function fun(constant cst : in integer) return integer;
+	      --                    ^^^                                 <- Identifiers
+	      --                          ^^                            <- Mode
+	      --                             ^^^^^^^                    <- Subtype
 	"""
 	def __init__(
 		self,
@@ -545,10 +536,10 @@ class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItemMixin, Inte
 
 	   .. code-block:: VHDL
 
-	      procedure proc(variable v : out bit);
-	      --             ^                        <- Identifiers
-	      --                          ^^^         <- Mode
-	      --                              ^^^     <- Subtype
+	      procedure proc(variable var : out bit);
+	      --                      ^^^               <- Identifiers
+	      --                            ^^^         <- Mode
+	      --                                ^^^     <- Subtype
 	"""
 	def __init__(
 		self,
@@ -573,10 +564,10 @@ class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin):
 
 	   .. code-block:: VHDL
 
-	      procedure proc(signal s : in bit);
-	      --             ^                     <- Identifiers
-	      --                        ^^         <- Mode
-	      --                           ^^^     <- Subtype
+	      procedure proc(signal sig : in bit);
+	      --                    ^^^              <- Identifiers
+	      --                          ^^         <- Mode
+	      --                             ^^^     <- Subtype
 
 	.. seealso::
 
@@ -596,10 +587,10 @@ class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, Interface
 
 	   .. code-block:: VHDL
 
-	      procedure proc(signal s : in bit);
-	      --             ^                     <- Identifiers
-	      --                        ^^         <- Mode
-	      --                           ^^^     <- Subtype
+	      procedure proc(signal sig : in bit);
+	      --                    ^^^              <- Identifiers
+	      --                          ^^         <- Mode
+	      --                             ^^^     <- Subtype
 	"""
 
 	def __init__(
@@ -628,14 +619,9 @@ class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
 
 	   .. code-block:: VHDL
 
-	      procedure proc(signal s : view MyView);
-	      --             ^                          <- Identifiers
-	      --                             ^^^^^^     <- ModeViewIndication
-
-	. note::
-
-	  See :class:`PortViewSignalInterfaceItem` for why the mode view reference *is* :attr:`Subtype`
-	  (aliased as :attr:`ModeViewIndication`), rather than a separate, possibly-``None`` field.
+	      procedure proc(signal sig : view MasterView);
+	      --                    ^^^                       <- Identifiers
+	      --                               ^^^^^^^^^^     <- ModeViewIndication
 
 	.. seealso::
 
@@ -672,9 +658,9 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
 
 	   .. code-block:: VHDL
 
-	      procedure proc(file f : text_file);
-	      --             ^                      <- Identifiers
-	      --                      ^^^^^^^^^     <- Subtype
+	      procedure proc(file fil : text_file);
+	      --                  ^^^                 <- Identifiers
+	      --                        ^^^^^^^^^     <- Subtype
 	"""
 	def __init__(
 		self,
@@ -694,9 +680,9 @@ class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
+	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
 	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
 	   * :class:`Generic group <pyVHDLModel.Interface.GenericGroup>`
-	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
 	"""
 	_genericItems: List[GenericInterfaceItemMixin]
 
@@ -821,8 +807,8 @@ class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin, DocumentedEntityMi
 	.. seealso::
 
 	   * :class:`Generic group <pyVHDLModel.Interface.GenericGroup>`
-	   * :class:`Parameter group <pyVHDLModel.Interface.ParameterGroup>`
 	   * :class:`Port group <pyVHDLModel.Interface.PortGroup>`
+	   * :class:`Parameter group <pyVHDLModel.Interface.ParameterGroup>`
 	"""
 	def __init__(
 		self,

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -185,13 +185,19 @@ class ModeViewDeclaration(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 @export
 class InterfaceItemMixin(metaclass=ExtendedType, mixin=True):
 	"""
-	A base-class for all mixin-classes for all interface items.
+	A mixin-class marking a declaration as an interface item.
+
+	Interface items appear in generic clauses, port clauses and parameter lists.
 	"""
 
 
 @export
 class InterfaceItemWithModeMixin(metaclass=ExtendedType, mixin=True):
-	"""An ``InterfaceItemWithMode`` is a mixin-class to provide a ``Mode`` to interface items."""
+	"""
+	A mixin-class for interface items declared with a mode.
+
+	The mode is available as :data:`Mode`.
+	"""
 
 	_mode: Mode
 
@@ -210,12 +216,16 @@ class InterfaceItemWithModeMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class GenericInterfaceItemMixin(InterfaceItemMixin, mixin=True):
-	"""A ``GenericInterfaceItem`` is a mixin class for all generic interface items."""
+	"""
+	A mixin-class for all items in a generic clause.
+	"""
 
 
 @export
 class PortInterfaceItemMixin(InterfaceItemMixin, InterfaceItemWithModeMixin, mixin=True):
-	"""A ``PortInterfaceItem`` is a mixin class for all port interface items."""
+	"""
+	A mixin-class for all items in a port clause.
+	"""
 
 	def __init__(self, mode: Mode) -> None:
 		super().__init__()
@@ -224,11 +234,25 @@ class PortInterfaceItemMixin(InterfaceItemMixin, InterfaceItemWithModeMixin, mix
 
 @export
 class ParameterInterfaceItemMixin(InterfaceItemMixin, mixin=True):
-	"""A ``ParameterInterfaceItem`` is a mixin class for all parameter interface items."""
+	"""
+	A mixin-class for all items in a subprogram's parameter list.
+	"""
 
 
 @export
 class GenericConstantInterfaceItem(Constant, GenericInterfaceItemMixin, InterfaceItemWithModeMixin):
+	"""
+	Represents a constant in a generic clause.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      generic (W : positive := 8);
+	      --       ^                     <- Identifiers
+	      --           ^^^^^^^^          <- Subtype
+	      --                       ^     <- DefaultExpression
+	"""
 	def __init__(
 		self,
 		identifiers: Iterable[str],
@@ -245,6 +269,18 @@ class GenericConstantInterfaceItem(Constant, GenericInterfaceItemMixin, Interfac
 
 @export
 class GenericTypeInterfaceItem(Type, GenericInterfaceItemMixin):
+	"""
+	Represents a type in a generic clause.
+
+	A generic type introduces a type name without defining the type.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      generic (type T);
+	      --            ^     <- Identifier
+	"""
 	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
@@ -252,11 +288,25 @@ class GenericTypeInterfaceItem(Type, GenericInterfaceItemMixin):
 
 @export
 class GenericSubprogramInterfaceItem(GenericInterfaceItemMixin):
+	"""
+	Represents the base-class of subprograms in a generic clause.
+	"""
 	pass
 
 
 @export
 class GenericProcedureInterfaceItem(Procedure, GenericInterfaceItemMixin):
+	"""
+	Represents a procedure in a generic clause.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      generic (procedure log(msg : string));
+	      --                 ^^^                   <- Identifier
+	      --                     ^^^^^^^^^^^^      <- ParameterItems
+	"""
 	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation=documentation, parent=parent)
 		GenericInterfaceItemMixin.__init__(self)
@@ -264,6 +314,18 @@ class GenericProcedureInterfaceItem(Procedure, GenericInterfaceItemMixin):
 
 @export
 class GenericFunctionInterfaceItem(Function, GenericInterfaceItemMixin):
+	"""
+	Represents a function in a generic clause.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      generic (function cmp(a, b : integer) return boolean);
+	      --                ^^^                                    <- Identifier
+	      --                    ^^^^^^^^^^^^^^                     <- ParameterItems
+	      --                                           ^^^^^^^     <- ReturnType
+	"""
 	def __init__(
 		self,
 		identifier:    str,
@@ -277,6 +339,11 @@ class GenericFunctionInterfaceItem(Function, GenericInterfaceItemMixin):
 
 @export
 class InterfacePackage(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
+	"""
+	Represents a package as a generic of a design unit.
+
+	An interface package parameterises a design unit with an instantiated package.
+	"""
 	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
@@ -285,6 +352,11 @@ class InterfacePackage(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 @export
 class GenericPackageInterfaceItem(InterfacePackage, GenericInterfaceItemMixin):
+	"""
+	Represents a package in a generic clause.
+
+	A generic package parameterises a design unit with an instantiated package.
+	"""
 	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
 		GenericInterfaceItemMixin.__init__(self)
@@ -293,21 +365,28 @@ class GenericPackageInterfaceItem(InterfacePackage, GenericInterfaceItemMixin):
 @export
 class PortSignalInterfaceItem(Signal, InterfaceItemMixin):
 	"""
-	Abstract base-class for port signal interface items - either declared with a simple mode
-	(:class:`PortSimpleSignalInterfaceItem`) or with a mode view (:class:`PortViewSignalInterfaceItem`,
-	VHDL-2019).
+	Represents the base-class of all signals in a port clause.
+
+	A port is declared either with a simple mode (:class:`PortSimpleSignalInterfaceItem`) or with a
+	mode view (:class:`PortViewSignalInterfaceItem`).
 	"""
 
 
 @export
 class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithModeMixin):
 	"""
+	Represents a port declared with a simple mode.
+
+	The port's mode is available as :data:`Mode`, its subtype as :data:`Subtype`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      port (p : in bit);
+	    --^                    <- Identifiers
+	    --          ^^         <- Mode
+	    --             ^^^     <- Subtype
 	"""
 
 	def __init__(
@@ -326,21 +405,27 @@ class PortSimpleSignalInterfaceItem(PortSignalInterfaceItem, InterfaceItemWithMo
 @export
 class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
 	"""
+	Represents a port declared with a mode view (VHDL-2019).
+
+	Instead of a mode, the port names a mode view (:data:`ModeViewIndication`) that assigns a mode to
+	each element of its record type.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      port (p : view MyView);
+	    --^                         <- Identifiers
+	    --               ^^^^^^     <- ModeViewIndication
 
-	.. note::
+	. note::
 
-	   VHDL's grammar treats a mode view indication as occupying the same structural position as an
-	   ordinary subtype indication (``mode_indication ::= simple_mode_indication | mode_view_indication``).
-	   Accordingly, the mode view reference *is* this object's :attr:`Subtype` (a :class:`Symbol` is a
-	   :class:`Symbol`, whether it names a subtype or a mode view) - :attr:`ModeViewIndication` is just a
-	   more specific, aliased name for the same value, not a separate field. An object's subtype can never
-	   be ``None`` - there is no VHDL syntax that omits it.
+	  VHDL's grammar treats a mode view indication as occupying the same structural position as an
+	  ordinary subtype indication (``mode_indication ::= simple_mode_indication | mode_view_indication``).
+	  Accordingly, the mode view reference *is* this object's :attr:`Subtype` (a :class:`Symbol` is a
+	  :class:`Symbol`, whether it names a subtype or a mode view) - :attr:`ModeViewIndication` is just a
+	  more specific, aliased name for the same value, not a separate field. An object's subtype can never
+	  be ``None`` - there is no VHDL syntax that omits it.
 	"""
 
 	def __init__(
@@ -364,6 +449,18 @@ class PortViewSignalInterfaceItem(PortSignalInterfaceItem):
 
 @export
 class ParameterConstantInterfaceItem(Constant, ParameterInterfaceItemMixin, InterfaceItemWithModeMixin):
+	"""
+	Represents a constant parameter of a subprogram.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      function fun(constant c : in integer) return integer;
+	      -- ^                                                    <- Identifiers
+	      --                        ^^                            <- Mode
+	      --                           ^^^^^^^                    <- Subtype
+	"""
 	def __init__(
 		self,
 		identifiers: Iterable[str],
@@ -380,6 +477,18 @@ class ParameterConstantInterfaceItem(Constant, ParameterInterfaceItemMixin, Inte
 
 @export
 class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItemMixin, InterfaceItemWithModeMixin):
+	"""
+	Represents a variable parameter of a subprogram.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure proc(variable v : out bit);
+	      --             ^                        <- Identifiers
+	      --                          ^^^         <- Mode
+	      --                              ^^^     <- Subtype
+	"""
 	def __init__(
 		self,
 		identifiers: Iterable[str],
@@ -397,21 +506,34 @@ class ParameterVariableInterfaceItem(Variable, ParameterInterfaceItemMixin, Inte
 @export
 class ParameterSignalInterfaceItem(Signal, ParameterInterfaceItemMixin):
 	"""
-	Abstract base-class for subprogram signal parameters - either declared with a simple mode
-	(:class:`ParameterSimpleSignalInterfaceItem`) or with a mode view
-	(:class:`ParameterViewSignalInterfaceItem`, VHDL-2019).
-	"""
-
-
-@export
-class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, InterfaceItemWithModeMixin):
-	"""
+	Represents a signal parameter of a subprogram.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      procedure proc(signal s : in bit);
+	      --             ^                     <- Identifiers
+	      --                        ^^         <- Mode
+	      --                           ^^^     <- Subtype
+	"""
+
+
+@export
+class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, InterfaceItemWithModeMixin):
+	"""
+	Represents a signal parameter declared with a simple mode.
+
+	The parameter's mode is available as :data:`Mode`, its subtype as :data:`Subtype`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure proc(signal s : in bit);
+	      --             ^                     <- Identifiers
+	      --                        ^^         <- Mode
+	      --                           ^^^     <- Subtype
 	"""
 
 	def __init__(
@@ -431,17 +553,23 @@ class ParameterSimpleSignalInterfaceItem(ParameterSignalInterfaceItem, Interface
 @export
 class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
 	"""
+	Represents a signal parameter declared with a mode view (VHDL-2019).
+
+	Instead of a mode, the parameter names a mode view (:data:`ModeViewIndication`) that assigns a mode
+	to each element of its record type.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      procedure proc(signal s : view MyView);
+	      --             ^                          <- Identifiers
+	      --                             ^^^^^^     <- ModeViewIndication
 
-	.. note::
+	. note::
 
-	   See :class:`PortViewSignalInterfaceItem` for why the mode view reference *is* :attr:`Subtype`
-	   (aliased as :attr:`ModeViewIndication`), rather than a separate, possibly-``None`` field.
+	  See :class:`PortViewSignalInterfaceItem` for why the mode view reference *is* :attr:`Subtype`
+	  (aliased as :attr:`ModeViewIndication`), rather than a separate, possibly-``None`` field.
 	"""
 
 	def __init__(
@@ -466,6 +594,17 @@ class ParameterViewSignalInterfaceItem(ParameterSignalInterfaceItem):
 
 @export
 class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
+	"""
+	Represents a file parameter of a subprogram.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure proc(file f : text_file);
+	      --             ^                      <- Identifiers
+	      --                      ^^^^^^^^^     <- Subtype
+	"""
 	def __init__(
 		self,
 		identifiers: Iterable[str],
@@ -479,6 +618,9 @@ class ParameterFileInterfaceItem(File, ParameterInterfaceItemMixin):
 
 @export
 class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language constructs with a generic clause.
+	"""
 	_genericItems: List[GenericInterfaceItemMixin]
 
 	def __init__(
@@ -512,6 +654,9 @@ class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class WithPortsMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language constructs with a port clause.
+	"""
 	_portItems: List[PortInterfaceItemMixin]
 
 	def __init__(
@@ -545,6 +690,9 @@ class WithPortsMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class WithParametersMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language constructs with a parameter list.
+	"""
 	_parameterItems: List[ParameterInterfaceItemMixin]
 
 	def __init__(
@@ -578,6 +726,11 @@ class WithParametersMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin, DocumentedEntityMixin):
+	"""
+	Represents a group of interface items sharing one clause.
+
+	The group may be named (:data:`Identifier`), which is optional.
+	"""
 	def __init__(
 		self,
 		name:   Nullable[str] = None,
@@ -592,6 +745,11 @@ class InterfaceGroup(ModelEntity, OptionallyNamedEntityMixin, DocumentedEntityMi
 
 @export
 class GenericGroup(InterfaceGroup, WithGenericsMixin):
+	"""
+	Represents the generic clause of a design unit.
+
+	The generics are available as :data:`GenericItems`.
+	"""
 	def __init__(
 		self,
 		genericItems:  Iterable[GenericInterfaceItemMixin],
@@ -615,6 +773,11 @@ class GenericGroup(InterfaceGroup, WithGenericsMixin):
 
 @export
 class PortGroup(InterfaceGroup, WithPortsMixin):
+	"""
+	Represents the port clause of a design unit.
+
+	The ports are available as :data:`PortItems`.
+	"""
 	def __init__(
 		self,
 		portItems:     Iterable[PortInterfaceItemMixin],
@@ -638,6 +801,11 @@ class PortGroup(InterfaceGroup, WithPortsMixin):
 
 @export
 class ParameterGroup(InterfaceGroup, WithParametersMixin):
+	"""
+	Represents the parameter list of a subprogram.
+
+	The parameters are available as :data:`ParameterItems`.
+	"""
 	def __init__(
 		self,
 		parameterItems: Iterable[ParameterInterfaceItemMixin],

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -45,7 +45,19 @@ from pyVHDLModel.Base import ModelEntity, ExpressionUnion
 
 @export
 class Name(ModelEntity):
-	"""``Name`` is the base-class for all *names* in the VHDL language model."""
+	"""
+	``Name`` is the base-class for all *names* in the VHDL language model.
+
+	.. seealso::
+
+	   * :class:`Attribute name <pyVHDLModel.Name.AttributeName>`
+	   * :class:`Indexed name <pyVHDLModel.Name.IndexedName>`
+	   * :class:`Open name <pyVHDLModel.Name.OpenName>`
+	   * :class:`Parenthesis name <pyVHDLModel.Name.ParenthesisName>`
+	   * :class:`Selected name <pyVHDLModel.Name.SelectedName>`
+	   * :class:`Simple name <pyVHDLModel.Name.SimpleName>`
+	   * :class:`Sliced name <pyVHDLModel.Name.SlicedName>`
+	"""
 
 	_identifier: str
 	_normalizedIdentifier: str
@@ -220,6 +232,10 @@ class SelectedName(Name):
 	For example, the library and entity name in a direct entity instantiation is a selected name. Here the entity
 	identifier is a selected name. The library identifier is a :class:`simple name <SimpleName>`, which is
 	referenced by the selected name via the :attr:`~pyVHDLModel.Name.Prefix` property.
+
+	.. seealso::
+
+	   * :class:`All name <pyVHDLModel.Name.AllName>`
 	"""
 
 	def __init__(self, identifier: str, prefix: Name, parent: Nullable[ModelEntity] = None) -> None:

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -134,6 +134,11 @@ class SimpleName(Name):
 
 @export
 class ParenthesisName(Name):
+	"""
+	Represents a name followed by a parenthesized association list.
+
+	Used where indexing and a function call are indistinguishable before resolution.
+	"""
 	_associations: List
 
 	def __init__(self, prefix: Name, associations: Iterable, parent: Nullable[ModelEntity] = None) -> None:
@@ -159,6 +164,16 @@ class ParenthesisName(Name):
 
 @export
 class IndexedName(Name):
+	"""
+	Represents a name indexing an array by one or more values.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= v(0);
+	      --   ^^^^    <- the indexed name
+	"""
 	_indices: List[ExpressionUnion]
 
 	def __init__(self, prefix: Name, indices: Iterable[ExpressionUnion], parent: Nullable[ModelEntity] = None) -> None:
@@ -184,6 +199,16 @@ class IndexedName(Name):
 
 @export
 class SlicedName(Name):
+	"""
+	Represents a name selecting a slice of an array.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      vres := v(3 downto 0);
+	      --      ^^^^^^^^^^^^^    <- the sliced name
+	"""
 	pass
 
 
@@ -206,6 +231,16 @@ class SelectedName(Name):
 
 @export
 class AttributeName(Name):
+	"""
+	Represents a name selecting an attribute of its prefix.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for i in v'range loop
+	      --       ^^^^^^^        <- the attribute name
+	"""
 	def __init__(self, identifier: str, prefix: Name, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, prefix, parent)
 

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -50,13 +50,13 @@ class Name(ModelEntity):
 
 	.. seealso::
 
-	   * :class:`Attribute name <pyVHDLModel.Name.AttributeName>`
-	   * :class:`Indexed name <pyVHDLModel.Name.IndexedName>`
-	   * :class:`Open name <pyVHDLModel.Name.OpenName>`
-	   * :class:`Parenthesis name <pyVHDLModel.Name.ParenthesisName>`
-	   * :class:`Selected name <pyVHDLModel.Name.SelectedName>`
 	   * :class:`Simple name <pyVHDLModel.Name.SimpleName>`
+	   * :class:`Parenthesis name <pyVHDLModel.Name.ParenthesisName>`
+	   * :class:`Indexed name <pyVHDLModel.Name.IndexedName>`
 	   * :class:`Sliced name <pyVHDLModel.Name.SlicedName>`
+	   * :class:`Selected name <pyVHDLModel.Name.SelectedName>`
+	   * :class:`Attribute name <pyVHDLModel.Name.AttributeName>`
+	   * :class:`Open name <pyVHDLModel.Name.OpenName>`
 	"""
 
 	_identifier: str

--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -48,6 +48,12 @@ O = TypeVar("O")
 
 
 class ExtendedKeyError(KeyError):
+	"""
+	A :exc:`KeyError` reporting which namespaces were searched.
+
+	Raised when a name cannot be resolved. Besides the key (:data:`key`), it carries every namespace
+	visited while walking outwards (:data:`searchedNamespaces`).
+	"""
 	key: str
 	searchedNamespaces: Tuple["Namespace", ...]
 
@@ -59,6 +65,13 @@ class ExtendedKeyError(KeyError):
 
 
 class Namespace(Generic[K, O]):
+	"""
+	Represents a namespace: the declared items visible in one declarative region.
+
+	Namespaces nest, so a lookup that misses locally continues in the parent namespace
+	(:data:`ParentNamespace`). That is what makes an entity's ports visible inside its architecture,
+	and lets a process variable hide an outer signal.
+	"""
 	_name:            str
 	_parentNamespace: "Namespace"
 	_subNamespaces:   Dict[str, "Namespace"]

--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -71,6 +71,11 @@ class Namespace(Generic[K, O]):
 	Namespaces nest, so a lookup that misses locally continues in the parent namespace
 	(:data:`ParentNamespace`). That is what makes an entity's ports visible inside its architecture,
 	and lets a process variable hide an outer signal.
+
+	.. seealso::
+
+	   * :class:`Concurrent declaration region <pyVHDLModel.Regions.ConcurrentDeclarationRegionMixin>`
+	   * :class:`Sequential declaration region <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
 	"""
 	_name:            str
 	_parentNamespace: "Namespace"

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -61,10 +61,10 @@ class Obj(ModelEntity, MultipleNamedEntityMixin, DocumentedEntityMixin):
 	.. seealso::
 
 	   * :class:`Base constant <pyVHDLModel.Object.BaseConstant>`
-	   * :class:`File <pyVHDLModel.Object.File>`
+	   * :class:`Variable <pyVHDLModel.Object.Variable>`
 	   * :class:`Shared variable <pyVHDLModel.Object.SharedVariable>`
 	   * :class:`Signal <pyVHDLModel.Object.Signal>`
-	   * :class:`Variable <pyVHDLModel.Object.Variable>`
+	   * :class:`File <pyVHDLModel.Object.File>`
 	"""
 
 	_subtype:      Symbol
@@ -112,8 +112,8 @@ class WithDefaultExpressionMixin(metaclass=ExtendedType, mixin=True):
 	.. seealso::
 
 	   * :class:`Constant <pyVHDLModel.Object.Constant>`
-	   * :class:`Signal <pyVHDLModel.Object.Signal>`
 	   * :class:`Variable <pyVHDLModel.Object.Variable>`
+	   * :class:`Signal <pyVHDLModel.Object.Signal>`
 	"""
 
 	_defaultExpression: Nullable[ExpressionUnion]
@@ -271,8 +271,8 @@ class Signal(Obj, WithDefaultExpressionMixin):
 
 	.. seealso::
 
-	   * :class:`Parameter signal interface item <pyVHDLModel.Interface.ParameterSignalInterfaceItem>`
 	   * :class:`Port signal interface item <pyVHDLModel.Interface.PortSignalInterfaceItem>`
+	   * :class:`Parameter signal interface item <pyVHDLModel.Interface.ParameterSignalInterfaceItem>`
 	"""
 
 	def __init__(

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -57,6 +57,14 @@ class Obj(ModelEntity, MultipleNamedEntityMixin, DocumentedEntityMixin):
 
 	Objects are elements in the type and object graph, thus a reference to a vertex in that graph is stored in
 	:data:`__objectVertex`.
+
+	.. seealso::
+
+	   * :class:`Base constant <pyVHDLModel.Object.BaseConstant>`
+	   * :class:`File <pyVHDLModel.Object.File>`
+	   * :class:`Shared variable <pyVHDLModel.Object.SharedVariable>`
+	   * :class:`Signal <pyVHDLModel.Object.Signal>`
+	   * :class:`Variable <pyVHDLModel.Object.Variable>`
 	"""
 
 	_subtype:      Symbol
@@ -100,6 +108,12 @@ class WithDefaultExpressionMixin(metaclass=ExtendedType, mixin=True):
 
 	The default expression is referenced by :data:`__defaultExpression`. If no default expression is present, this field
 	is ``None``.
+
+	.. seealso::
+
+	   * :class:`Constant <pyVHDLModel.Object.Constant>`
+	   * :class:`Signal <pyVHDLModel.Object.Signal>`
+	   * :class:`Variable <pyVHDLModel.Object.Variable>`
 	"""
 
 	_defaultExpression: Nullable[ExpressionUnion]
@@ -123,6 +137,11 @@ class WithDefaultExpressionMixin(metaclass=ExtendedType, mixin=True):
 class BaseConstant(Obj):
 	"""
 	Base-class for all constants (normal and deferred constants) in VHDL.
+
+	.. seealso::
+
+	   * :class:`Constant <pyVHDLModel.Object.Constant>`
+	   * :class:`Deferred constant <pyVHDLModel.Object.DeferredConstant>`
 	"""
 
 
@@ -138,6 +157,11 @@ class Constant(BaseConstant, WithDefaultExpressionMixin):
 	   .. code-block:: VHDL
 
 	      constant BITS : positive := 8;
+
+	.. seealso::
+
+	   * :class:`Generic constant interface item <pyVHDLModel.Interface.GenericConstantInterfaceItem>`
+	   * :class:`Parameter constant interface item <pyVHDLModel.Interface.ParameterConstantInterfaceItem>`
 	"""
 
 	def __init__(
@@ -204,6 +228,10 @@ class Variable(Obj, WithDefaultExpressionMixin):
 	   .. code-block:: VHDL
 
 	      variable result : natural := 0;
+
+	.. seealso::
+
+	   * :class:`Parameter variable interface item <pyVHDLModel.Interface.ParameterVariableInterfaceItem>`
 	"""
 
 	def __init__(
@@ -240,6 +268,11 @@ class Signal(Obj, WithDefaultExpressionMixin):
 	   .. code-block:: VHDL
 
 	      signal counter : unsigned(7 downto 0) := '0';
+
+	.. seealso::
+
+	   * :class:`Parameter signal interface item <pyVHDLModel.Interface.ParameterSignalInterfaceItem>`
+	   * :class:`Port signal interface item <pyVHDLModel.Interface.PortSignalInterfaceItem>`
 	"""
 
 	def __init__(
@@ -260,4 +293,8 @@ class File(Obj):
 	Represents a file.
 
 	.. todo:: File object not implemented.
+
+	.. seealso::
+
+	   * :class:`Parameter file interface item <pyVHDLModel.Interface.ParameterFileInterfaceItem>`
 	"""

--- a/pyVHDLModel/PSLModel.py
+++ b/pyVHDLModel/PSLModel.py
@@ -40,34 +40,57 @@ from pyVHDLModel.DesignUnit import PrimaryUnit
 
 @export
 class PSLEntity(ModelEntity):
+	"""
+	Represents the base-class of all PSL entities.
+
+	PSL (Property Specification Language) support is rudimentary: verification units are recognised
+	and named, but their contents are not modelled.
+	"""
 	pass
 
 
 @export
 class PSLPrimaryUnit(PrimaryUnit):
+	"""
+	Represents the base-class of all PSL primary units.
+	"""
 	pass
 
 
 @export
 class VerificationUnit(PSLPrimaryUnit):
+	"""
+	Represents a PSL verification unit (``vunit``).
+	"""
 	def __init__(self, identifier: str) -> None:
 		super().__init__(identifier, parent=None)
 
 
 @export
 class VerificationProperty(PSLPrimaryUnit):
+	"""
+	Represents a PSL verification property (``vprop``).
+	"""
 	def __init__(self, identifier: str) -> None:
 		super().__init__(identifier, parent=None)
 
 
 @export
 class VerificationMode(PSLPrimaryUnit):
+	"""
+	Represents a PSL verification mode (``vmode``).
+	"""
 	def __init__(self, identifier: str) -> None:
 		super().__init__(identifier, parent=None)
 
 
 @export
 class DefaultClock(PSLEntity, NamedEntityMixin):
+	"""
+	Represents a PSL default clock declaration.
+
+	It names the clock expression used by PSL directives that do not state one themselves.
+	"""
 	def __init__(self, identifier: str) -> None:
 		super().__init__()
 		NamedEntityMixin.__init__(self, identifier)

--- a/pyVHDLModel/PSLModel.py
+++ b/pyVHDLModel/PSLModel.py
@@ -60,9 +60,9 @@ class PSLPrimaryUnit(PrimaryUnit):
 
 	.. seealso::
 
-	   * :class:`Verification mode <pyVHDLModel.PSLModel.VerificationMode>`
-	   * :class:`Verification property <pyVHDLModel.PSLModel.VerificationProperty>`
 	   * :class:`Verification unit <pyVHDLModel.PSLModel.VerificationUnit>`
+	   * :class:`Verification property <pyVHDLModel.PSLModel.VerificationProperty>`
+	   * :class:`Verification mode <pyVHDLModel.PSLModel.VerificationMode>`
 	"""
 	pass
 

--- a/pyVHDLModel/PSLModel.py
+++ b/pyVHDLModel/PSLModel.py
@@ -45,6 +45,10 @@ class PSLEntity(ModelEntity):
 
 	PSL (Property Specification Language) support is rudimentary: verification units are recognised
 	and named, but their contents are not modelled.
+
+	.. seealso::
+
+	   * :class:`Default clock <pyVHDLModel.PSLModel.DefaultClock>`
 	"""
 	pass
 
@@ -53,6 +57,12 @@ class PSLEntity(ModelEntity):
 class PSLPrimaryUnit(PrimaryUnit):
 	"""
 	Represents the base-class of all PSL primary units.
+
+	.. seealso::
+
+	   * :class:`Verification mode <pyVHDLModel.PSLModel.VerificationMode>`
+	   * :class:`Verification property <pyVHDLModel.PSLModel.VerificationProperty>`
+	   * :class:`Verification unit <pyVHDLModel.PSLModel.VerificationUnit>`
 	"""
 	pass
 

--- a/pyVHDLModel/Predefined.py
+++ b/pyVHDLModel/Predefined.py
@@ -50,6 +50,11 @@ class PredefinedLibrary(Library):
 
 	* :class:`~pyVHDLModel.STD.Std`
 	* :class:`~pyVHDLModel.IEEE.Ieee`
+
+	.. seealso::
+
+	   * :class:`Ieee <pyVHDLModel.IEEE.Ieee>`
+	   * :class:`Std <pyVHDLModel.STD.Std>`
 	"""
 
 	def __init__(self, packages) -> None:
@@ -73,6 +78,11 @@ class PredefinedLibrary(Library):
 class PredefinedPackageMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for predefined VHDL packages and package bodies.
+
+	.. seealso::
+
+	   * :class:`Predefined package <pyVHDLModel.Predefined.PredefinedPackage>`
+	   * :class:`Predefined package body <pyVHDLModel.Predefined.PredefinedPackageBody>`
 	"""
 
 	def _AddLibraryClause(self, libraries: Iterable[str]) -> None:

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -68,6 +68,11 @@ class DeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 	class calls the ones it needs from its own :meth:`IndexDeclaredItems` before delegating upwards.
 	Interface items are added to the namespace only - ``GenericItems``/``PortItems``/``ParameterItems``
 	already expose them as ordered lists, so no extra lookup table is needed.
+
+	.. seealso::
+
+	   * :class:`Concurrent declaration region mixin <pyVHDLModel.Regions.ConcurrentDeclarationRegionMixin>`
+	   * :class:`Sequential declaration region mixin <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
 	"""
 
 	def _IndexGenericItems(self) -> None:
@@ -102,6 +107,19 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	Entities, architectures, packages, blocks and generate bodies declare items concurrently. Beside
 	the namespace, the region keeps a lookup table per kind of declared item (:data:`Types`,
 	:data:`Signals`, :data:`Constants`, ...).
+
+	.. seealso::
+
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
+	   * :class:`Generate branch <pyVHDLModel.Concurrent.GenerateBranch>`
+	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
+	   * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
+	   * :class:`Sequential declaration region <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
+	   * :class:`Namespace <pyVHDLModel.Namespace.Namespace>`
 	"""
 	_declaredItems:   List                              #: List of all declared items in this concurrent declaration region.
 
@@ -329,6 +347,13 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	   (:class:`ConcurrentDeclarationRegionMixin`, ``block_declarative_item``), a sequential region can
 	   declare a **variable**, but no signal, shared variable, component or mode view, and none of the
 	   specifications.
+
+	.. seealso::
+
+	   * :class:`Process statement <pyVHDLModel.Concurrent.ProcessStatement>`
+	   * :class:`Subprogram <pyVHDLModel.Subprogram.Subprogram>`
+	   * :class:`Concurrent declaration region <pyVHDLModel.Regions.ConcurrentDeclarationRegionMixin>`
+	   * :class:`Namespace <pyVHDLModel.Namespace.Namespace>`
 	"""
 
 	_declaredItems: List                          #: List of all declared items in this sequential declaration region.

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -110,14 +110,14 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
 	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
-	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
-	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
-	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	   * :class:`Generate branch <pyVHDLModel.Concurrent.GenerateBranch>`
+	   * :class:`Concurrent case <pyVHDLModel.Concurrent.ConcurrentCase>`
+	   * :class:`For generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	   * :class:`Package <pyVHDLModel.DesignUnit.Package>`
 	   * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
+	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
+	   * :class:`Architecture <pyVHDLModel.DesignUnit.Architecture>`
 	   * :class:`Sequential declaration region <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
 	   * :class:`Namespace <pyVHDLModel.Namespace.Namespace>`
 	"""

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -96,6 +96,13 @@ class DeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 @export
 class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	# FIXME: define list prefix type e.g. via Union
+	"""
+	A mixin-class for concurrent declaration regions.
+
+	Entities, architectures, packages, blocks and generate bodies declare items concurrently. Beside
+	the namespace, the region keeps a lookup table per kind of declared item (:data:`Types`,
+	:data:`Signals`, :data:`Constants`, ...).
+	"""
 	_declaredItems:   List                              #: List of all declared items in this concurrent declaration region.
 
 	# _attributes:     Dict[str, Attribute]

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -54,11 +54,20 @@ from pyVHDLModel.Association import ParameterAssociationItem
 
 @export
 class SequentialStatement(Statement):
-	"""A ``SequentialStatement`` is a base-class for all sequential statements."""
+	"""
+	Represents the base-class of all sequential statements.
+
+	Sequential statements appear in a process or a subprogram body.
+	"""
 
 
 @export
 class SequentialStatementsMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language constructs containing sequential statements.
+
+	The statements are available in declaration order as :data:`Statements`.
+	"""
 	_statements: List[SequentialStatement]
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None) -> None:
@@ -81,6 +90,16 @@ class SequentialStatementsMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
+	"""
+	Represents a procedure call as a sequential statement.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      log("hello");
+	    --^^^^^^^^^^^^    <- the call
+	"""
 	def __init__(
 		self,
 		procedureName: Symbol,
@@ -94,6 +113,9 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 
 @export
 class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
+	"""
+	Represents the base-class of all sequential signal assignments.
+	"""
 	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		SignalAssignmentMixin.__init__(self, target)
@@ -101,6 +123,17 @@ class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
 
 @export
 class SequentialSimpleSignalAssignment(SequentialSignalAssignment, WaveformMixin):
+	"""
+	Represents a simple sequential signal assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      s <= '1';
+	      --^         <- Target
+	      --   ^^^    <- the waveform
+	"""
 	def __init__(self, target: SignalSymbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(target, label, parent)
 		WaveformMixin.__init__(self, waveform)
@@ -108,6 +141,17 @@ class SequentialSimpleSignalAssignment(SequentialSignalAssignment, WaveformMixin
 
 @export
 class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin):
+	"""
+	Represents a simple sequential variable assignment.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      v := '1';
+	      --^         <- Target
+	      --   ^^^    <- Expression
+	"""
 	def __init__(self, target: VariableSymbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		VariableAssignmentMixin.__init__(self, target, expression)
@@ -116,11 +160,18 @@ class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin)
 @export
 class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMixin):
 	"""
+	Represents a conditional sequential variable assignment.
+
+	The branches are available as :data:`ConditionalExpressions`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      v := '1' when cond1 else '0' when cond2 else 'Z';
+	      v := '1' when sel = 0 else '0';
+	      --^                               <- Target
+	      --   ^^^^^^^^^^^^^^^^             <- first branch
+	      --                         ^^^    <- final branch
 	"""
 
 	_conditionalExpressions: List[ConditionalExpression]
@@ -153,11 +204,16 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 @export
 class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmentMixin, ConditionalWaveformsMixin):
 	"""
+	Represents a conditional sequential signal assignment.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      s <= '1' when cond1 else '0' when cond2 else 'Z';
+	      s <= '1' when sel = 0 else '0';
+	      --^                               <- Target
+	      --   ^^^^^^^^^^^^^^^^             <- first branch
+	      --                         ^^^    <- final branch
 	"""
 
 	def __init__(
@@ -175,11 +231,15 @@ class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmen
 @export
 class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin, ExpressionMixin, SelectedExpressionsMixin):
 	"""
+	Represents a selected sequential variable assignment.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      with sel select v := '1' when 0, '0' when others;
+	      --   ^^^                                            <- the selector
+	      --                   ^^^^^^^^^^                     <- first alternative
 	"""
 
 	def __init__(
@@ -199,11 +259,15 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin,
 @export
 class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMixin, ExpressionMixin, SelectedWaveformsMixin):
 	"""
+	Represents a selected sequential signal assignment.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      with sel select s <= '1' when 0, '0' when others;
+	      with sel select t <= '1' when 0, '0' when others;
+	      --   ^^^                                            <- the selector
+	      --                   ^^^^^^^^^^                     <- first alternative
 	"""
 
 	def __init__(
@@ -223,11 +287,17 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 @export
 class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin, ExpressionMixin):
 	"""
+	Represents a signal force assignment.
+
+	A force assignment overrides a signal's driver until it is released.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      s <= force '1';
+	      --^               <- Target
+	      --         ^^^    <- the forced value
 	"""
 
 	def __init__(
@@ -245,11 +315,16 @@ class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin, Expressi
 @export
 class SignalReleaseAssignment(SequentialStatement, SignalAssignmentMixin):
 	"""
+	Represents a signal release assignment.
+
+	A release assignment ends a previously applied force.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      s <= release;
+	      --^             <- Target
 	"""
 
 	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -259,6 +334,17 @@ class SignalReleaseAssignment(SequentialStatement, SignalAssignmentMixin):
 
 @export
 class SequentialReportStatement(SequentialStatement, ReportStatementMixin):
+	"""
+	Represents a sequential report statement.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      report "message" severity note;
+	      --     ^^^^^^^^^                  <- Message
+	      --                        ^^^^    <- Severity
+	"""
 	def __init__(self, message: ExpressionUnion, severity: Nullable[ExpressionUnion] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
 		ReportStatementMixin.__init__(self, message, severity)
@@ -266,6 +352,18 @@ class SequentialReportStatement(SequentialStatement, ReportStatementMixin):
 
 @export
 class SequentialAssertStatement(SequentialStatement, AssertStatementMixin):
+	"""
+	Represents a sequential assertion statement.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      assert sel = 0 report "bad" severity error;
+	      --     ^^^^^^^                                <- Condition
+	      --                    ^^^^^                   <- Message
+	      --                                   ^^^^^    <- Severity
+	"""
 	def __init__(
 		self,
 		condition: ExpressionUnion,
@@ -280,12 +378,18 @@ class SequentialAssertStatement(SequentialStatement, AssertStatementMixin):
 
 @export
 class CompoundStatement(SequentialStatement):
-	"""A ``CompoundStatement`` is a base-class for all compound statements."""
+	"""
+	Represents the base-class of all compound statements.
+
+	A compound statement contains further sequential statements: if, case and loop statements.
+	"""
 
 
 @export
 class Branch(ModelEntity, SequentialStatementsMixin):
-	"""A ``Branch`` is a base-class for all branches in a if statement."""
+	"""
+	Represents the base-class of all branches of an if statement.
+	"""
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -294,6 +398,16 @@ class Branch(ModelEntity, SequentialStatementsMixin):
 
 @export
 class IfBranch(Branch, IfBranchMixin):
+	"""
+	Represents the ``if`` branch of an if statement.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      if sel = 0 then
+	      -- ^^^^^^^        <- Condition
+	"""
 	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 		IfBranchMixin.__init__(self, condition)
@@ -301,6 +415,16 @@ class IfBranch(Branch, IfBranchMixin):
 
 @export
 class ElsifBranch(Branch, ElsifBranchMixin):
+	"""
+	Represents an ``elsif`` branch of an if statement.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      elsif sel = 1 then
+	      --    ^^^^^^^        <- Condition
+	"""
 	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 		ElsifBranchMixin.__init__(self, condition)
@@ -308,6 +432,11 @@ class ElsifBranch(Branch, ElsifBranchMixin):
 
 @export
 class ElseBranch(Branch, ElseBranchMixin):
+	"""
+	Represents the ``else`` branch of an if statement.
+
+	Unlike the other branches, an else branch has no condition.
+	"""
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
 		ElseBranchMixin.__init__(self)
@@ -315,6 +444,34 @@ class ElseBranch(Branch, ElseBranchMixin):
 
 @export
 class IfStatement(CompoundStatement):
+	"""
+	Represents an if statement.
+
+	An if statement has one ``if`` branch (:data:`IfBranch`), any number of ``elsif`` branches
+	(:data:`ElsIfBranches`) and an optional ``else`` branch (:data:`ElseBranch`).
+
+	.. admonition:: Example
+
+	   Only an ``if`` branch:
+
+	   .. code-block:: VHDL
+
+	      if sel = 0 then
+	        v := '1';
+	      end if;
+
+	   With ``elsif`` and ``else`` branches:
+
+	   .. code-block:: VHDL
+
+	      if sel = 0 then
+	        v := '1';
+	      elsif sel = 1 then
+	        v := '0';
+	      else
+	        null;
+	      end if;
+	"""
 	_ifBranch: IfBranch
 	_elsifBranches: List['ElsifBranch']
 	_elseBranch: Nullable[ElseBranch]
@@ -374,11 +531,25 @@ class IfStatement(CompoundStatement):
 
 @export
 class SequentialChoice(BaseChoice):
-	"""A ``SequentialChoice`` is a base-class for all sequential choices (in case statements)."""
+	"""
+	Represents the base-class of all choices in a sequential case statement.
+	"""
 
 
 @export
 class IndexedChoice(SequentialChoice):
+	"""
+	Represents a case choice given by a single value.
+
+	The value is available as :data:`Expression`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when 0      => v := '1';
+	      --   ^                     <- Expression
+	"""
 	_expression: ExpressionUnion
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
@@ -402,6 +573,18 @@ class IndexedChoice(SequentialChoice):
 
 @export
 class RangedChoice(SequentialChoice):
+	"""
+	Represents a case choice given by a range.
+
+	The range is available as :data:`Range`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when 1 to 2 => v := '0';
+	      --   ^^^^^^                <- Range
+	"""
 	_range: 'Range'
 
 	def __init__(self, rng: 'Range', parent: Nullable[ModelEntity] = None) -> None:
@@ -425,6 +608,9 @@ class RangedChoice(SequentialChoice):
 
 @export
 class SequentialCase(BaseCase, SequentialStatementsMixin, ChoicesMixin):
+	"""
+	Represents the base-class of all alternatives of a sequential case statement.
+	"""
 	def __init__(
 		self,
 		statements: Nullable[Iterable[SequentialStatement]] = None,
@@ -438,6 +624,17 @@ class SequentialCase(BaseCase, SequentialStatementsMixin, ChoicesMixin):
 
 @export
 class Case(SequentialCase):
+	"""
+	Represents one alternative of a case statement, selected by its choices.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when 1 to 2 => v := '0';
+	      --   ^^^^^^                <- Choices
+	      --             ^^^^^^^^^   <- the statements
+	"""
 	def __init__(self, choices: Iterable[SequentialChoice], statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, choices, parent)
 
@@ -447,12 +644,40 @@ class Case(SequentialCase):
 
 @export
 class OthersCase(SequentialCase):
+	"""
+	Represents the ``others`` alternative of a case statement.
+
+	It covers every choice not named explicitly.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      when others => null;
+	      --   ^^^^^^            <- the choice
+	"""
 	def __str__(self) -> str:
 		return "when others =>"
 
 
 @export
 class CaseStatement(CompoundStatement):
+	"""
+	Represents a case statement.
+
+	The expression being tested is available as :data:`SelectExpression`, the alternatives as
+	:data:`Cases`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      case sel is
+	        when 0      => v := '1';
+	        when others => null;
+	      end case;
+	      --   ^^^                     <- SelectExpression
+	"""
 	_expression: ExpressionUnion
 	_cases:      List[SequentialCase]
 
@@ -489,7 +714,9 @@ class CaseStatement(CompoundStatement):
 
 @export
 class LoopStatement(CompoundStatement, SequentialStatementsMixin):
-	"""A ``LoopStatement`` is a base-class for all loop statements."""
+	"""
+	Represents the base-class of all loop statements.
+	"""
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -498,11 +725,38 @@ class LoopStatement(CompoundStatement, SequentialStatementsMixin):
 
 @export
 class EndlessLoopStatement(LoopStatement):
+	"""
+	Represents an endless loop statement.
+
+	An endless loop has no iteration scheme; it is left with ``exit`` or ``return``.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      loop
+	        exit;
+	      end loop;
+	"""
 	pass
 
 
 @export
 class ForLoopStatement(LoopStatement):
+	"""
+	Represents a for loop statement.
+
+	The loop parameter is available as :data:`LoopIndex`, the discrete range it iterates over as
+	:data:`Range`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      for k in 0 to 3 loop
+	      --  ^                  <- LoopIndex
+	      --       ^^^^^^        <- Range
+	"""
 	_loopIndex: str
 	_range:     Range
 
@@ -535,6 +789,18 @@ class ForLoopStatement(LoopStatement):
 
 @export
 class WhileLoopStatement(LoopStatement, ConditionalMixin):
+	"""
+	Represents a while loop statement.
+
+	The loop repeats as long as its condition (:data:`Condition`) holds.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      while i < 4 loop
+	      --    ^^^^^        <- Condition
+	"""
 	def __init__(
 		self,
 		condition: ExpressionUnion,
@@ -548,7 +814,11 @@ class WhileLoopStatement(LoopStatement, ConditionalMixin):
 
 @export
 class LoopControlStatement(SequentialStatement, ConditionalMixin):
-	"""A ``LoopControlStatement`` is a base-class for all loop controlling statements."""
+	"""
+	Represents the base-class of the loop control statements ``next`` and ``exit``.
+
+	An optional loop label (:data:`LoopReference`) selects which enclosing loop is affected.
+	"""
 
 	_loopReference: LoopStatement
 
@@ -573,21 +843,67 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 
 @export
 class NextStatement(LoopControlStatement):
+	"""
+	Represents a ``next`` statement.
+
+	It skips to the next iteration of the enclosing loop.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      next when k = 1;
+	      --        ^^^^^    <- Condition
+	"""
 	pass
 
 
 @export
 class ExitStatement(LoopControlStatement):
+	"""
+	Represents an ``exit`` statement.
+
+	It leaves the enclosing loop.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      exit;
+	    --^^^^    <- the statement
+	"""
 	pass
 
 
 @export
 class NullStatement(SequentialStatement):
+	"""
+	Represents a ``null`` statement, which does nothing.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      null;
+	    --^^^^    <- the statement
+	"""
 	pass
 
 
 @export
 class ReturnStatement(SequentialStatement):
+	"""
+	Represents a ``return`` statement.
+
+	A function returns a value (:data:`ReturnValue`); a procedure returns none.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      return x;
+	      --     ^    <- ReturnValue
+	"""
 	_returnValue: Nullable[ExpressionUnion]
 
 	def __init__(
@@ -614,6 +930,20 @@ class ReturnStatement(SequentialStatement):
 
 @export
 class WaitStatement(SequentialStatement, ConditionalMixin):
+	"""
+	Represents a wait statement.
+
+	A wait statement may name a sensitivity list (:data:`SensitivityList`), a condition
+	(:data:`Condition`) and a timeout (:data:`Timeout`); all three are optional.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      wait until clk = '1' for 10 ns;
+	      --         ^^^^^^^^^              <- Condition
+	      --                       ^^^^^    <- Timeout
+	"""
 	_sensitivityList: Nullable[List[Symbol]]
 	_timeout:         ExpressionUnion
 

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -67,6 +67,13 @@ class SequentialStatementsMixin(metaclass=ExtendedType, mixin=True):
 	A mixin-class for language constructs containing sequential statements.
 
 	The statements are available in declaration order as :data:`Statements`.
+
+	.. seealso::
+
+	   * :class:`Branch <pyVHDLModel.Sequential.Branch>`
+	   * :class:`Loop statement <pyVHDLModel.Sequential.LoopStatement>`
+	   * :class:`Process statement <pyVHDLModel.Concurrent.ProcessStatement>`
+	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
 	"""
 	_statements: List[SequentialStatement]
 
@@ -99,6 +106,10 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 
 	      log("hello");
 	    --^^^^^^^^^^^^    <- the call
+
+	.. seealso::
+
+	   * :class:`Concurrent counterpart <pyVHDLModel.Concurrent.ConcurrentProcedureCall>`
 	"""
 	def __init__(
 		self,
@@ -115,6 +126,10 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 class SequentialSignalAssignment(SequentialStatement, SignalAssignmentMixin):
 	"""
 	Represents the base-class of all sequential signal assignments.
+
+	.. seealso::
+
+	   * :class:`Sequential simple signal assignment <pyVHDLModel.Sequential.SequentialSimpleSignalAssignment>`
 	"""
 	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -133,6 +148,10 @@ class SequentialSimpleSignalAssignment(SequentialSignalAssignment, WaveformMixin
 	      s <= '1';
 	      --^         <- Target
 	      --   ^^^    <- the waveform
+
+	.. seealso::
+
+	   * :class:`Concurrent counterpart <pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment>`
 	"""
 	def __init__(self, target: SignalSymbol, waveform: Iterable[WaveformElement], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(target, label, parent)
@@ -172,6 +191,10 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 	      --^                               <- Target
 	      --   ^^^^^^^^^^^^^^^^             <- first branch
 	      --                         ^^^    <- final branch
+
+	.. seealso::
+
+	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
 	"""
 
 	_conditionalExpressions: List[ConditionalExpression]
@@ -214,6 +237,11 @@ class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmen
 	      --^                               <- Target
 	      --   ^^^^^^^^^^^^^^^^             <- first branch
 	      --                         ^^^    <- final branch
+
+	.. seealso::
+
+	   * :class:`Concurrent counterpart <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
+	   * :class:`Conditional waveform <pyVHDLModel.Common.ConditionalWaveform>`
 	"""
 
 	def __init__(
@@ -240,6 +268,10 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin,
 	      with sel select v := '1' when 0, '0' when others;
 	      --   ^^^                                            <- the selector
 	      --                   ^^^^^^^^^^                     <- first alternative
+
+	.. seealso::
+
+	   * :class:`Selected expression <pyVHDLModel.Common.SelectedExpression>`
 	"""
 
 	def __init__(
@@ -268,6 +300,11 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 	      with sel select t <= '1' when 0, '0' when others;
 	      --   ^^^                                            <- the selector
 	      --                   ^^^^^^^^^^                     <- first alternative
+
+	.. seealso::
+
+	   * :class:`Concurrent counterpart <pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment>`
+	   * :class:`Selected waveform <pyVHDLModel.Common.SelectedWaveform>`
 	"""
 
 	def __init__(
@@ -363,6 +400,10 @@ class SequentialAssertStatement(SequentialStatement, AssertStatementMixin):
 	      --     ^^^^^^^                                <- Condition
 	      --                    ^^^^^                   <- Message
 	      --                                   ^^^^^    <- Severity
+
+	.. seealso::
+
+	   * :class:`Concurrent counterpart <pyVHDLModel.Concurrent.ConcurrentAssertStatement>`
 	"""
 	def __init__(
 		self,
@@ -382,6 +423,12 @@ class CompoundStatement(SequentialStatement):
 	Represents the base-class of all compound statements.
 
 	A compound statement contains further sequential statements: if, case and loop statements.
+
+	.. seealso::
+
+	   * :class:`Case statement <pyVHDLModel.Sequential.CaseStatement>`
+	   * :class:`If statement <pyVHDLModel.Sequential.IfStatement>`
+	   * :class:`Loop statement <pyVHDLModel.Sequential.LoopStatement>`
 	"""
 
 
@@ -389,6 +436,12 @@ class CompoundStatement(SequentialStatement):
 class Branch(ModelEntity, SequentialStatementsMixin):
 	"""
 	Represents the base-class of all branches of an if statement.
+
+	.. seealso::
+
+	   * :class:`Else branch <pyVHDLModel.Sequential.ElseBranch>`
+	   * :class:`Elsif branch <pyVHDLModel.Sequential.ElsifBranch>`
+	   * :class:`If branch <pyVHDLModel.Sequential.IfBranch>`
 	"""
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -471,6 +524,10 @@ class IfStatement(CompoundStatement):
 	      else
 	        null;
 	      end if;
+
+	.. seealso::
+
+	   * :class:`If-generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
 	"""
 	_ifBranch: IfBranch
 	_elsifBranches: List['ElsifBranch']
@@ -533,6 +590,11 @@ class IfStatement(CompoundStatement):
 class SequentialChoice(BaseChoice):
 	"""
 	Represents the base-class of all choices in a sequential case statement.
+
+	.. seealso::
+
+	   * :class:`Indexed choice <pyVHDLModel.Sequential.IndexedChoice>`
+	   * :class:`Ranged choice <pyVHDLModel.Sequential.RangedChoice>`
 	"""
 
 
@@ -610,6 +672,11 @@ class RangedChoice(SequentialChoice):
 class SequentialCase(BaseCase, SequentialStatementsMixin, ChoicesMixin):
 	"""
 	Represents the base-class of all alternatives of a sequential case statement.
+
+	.. seealso::
+
+	   * :class:`Case <pyVHDLModel.Sequential.Case>`
+	   * :class:`Others case <pyVHDLModel.Sequential.OthersCase>`
 	"""
 	def __init__(
 		self,
@@ -677,6 +744,10 @@ class CaseStatement(CompoundStatement):
 	        when others => null;
 	      end case;
 	      --   ^^^                     <- SelectExpression
+
+	.. seealso::
+
+	   * :class:`Case-generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
 	"""
 	_expression: ExpressionUnion
 	_cases:      List[SequentialCase]
@@ -716,6 +787,12 @@ class CaseStatement(CompoundStatement):
 class LoopStatement(CompoundStatement, SequentialStatementsMixin):
 	"""
 	Represents the base-class of all loop statements.
+
+	.. seealso::
+
+	   * :class:`Endless loop statement <pyVHDLModel.Sequential.EndlessLoopStatement>`
+	   * :class:`For loop statement <pyVHDLModel.Sequential.ForLoopStatement>`
+	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
 	"""
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -737,6 +814,11 @@ class EndlessLoopStatement(LoopStatement):
 	      loop
 	        exit;
 	      end loop;
+
+	.. seealso::
+
+	   * :class:`For loop statement <pyVHDLModel.Sequential.ForLoopStatement>`
+	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
 	"""
 	pass
 
@@ -756,6 +838,12 @@ class ForLoopStatement(LoopStatement):
 	      for k in 0 to 3 loop
 	      --  ^                  <- LoopIndex
 	      --       ^^^^^^        <- Range
+
+	.. seealso::
+
+	   * :class:`Endless loop statement <pyVHDLModel.Sequential.EndlessLoopStatement>`
+	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
+	   * :class:`For-generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	"""
 	_loopIndex: str
 	_range:     Range
@@ -800,6 +888,11 @@ class WhileLoopStatement(LoopStatement, ConditionalMixin):
 
 	      while i < 4 loop
 	      --    ^^^^^        <- Condition
+
+	.. seealso::
+
+	   * :class:`Endless loop statement <pyVHDLModel.Sequential.EndlessLoopStatement>`
+	   * :class:`For loop statement <pyVHDLModel.Sequential.ForLoopStatement>`
 	"""
 	def __init__(
 		self,
@@ -818,6 +911,11 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 	Represents the base-class of the loop control statements ``next`` and ``exit``.
 
 	An optional loop label (:data:`LoopReference`) selects which enclosing loop is affected.
+
+	.. seealso::
+
+	   * :class:`Exit statement <pyVHDLModel.Sequential.ExitStatement>`
+	   * :class:`Next statement <pyVHDLModel.Sequential.NextStatement>`
 	"""
 
 	_loopReference: LoopStatement

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -106,9 +106,9 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 
 	   .. code-block:: VHDL
 
-	        call_lbl : log("hello");
-	      --^^^^^^^^                   <- Label (optional)
-	      --           ^^^^^^^^^^^^    <- the call
+	        lbl : log("hello");
+	      --^^^                   <- optional Label
+	      --      ^^^^^^^^^^^^    <- the call
 
 	.. seealso::
 
@@ -150,9 +150,10 @@ class SequentialSimpleSignalAssignment(SequentialSignalAssignment, WaveformMixin
 
 	   .. code-block:: VHDL
 
-	        s <= '1';
-	      --^           <- Target
-	      --     ^^^    <- Waveform
+	        lbl : s <= '1';
+	      --^^^               <- optional Label
+	      --      ^           <- Target
+	      --           ^^^    <- Waveform
 
 	.. seealso::
 
@@ -174,9 +175,10 @@ class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin)
 
 	   .. code-block:: VHDL
 
-	        v := '1';
-	      --^           <- Target
-	      --     ^^^    <- Expression
+	        lbl : v := '1';
+	      --^^^               <- optional Label
+	      --      ^           <- Target
+	      --           ^^^    <- Expression
 	"""
 	def __init__(self, target: VariableSymbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -196,10 +198,11 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 
 	   .. code-block:: VHDL
 
-	        v := '1' when sel = '0' else '0';
-	      --^                                   <- Target
-	      --     ^^^^^^^^^^^^^^^^^^             <- ConditionalExpressions[0]
-	      --                             ^^^    <- ConditionalExpressions[1]
+	        lbl : v := '1' when sel = '0' else '0';
+	      --^^^                                       <- optional Label
+	      --      ^                                   <- Target
+	      --           ^^^^^^^^^^^^^^^^^^             <- ConditionalExpressions[0]
+	      --                                   ^^^    <- ConditionalExpressions[1]
 
 	.. seealso::
 
@@ -246,10 +249,11 @@ class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmen
 
 	   .. code-block:: VHDL
 
-	        s <= '1' when sel = '0' else '0';
-	      --^                                   <- Target
-	      --     ^^^^^^^^^^^^^^^^^^             <- ConditionalWaveforms[0]
-	      --                             ^^^    <- ConditionalWaveforms[1]
+	        lbl : s <= '1' when sel = '0' else '0';
+	      --^^^                                       <- optional Label
+	      --      ^                                   <- Target
+	      --           ^^^^^^^^^^^^^^^^^^             <- ConditionalWaveforms[0]
+	      --                                   ^^^    <- ConditionalWaveforms[1]
 
 	.. seealso::
 
@@ -282,11 +286,12 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin,
 
 	   .. code-block:: VHDL
 
-	      with sel select v := '1' when '0', '0' when others;
-	      --   ^^^                                              <- Expression
-	      --              ^                                     <- Target
-	      --                   ^^^^^^^^^^^^                     <- SelectedExpressions[0]
-	      --                                 ^^^^^^^^^^^^^^^    <- SelectedExpressions[1]
+	        lbl : with sel select v := '1' when '0', '0' when others;
+	      --^^^                                                         <- optional Label
+	      --           ^^^                                              <- Expression
+	      --                      ^                                     <- Target
+	      --                           ^^^^^^^^^^^^                     <- SelectedExpressions[0]
+	      --                                         ^^^^^^^^^^^^^^^    <- SelectedExpressions[1]
 
 	.. seealso::
 
@@ -320,11 +325,12 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 
 	   .. code-block:: VHDL
 
-	      with sel select s <= '1' when '0', '0' when others;
-	      --   ^^^                                              <- Expression
-	      --              ^                                     <- Target
-	      --                   ^^^^^^^^^^^^                     <- SelectedWaveforms[0]
-	      --                                 ^^^^^^^^^^^^^^^    <- SelectedWaveforms[1]
+	        lbl : with sel select s <= '1' when '0', '0' when others;
+	      --^^^                                                         <- optional Label
+	      --           ^^^                                              <- Expression
+	      --                      ^                                     <- Target
+	      --                           ^^^^^^^^^^^^                     <- SelectedWaveforms[0]
+	      --                                         ^^^^^^^^^^^^^^^    <- SelectedWaveforms[1]
 
 	.. seealso::
 
@@ -357,9 +363,10 @@ class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin, Expressi
 
 	   .. code-block:: VHDL
 
-	        s <= force '1';
-	      --^                 <- Target
-	      --           ^^^    <- Expression
+	        lbl : s <= force '1';
+	      --^^^                     <- optional Label
+	      --      ^                 <- Target
+	      --                 ^^^    <- Expression
 	"""
 
 	def __init__(
@@ -385,8 +392,9 @@ class SignalReleaseAssignment(SequentialStatement, SignalAssignmentMixin):
 
 	   .. code-block:: VHDL
 
-	        s <= release;
-	      --^               <- Target
+	        lbl : s <= release;
+	      --^^^                   <- optional Label
+	      --      ^               <- Target
 	"""
 
 	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -399,13 +407,16 @@ class SequentialReportStatement(SequentialStatement, ReportStatementMixin):
 	"""
 	Represents a sequential report statement.
 
+	The report string is available as :data:`Message`, the optional severity as :data:`Severity`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      report "message" severity note;
-	      --     ^^^^^^^^^                  <- Message
-	      --                        ^^^^    <- Severity
+	        lbl : report "message" severity note;
+	      --^^^                                     <- optional Label
+	      --             ^^^^^^^^^                  <- Message
+	      --                                ^^^^    <- optional Severity
 	"""
 	def __init__(self, message: ExpressionUnion, severity: Nullable[ExpressionUnion] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -424,10 +435,11 @@ class SequentialAssertStatement(SequentialStatement, AssertStatementMixin):
 
 	   .. code-block:: VHDL
 
-	      assert sel = '0' report "bad" severity error;
-	      --     ^^^^^^^^^                                <- Condition
-	      --                      ^^^^^                   <- Message (optional)
-	      --                                     ^^^^^    <- Severity (optional)
+	        lbl : assert sel = '0' report "bad" severity error;
+	      --^^^                                                   <- optional Label
+	      --             ^^^^^^^^^                                <- Condition
+	      --                              ^^^^^                   <- optional Message
+	      --                                             ^^^^^    <- optional Severity
 
 	.. seealso::
 
@@ -576,22 +588,24 @@ class IfStatement(CompoundStatement):
 
 	   .. code-block:: VHDL
 
-	      if sel = '0' then
-	        s <= '0';
-	      end if;
+	        lbl : if sel = '0' then
+	      --^^^                       <- optional Label
+	          s <= '0';
+	        end if;
 
 	   With ``elsif`` and ``else`` branches:
 
 	   .. code-block:: VHDL
 
-	        if sel = '0' then
-	      --^^^^^^^^^^^^^^^^^      <- IfBranch
+	        lbl : if sel = '0' then
+	      --^^^                       <- optional Label
+	      --      ^^^^^^^^^^^^^^^^^   <- IfBranch
 	          s <= '0';
 	        elsif sel = '1' then
-	      --^^^^^^^^^^^^^^^^^^^^   <- ElsIfBranches[0]
+	      --^^^^^^^^^^^^^^^^^^^^      <- ElsIfBranches[0]
 	          s <= '1';
 	        else
-	      --^^^^                   <- ElseBranch
+	      --^^^^                      <- ElseBranch
 	          s <= '0';
 	        end if;
 
@@ -809,13 +823,14 @@ class CaseStatement(CompoundStatement):
 
 	   .. code-block:: VHDL
 
-	      case sel is
-	      --   ^^^                     <- SelectExpression
-	        when '0'    => s <= '1';
-	      --^^^^^^^^^^^^^^^^^^^^^^^^   <- Cases[0]
-	        when others => null;
-	      --^^^^^^^^^^^^^^^^^^^^       <- Cases[1]
-	      end case;
+	        lbl : case sel is
+	      --^^^                          <- optional Label
+	      --           ^^^               <- SelectExpression
+	          when '0'    => s <= '1';
+	      --  ^^^^^^^^^^^^^^^^^^^^^^^^   <- Cases[0]
+	          when others => null;
+	      --  ^^^^^^^^^^^^^^^^^^^^       <- Cases[1]
+	        end case;
 
 	.. seealso::
 
@@ -877,15 +892,18 @@ class EndlessLoopStatement(LoopStatement):
 	"""
 	Represents an endless loop statement.
 
-	An endless loop has no iteration scheme; it is left with ``exit`` or ``return``.
+	The loop body is available as :data:`Statements`. The loop has no iteration scheme, so it is
+	left with an exit or return statement.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      loop
-	        exit;
-	      end loop;
+	        lbl : loop
+	      --^^^          <- optional Label
+	          exit;
+	      --  ^^^^^      <- Statements
+	        end loop;
 
 	.. seealso::
 
@@ -898,18 +916,22 @@ class EndlessLoopStatement(LoopStatement):
 @export
 class ForLoopStatement(LoopStatement):
 	"""
-	Represents a for loop statement.
+	Represents a for-loop statement.
 
-	The loop parameter is available as :data:`LoopIndex`, the discrete range it iterates over as
-	:data:`Range`.
+	The loop index is available as :data:`LoopIndex`, the iteration range as :data:`Range` and the
+	loop body as :data:`Statements`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      for k in 0 to 3 loop
-	      --  ^                  <- LoopIndex
-	      --       ^^^^^^        <- Range
+	        lbl : for k in 0 to 3 loop
+	      --^^^                          <- optional Label
+	      --          ^                  <- LoopIndex
+	      --               ^^^^^^        <- Range
+	          null;
+	      --  ^^^^^                      <- Statements
+	        end loop;
 
 	.. seealso::
 
@@ -950,16 +972,20 @@ class ForLoopStatement(LoopStatement):
 @export
 class WhileLoopStatement(LoopStatement, ConditionalMixin):
 	"""
-	Represents a while loop statement.
+	Represents a while-loop statement.
 
-	The loop repeats as long as its condition (:data:`Condition`) holds.
+	The loop condition is available as :data:`Condition`, the loop body as :data:`Statements`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      while i < 4 loop
-	      --    ^^^^^        <- Condition
+	        lbl : while i < 4 loop
+	      --^^^                      <- optional Label
+	      --            ^^^^^        <- Condition
+	          null;
+	      --  ^^^^^                  <- Statements
+	        end loop;
 
 	.. seealso::
 
@@ -1014,16 +1040,19 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 @export
 class NextStatement(LoopControlStatement):
 	"""
-	Represents a ``next`` statement.
+	Represents a next statement.
 
-	It skips to the next iteration of the enclosing loop.
+	A next statement skips to the next iteration of the named loop (:data:`LoopReference`),
+	optionally only when a condition (:data:`Condition`) holds.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      next when k = 1;
-	      --        ^^^^^    <- Condition
+	        lbl : next outer when k = 1;
+	      --^^^                            <- optional Label
+	      --           ^^^^^               <- optional LoopReference
+	      --                      ^^^^^    <- optional Condition
 	"""
 	pass
 
@@ -1031,16 +1060,19 @@ class NextStatement(LoopControlStatement):
 @export
 class ExitStatement(LoopControlStatement):
 	"""
-	Represents an ``exit`` statement.
+	Represents an exit statement.
 
-	It leaves the enclosing loop.
+	An exit statement leaves the named loop (:data:`LoopReference`), optionally only when a
+	condition (:data:`Condition`) holds.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	        exit;
-	      --^^^^    <- the statement
+	        lbl : exit outer when k = 1;
+	      --^^^                            <- optional Label
+	      --           ^^^^^               <- optional LoopReference
+	      --                      ^^^^^    <- optional Condition
 	"""
 	pass
 
@@ -1048,14 +1080,18 @@ class ExitStatement(LoopControlStatement):
 @export
 class NullStatement(SequentialStatement):
 	"""
-	Represents a ``null`` statement, which does nothing.
+	Represents a null statement.
+
+	A null statement does nothing. Like every sequential statement, it can carry an optional label
+	(:data:`Label`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	        null;
-	      --^^^^    <- the statement
+	        lbl : null;
+	      --^^^           <- optional Label
+	      --      ^^^^    <- the statement
 	"""
 	pass
 
@@ -1063,16 +1099,17 @@ class NullStatement(SequentialStatement):
 @export
 class ReturnStatement(SequentialStatement):
 	"""
-	Represents a ``return`` statement.
+	Represents a return statement.
 
-	A function returns a value (:data:`ReturnValue`); a procedure returns none.
+	The optionally returned value is available as :data:`ReturnValue`; a procedure returns nothing.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      return x;
-	      --     ^    <- ReturnValue
+	        lbl : return x;
+	      --^^^               <- optional Label
+	      --             ^    <- optional ReturnValue
 	"""
 	_returnValue: Nullable[ExpressionUnion]
 
@@ -1110,9 +1147,10 @@ class WaitStatement(SequentialStatement, ConditionalMixin):
 
 	   .. code-block:: VHDL
 
-	      wait until clock = '1' for 10 ns;
-	      --         ^^^^^^^^^^^              <- Condition (optional)
-	      --                         ^^^^^    <- Timeout (optional)
+	        lbl : wait until clock = '1' for 10 ns;
+	      --^^^                                       <- optional Label
+	      --                 ^^^^^^^^^^^              <- optional Condition
+	      --                                 ^^^^^    <- optional Timeout
 	"""
 	_sensitivityList: Nullable[List[Symbol]]
 	_timeout:         ExpressionUnion

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -100,12 +100,15 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 	"""
 	Represents a procedure call as a sequential statement.
 
+	Like every sequential statement, it can carry an optional label (:data:`Label`).
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	        log("hello");
-	      --^^^^^^^^^^^^    <- the call
+	        call_lbl : log("hello");
+	      --^^^^^^^^                   <- Label (optional)
+	      --           ^^^^^^^^^^^^    <- the call
 
 	.. seealso::
 
@@ -141,13 +144,15 @@ class SequentialSimpleSignalAssignment(SequentialSignalAssignment, WaveformMixin
 	"""
 	Represents a simple sequential signal assignment.
 
+	The assignment's destination is available as :data:`Target`, its value as :data:`Waveform`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      s <= '1';
-	      --^         <- Target
-	      --   ^^^    <- the waveform
+	        s <= '1';
+	      --^           <- Target
+	      --     ^^^    <- Waveform
 
 	.. seealso::
 
@@ -163,13 +168,15 @@ class SequentialVariableAssignment(SequentialStatement, VariableAssignmentMixin)
 	"""
 	Represents a simple sequential variable assignment.
 
+	The assignment's destination is available as :data:`Target`, its value as :data:`Expression`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      v := '1';
-	      --^         <- Target
-	      --   ^^^    <- Expression
+	        v := '1';
+	      --^           <- Target
+	      --     ^^^    <- Expression
 	"""
 	def __init__(self, target: VariableSymbol, expression: ExpressionUnion, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -181,16 +188,18 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 	"""
 	Represents a conditional sequential variable assignment.
 
-	The branches are available as :data:`ConditionalExpressions`.
+	The alternatives are available as :data:`ConditionalExpressions`, a list of
+	:class:`~pyVHDLModel.Common.ConditionalExpression`. The model holds them in a list and has no
+	distinct field per alternative, so the markers below name list elements.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      v := '1' when sel = 0 else '0';
-	      --^                               <- Target
-	      --   ^^^^^^^^^^^^^^^^             <- first branch
-	      --                         ^^^    <- final branch
+	        v := '1' when sel = '0' else '0';
+	      --^                                   <- Target
+	      --     ^^^^^^^^^^^^^^^^^^             <- ConditionalExpressions[0]
+	      --                             ^^^    <- ConditionalExpressions[1]
 
 	.. seealso::
 
@@ -229,14 +238,18 @@ class SequentialConditionalSignalAssignment(SequentialStatement, SignalAssignmen
 	"""
 	Represents a conditional sequential signal assignment.
 
+	The alternatives are available as :data:`ConditionalWaveforms`, a list of
+	:class:`~pyVHDLModel.Common.ConditionalWaveform`. The model holds them in a list and has no
+	distinct field per alternative, so the markers below name list elements.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      s <= '1' when sel = 0 else '0';
-	      --^                               <- Target
-	      --   ^^^^^^^^^^^^^^^^             <- first branch
-	      --                         ^^^    <- final branch
+	        s <= '1' when sel = '0' else '0';
+	      --^                                   <- Target
+	      --     ^^^^^^^^^^^^^^^^^^             <- ConditionalWaveforms[0]
+	      --                             ^^^    <- ConditionalWaveforms[1]
 
 	.. seealso::
 
@@ -261,13 +274,19 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin,
 	"""
 	Represents a selected sequential variable assignment.
 
+	The selector is available as :data:`Expression`, the alternatives as :data:`SelectedExpressions`,
+	a list of :class:`~pyVHDLModel.Common.SelectedExpression`. The model holds them in a list and has
+	no distinct field per alternative, so the markers below name list elements.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      with sel select v := '1' when '0', '0' when others;
-	      --   ^^^                                              <- the selector
-	      --                   ^^^^^^^^^^^^                     <- first alternative
+	      --   ^^^                                              <- Expression
+	      --              ^                                     <- Target
+	      --                   ^^^^^^^^^^^^                     <- SelectedExpressions[0]
+	      --                                 ^^^^^^^^^^^^^^^    <- SelectedExpressions[1]
 
 	.. seealso::
 
@@ -293,13 +312,19 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 	"""
 	Represents a selected sequential signal assignment.
 
+	The selector is available as :data:`Expression`, the alternatives as :data:`SelectedWaveforms`,
+	a list of :class:`~pyVHDLModel.Common.SelectedWaveform`. The model holds them in a list and has
+	no distinct field per alternative, so the markers below name list elements.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      with sel select s <= '1' when '0', '0' when others;
-	      --   ^^^                                              <- the selector
-	      --                   ^^^^^^^^^^^^                     <- first alternative
+	      --   ^^^                                              <- Expression
+	      --              ^                                     <- Target
+	      --                   ^^^^^^^^^^^^                     <- SelectedWaveforms[0]
+	      --                                 ^^^^^^^^^^^^^^^    <- SelectedWaveforms[1]
 
 	.. seealso::
 
@@ -332,9 +357,9 @@ class SignalForceAssignment(SequentialStatement, SignalAssignmentMixin, Expressi
 
 	   .. code-block:: VHDL
 
-	      s <= force '1';
-	      --^               <- Target
-	      --         ^^^    <- the forced value
+	        s <= force '1';
+	      --^                 <- Target
+	      --           ^^^    <- Expression
 	"""
 
 	def __init__(
@@ -360,8 +385,8 @@ class SignalReleaseAssignment(SequentialStatement, SignalAssignmentMixin):
 
 	   .. code-block:: VHDL
 
-	      s <= release;
-	      --^             <- Target
+	        s <= release;
+	      --^               <- Target
 	"""
 
 	def __init__(self, target: SignalSymbol, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -392,14 +417,17 @@ class SequentialAssertStatement(SequentialStatement, AssertStatementMixin):
 	"""
 	Represents a sequential assertion statement.
 
+	The checked condition is available as :data:`Condition`, the optional report string as
+	:data:`Message` and the optional severity as :data:`Severity`.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      assert sel = 0 report "bad" severity error;
-	      --     ^^^^^^^                                <- Condition
-	      --                    ^^^^^                   <- Message
-	      --                                   ^^^^^    <- Severity
+	      assert sel = '0' report "bad" severity error;
+	      --     ^^^^^^^^^                                <- Condition
+	      --                      ^^^^^                   <- Message (optional)
+	      --                                     ^^^^^    <- Severity (optional)
 
 	.. seealso::
 
@@ -454,12 +482,23 @@ class IfBranch(Branch, IfBranchMixin):
 	"""
 	Represents the ``if`` branch of an if statement.
 
+	The branch's condition is available as :data:`Condition`, its body as :data:`Statements`.
+
 	.. admonition:: Example
+
+	   The whole if statement is shown; the bracket marks the part this class represents.
 
 	   .. code-block:: VHDL
 
-	      if sel = 0 then
-	      -- ^^^^^^^        <- Condition
+	      if sel = '0' then     -- ┐ IfBranch
+	      -- ^^^^^^^^^          -- │   <- Condition
+	        s <= '0';           -- │
+	      --^^^^^^^^^           -- ┘   <- Statements
+	      elsif sel = '1' then
+	        s <= '1';
+	      else
+	        s <= '0';
+	      end if;
 	"""
 	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
@@ -471,12 +510,24 @@ class ElsifBranch(Branch, ElsifBranchMixin):
 	"""
 	Represents an ``elsif`` branch of an if statement.
 
+	The branch's condition is available as :data:`Condition`, its body as :data:`Statements`.
+	An if statement may have any number of them.
+
 	.. admonition:: Example
+
+	   The whole if statement is shown; the bracket marks the part this class represents.
 
 	   .. code-block:: VHDL
 
-	      elsif sel = 1 then
-	      --    ^^^^^^^        <- Condition
+	      if sel = '0' then
+	        s <= '0';
+	      elsif sel = '1' then  -- ┐ ElsifBranch
+	      --    ^^^^^^^^^       -- │   <- Condition
+	        s <= '1';           -- │
+	      --^^^^^^^^^           -- ┘   <- Statements
+	      else
+	        s <= '0';
+	      end if;
 	"""
 	def __init__(self, condition: ExpressionUnion, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
@@ -488,7 +539,23 @@ class ElseBranch(Branch, ElseBranchMixin):
 	"""
 	Represents the ``else`` branch of an if statement.
 
-	Unlike the other branches, an else branch has no condition.
+	Unlike the other branches, an else branch has no condition; it only has a body
+	(:data:`Statements`). An if statement has at most one.
+
+	.. admonition:: Example
+
+	   The whole if statement is shown; the bracket marks the part this class represents.
+
+	   .. code-block:: VHDL
+
+	      if sel = '0' then
+	        s <= '0';
+	      elsif sel = '1' then
+	        s <= '1';
+	      else                  -- ┐ ElseBranch
+	        s <= '0';           -- │
+	      --^^^^^^^^^           -- ┘   <- Statements
+	      end if;
 	"""
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, parent)
@@ -509,21 +576,24 @@ class IfStatement(CompoundStatement):
 
 	   .. code-block:: VHDL
 
-	      if sel = 0 then
-	        v := '1';
+	      if sel = '0' then
+	        s <= '0';
 	      end if;
 
 	   With ``elsif`` and ``else`` branches:
 
 	   .. code-block:: VHDL
 
-	      if sel = 0 then
-	        v := '1';
-	      elsif sel = 1 then
-	        v := '0';
-	      else
-	        null;
-	      end if;
+	        if sel = '0' then
+	      --^^^^^^^^^^^^^^^^^      <- IfBranch
+	          s <= '0';
+	        elsif sel = '1' then
+	      --^^^^^^^^^^^^^^^^^^^^   <- ElsIfBranches[0]
+	          s <= '1';
+	        else
+	      --^^^^                   <- ElseBranch
+	          s <= '0';
+	        end if;
 
 	.. seealso::
 
@@ -741,8 +811,10 @@ class CaseStatement(CompoundStatement):
 
 	      case sel is
 	      --   ^^^                     <- SelectExpression
-	        when 0      => v := '1';
+	        when '0'    => s <= '1';
+	      --^^^^^^^^^^^^^^^^^^^^^^^^   <- Cases[0]
 	        when others => null;
+	      --^^^^^^^^^^^^^^^^^^^^       <- Cases[1]
 	      end case;
 
 	.. seealso::
@@ -1038,9 +1110,9 @@ class WaitStatement(SequentialStatement, ConditionalMixin):
 
 	   .. code-block:: VHDL
 
-	      wait until clk = '1' for 10 ns;
-	      --         ^^^^^^^^^              <- Condition
-	      --                       ^^^^^    <- Timeout
+	      wait until clock = '1' for 10 ns;
+	      --         ^^^^^^^^^^^              <- Condition (optional)
+	      --                         ^^^^^    <- Timeout (optional)
 	"""
 	_sensitivityList: Nullable[List[Symbol]]
 	_timeout:         ExpressionUnion

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -70,10 +70,10 @@ class SequentialStatementsMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Branch <pyVHDLModel.Sequential.Branch>`
-	   * :class:`Loop statement <pyVHDLModel.Sequential.LoopStatement>`
 	   * :class:`Process statement <pyVHDLModel.Concurrent.ProcessStatement>`
+	   * :class:`Branch <pyVHDLModel.Sequential.Branch>`
 	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
+	   * :class:`Loop statement <pyVHDLModel.Sequential.LoopStatement>`
 	"""
 	_statements: List[SequentialStatement]
 
@@ -104,8 +104,8 @@ class SequentialProcedureCall(SequentialStatement, ProcedureCallMixin):
 
 	   .. code-block:: VHDL
 
-	      log("hello");
-	    --^^^^^^^^^^^^    <- the call
+	        log("hello");
+	      --^^^^^^^^^^^^    <- the call
 
 	.. seealso::
 
@@ -265,9 +265,9 @@ class SequentialSelectedVariableAssignment(SequentialStatement, AssignmentMixin,
 
 	   .. code-block:: VHDL
 
-	      with sel select v := '1' when 0, '0' when others;
-	      --   ^^^                                            <- the selector
-	      --                   ^^^^^^^^^^                     <- first alternative
+	      with sel select v := '1' when '0', '0' when others;
+	      --   ^^^                                              <- the selector
+	      --                   ^^^^^^^^^^^^                     <- first alternative
 
 	.. seealso::
 
@@ -297,9 +297,9 @@ class SequentialSelectedSignalAssignment(SequentialStatement, SignalAssignmentMi
 
 	   .. code-block:: VHDL
 
-	      with sel select t <= '1' when 0, '0' when others;
-	      --   ^^^                                            <- the selector
-	      --                   ^^^^^^^^^^                     <- first alternative
+	      with sel select s <= '1' when '0', '0' when others;
+	      --   ^^^                                              <- the selector
+	      --                   ^^^^^^^^^^^^                     <- first alternative
 
 	.. seealso::
 
@@ -426,8 +426,8 @@ class CompoundStatement(SequentialStatement):
 
 	.. seealso::
 
-	   * :class:`Case statement <pyVHDLModel.Sequential.CaseStatement>`
 	   * :class:`If statement <pyVHDLModel.Sequential.IfStatement>`
+	   * :class:`Case statement <pyVHDLModel.Sequential.CaseStatement>`
 	   * :class:`Loop statement <pyVHDLModel.Sequential.LoopStatement>`
 	"""
 
@@ -439,9 +439,9 @@ class Branch(ModelEntity, SequentialStatementsMixin):
 
 	.. seealso::
 
-	   * :class:`Else branch <pyVHDLModel.Sequential.ElseBranch>`
-	   * :class:`Elsif branch <pyVHDLModel.Sequential.ElsifBranch>`
 	   * :class:`If branch <pyVHDLModel.Sequential.IfBranch>`
+	   * :class:`Elsif branch <pyVHDLModel.Sequential.ElsifBranch>`
+	   * :class:`Else branch <pyVHDLModel.Sequential.ElseBranch>`
 	"""
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -740,10 +740,10 @@ class CaseStatement(CompoundStatement):
 	   .. code-block:: VHDL
 
 	      case sel is
+	      --   ^^^                     <- SelectExpression
 	        when 0      => v := '1';
 	        when others => null;
 	      end case;
-	      --   ^^^                     <- SelectExpression
 
 	.. seealso::
 
@@ -914,8 +914,8 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 
 	.. seealso::
 
-	   * :class:`Exit statement <pyVHDLModel.Sequential.ExitStatement>`
 	   * :class:`Next statement <pyVHDLModel.Sequential.NextStatement>`
+	   * :class:`Exit statement <pyVHDLModel.Sequential.ExitStatement>`
 	"""
 
 	_loopReference: LoopStatement
@@ -967,8 +967,8 @@ class ExitStatement(LoopControlStatement):
 
 	   .. code-block:: VHDL
 
-	      exit;
-	    --^^^^    <- the statement
+	        exit;
+	      --^^^^    <- the statement
 	"""
 	pass
 
@@ -982,8 +982,8 @@ class NullStatement(SequentialStatement):
 
 	   .. code-block:: VHDL
 
-	      null;
-	    --^^^^    <- the statement
+	        null;
+	      --^^^^    <- the statement
 	"""
 	pass
 

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -54,6 +54,11 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, Sequentia
 	A subprogram is a named entity (:data:`Identifier`) with an optional generic clause
 	(:data:`GenericItems`), a parameter list (:data:`ParameterItems`), its own declarative part
 	(:data:`DeclaredItems`) and a sequence of statements (:data:`Statements`).
+
+	.. seealso::
+
+	   * :class:`Function <pyVHDLModel.Subprogram.Function>`
+	   * :class:`Procedure <pyVHDLModel.Subprogram.Procedure>`
 	"""
 	_genericItems:   List['GenericInterfaceItemMixin']
 	_parameterItems: List['ParameterInterfaceItemMixin']
@@ -168,6 +173,13 @@ class Procedure(Subprogram):
 	    --                      ^^^^^^^^^^       <- ParameterItems
 	      begin
 	      end procedure;
+
+	.. seealso::
+
+	   * :class:`Generic procedure interface item <pyVHDLModel.Interface.GenericProcedureInterfaceItem>`
+	   * :class:`Procedure instantiation <pyVHDLModel.Instantiation.ProcedureInstantiation>`
+	   * :class:`Procedure method <pyVHDLModel.Subprogram.ProcedureMethod>`
+	   * :class:`Function <pyVHDLModel.Subprogram.Function>`
 	"""
 	def __init__(
 		self,
@@ -200,6 +212,13 @@ class Function(Subprogram):
 	    --                             ^^^^^^^                      <- ReturnType
 	      begin
 	      end function;
+
+	.. seealso::
+
+	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
+	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
+	   * :class:`Generic function interface item <pyVHDLModel.Interface.GenericFunctionInterfaceItem>`
+	   * :class:`Procedure <pyVHDLModel.Subprogram.Procedure>`
 	"""
 	_returnType: SubtypeSymbol
 
@@ -232,7 +251,14 @@ class Function(Subprogram):
 
 @export
 class MethodMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``Method`` is a mixin class for all subprograms in a protected type."""
+	"""
+	A ``Method`` is a mixin class for all subprograms in a protected type.
+
+	.. seealso::
+
+	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
+	   * :class:`Procedure method <pyVHDLModel.Subprogram.ProcedureMethod>`
+	"""
 
 	_protectedType: ProtectedType
 
@@ -257,6 +283,10 @@ class ProcedureMethod(Procedure, MethodMixin):
 	Represents a procedure declared as a method of a protected type.
 
 	The protected type is available as :data:`ProtectedType`.
+
+	.. seealso::
+
+	   * :class:`Protected type <pyVHDLModel.Type.ProtectedType>`
 	"""
 	def __init__(
 		self,
@@ -279,6 +309,10 @@ class FunctionMethod(Function, MethodMixin):
 	Represents a function declared as a method of a protected type.
 
 	The protected type is available as :data:`ProtectedType`.
+
+	.. seealso::
+
+	   * :class:`Protected type <pyVHDLModel.Type.ProtectedType>`
 	"""
 	def __init__(
 		self,

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -48,6 +48,13 @@ from pyVHDLModel.Sequential import SequentialStatement
 
 @export
 class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, SequentialDeclarationRegionMixin):
+	"""
+	Represents the base-class of all subprograms: procedures and functions.
+
+	A subprogram is a named entity (:data:`Identifier`) with an optional generic clause
+	(:data:`GenericItems`), a parameter list (:data:`ParameterItems`), its own declarative part
+	(:data:`DeclaredItems`) and a sequence of statements (:data:`Statements`).
+	"""
 	_genericItems:   List['GenericInterfaceItemMixin']
 	_parameterItems: List['ParameterInterfaceItemMixin']
 	_statements:     List[SequentialStatement]
@@ -147,6 +154,21 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, Sequentia
 
 @export
 class Procedure(Subprogram):
+	"""
+	Represents a procedure.
+
+	Unlike a function, a procedure returns no value.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      procedure proc(signal s : in bit) is
+	    --^^^^                                   <- Identifier
+	    --                      ^^^^^^^^^^       <- ParameterItems
+	      begin
+	      end procedure;
+	"""
 	def __init__(
 		self,
 		identifier:     str,
@@ -162,6 +184,23 @@ class Procedure(Subprogram):
 
 @export
 class Function(Subprogram):
+	"""
+	Represents a function.
+
+	A function returns a value of its return type (:data:`ReturnType`) and is either pure or impure
+	(:data:`IsPure`).
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      function fun(constant c : in integer) return integer is
+	    --^^^                                                       <- Identifier
+	    --                      ^^^^^^^^^^^^^^                      <- ParameterItems
+	    --                             ^^^^^^^                      <- ReturnType
+	      begin
+	      end function;
+	"""
 	_returnType: SubtypeSymbol
 
 	def __init__(
@@ -214,6 +253,11 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class ProcedureMethod(Procedure, MethodMixin):
+	"""
+	Represents a procedure declared as a method of a protected type.
+
+	The protected type is available as :data:`ProtectedType`.
+	"""
 	def __init__(
 		self,
 		identifier:     str,
@@ -231,6 +275,11 @@ class ProcedureMethod(Procedure, MethodMixin):
 
 @export
 class FunctionMethod(Function, MethodMixin):
+	"""
+	Represents a function declared as a method of a protected type.
+
+	The protected type is available as :data:`ProtectedType`.
+	"""
 	def __init__(
 		self,
 		identifier:     str,

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -57,8 +57,8 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, Sequentia
 
 	.. seealso::
 
-	   * :class:`Function <pyVHDLModel.Subprogram.Function>`
 	   * :class:`Procedure <pyVHDLModel.Subprogram.Procedure>`
+	   * :class:`Function <pyVHDLModel.Subprogram.Function>`
 	"""
 	_genericItems:   List['GenericInterfaceItemMixin']
 	_parameterItems: List['ParameterInterfaceItemMixin']
@@ -162,22 +162,28 @@ class Procedure(Subprogram):
 	"""
 	Represents a procedure.
 
-	Unlike a function, a procedure returns no value.
+	Unlike a function, a procedure returns no value. Besides its parameters, it has its own
+	declarative part (:data:`DeclaredItems`) and statements (:data:`Statements`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      procedure proc(signal s : in bit) is
-	    --^^^^                                   <- Identifier
-	    --                      ^^^^^^^^^^       <- ParameterItems
+	      procedure proc(signal s : in bit; variable v : out bit) is
+	      --        ^^^^                                               <- Identifier
+	      --             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       <- ParameterItems
+	        variable tmp : bit;
+	      --^^^^^^^^^^^^^^^^^^^                                        <- DeclaredItems
 	      begin
+	        tmp := s;
+	      --^^^^^^^^^                                                  <- Statements
+	        v := tmp;
 	      end procedure;
 
 	.. seealso::
 
-	   * :class:`Generic procedure interface item <pyVHDLModel.Interface.GenericProcedureInterfaceItem>`
 	   * :class:`Procedure instantiation <pyVHDLModel.Instantiation.ProcedureInstantiation>`
+	   * :class:`Generic procedure interface item <pyVHDLModel.Interface.GenericProcedureInterfaceItem>`
 	   * :class:`Procedure method <pyVHDLModel.Subprogram.ProcedureMethod>`
 	   * :class:`Function <pyVHDLModel.Subprogram.Function>`
 	"""
@@ -200,24 +206,30 @@ class Function(Subprogram):
 	Represents a function.
 
 	A function returns a value of its return type (:data:`ReturnType`) and is either pure or impure
-	(:data:`IsPure`).
+	(:data:`IsPure`). Besides its parameters, it has its own declarative part (:data:`DeclaredItems`)
+	and statements (:data:`Statements`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      function fun(constant c : in integer) return integer is
-	    --^^^                                                       <- Identifier
-	    --                      ^^^^^^^^^^^^^^                      <- ParameterItems
-	    --                             ^^^^^^^                      <- ReturnType
+	      function fun(constant c : in positive) return integer is
+	      --       ^^^                                               <- Identifier
+	      --           ^^^^^^^^^^^^^^^^^^^^^^^^                      <- ParameterItems
+	      --                                            ^^^^^^^      <- ReturnType
+	        variable tmp : integer;
+	      --^^^^^^^^^^^^^^^^^^^^^^^                                  <- DeclaredItems
 	      begin
+	        tmp := c;
+	      --^^^^^^^^^                                                <- Statements
+	        return tmp;
 	      end function;
 
 	.. seealso::
 
 	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
-	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
 	   * :class:`Generic function interface item <pyVHDLModel.Interface.GenericFunctionInterfaceItem>`
+	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
 	   * :class:`Procedure <pyVHDLModel.Subprogram.Procedure>`
 	"""
 	_returnType: SubtypeSymbol
@@ -256,8 +268,8 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
-	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
 	   * :class:`Procedure method <pyVHDLModel.Subprogram.ProcedureMethod>`
+	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
 	"""
 
 	_protectedType: ProtectedType

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -689,6 +689,12 @@ class SubtypeSymbol(Symbol):
 	Represents the base-class of all references to a type or subtype.
 
 	The referenced language entity is available as :data:`Reference` once resolved.
+
+	.. seealso::
+
+	   * :class:`Constrained composite subtype symbol <pyVHDLModel.Symbol.ConstrainedCompositeSubtypeSymbol>`
+	   * :class:`Constrained scalar subtype symbol <pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol>`
+	   * :class:`Simple subtype symbol <pyVHDLModel.Symbol.SimpleSubtypeSymbol>`
 	"""
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.Type | PossibleReference.Subtype)
@@ -728,6 +734,12 @@ class SimpleSubtypeSymbol(SubtypeSymbol):
 class Constraint(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for symbols carrying a constraint.
+
+	.. seealso::
+
+	   * :class:`Array constraint <pyVHDLModel.Symbol.ArrayConstraint>`
+	   * :class:`Record constraint <pyVHDLModel.Symbol.RecordConstraint>`
+	   * :class:`Scalar constraint <pyVHDLModel.Symbol.ScalarConstraint>`
 	"""
 	pass
 
@@ -738,6 +750,10 @@ class ScalarConstraint(Constraint, mixin=True):
 	A mixin-class for a scalar constraint: a range.
 
 	The range is available as :data:`Constraint`.
+
+	.. seealso::
+
+	   * :class:`Constrained scalar subtype symbol <pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol>`
 	"""
 	_constraint: Nullable[Range]
 
@@ -781,6 +797,10 @@ class ArrayConstraint(Constraint, mixin=True):
 	A mixin-class for an array constraint: one range per dimension.
 
 	The ranges are available as :data:`Constraints`.
+
+	.. seealso::
+
+	   * :class:`Constrained array subtype symbol <pyVHDLModel.Symbol.ConstrainedArraySubtypeSymbol>`
 	"""
 	_constraints: List[Range]
 
@@ -803,6 +823,10 @@ class RecordConstraint(Constraint, mixin=True):
 	A mixin-class for a record constraint: one constraint per element.
 
 	The constraints are available as :data:`Constraints`.
+
+	.. seealso::
+
+	   * :class:`Constrained record subtype symbol <pyVHDLModel.Symbol.ConstrainedRecordSubtypeSymbol>`
 	"""
 	_constraints: Dict[RecordElementSymbol, Range]
 
@@ -825,6 +849,11 @@ class ConstrainedCompositeSubtypeSymbol(SubtypeSymbol):
 	Represents the base-class of references to constrained composite subtypes.
 
 	The referenced language entity is available as :data:`Reference` once resolved.
+
+	.. seealso::
+
+	   * :class:`Constrained array subtype symbol <pyVHDLModel.Symbol.ConstrainedArraySubtypeSymbol>`
+	   * :class:`Constrained record subtype symbol <pyVHDLModel.Symbol.ConstrainedRecordSubtypeSymbol>`
 	"""
 	pass
 

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -654,6 +654,18 @@ class PackageSymbol(Symbol):
 
 @export
 class RecordElementSymbol(Symbol):
+	"""
+	Represents a reference to a record element.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      r := (a => '1', b => '0');
+	      --    ^                      <- Name
+	"""
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.RecordElement)
 
@@ -673,6 +685,11 @@ class RangeAttributeSymbol(Symbol):
 
 @export
 class SubtypeSymbol(Symbol):
+	"""
+	Represents the base-class of all references to a type or subtype.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+	"""
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.Type | PossibleReference.Subtype)
 
@@ -692,16 +709,36 @@ class SubtypeSymbol(Symbol):
 
 @export
 class SimpleSubtypeSymbol(SubtypeSymbol):
+	"""
+	Represents a reference to a type or subtype by its type mark.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      signal s : bit := '0';
+	      --         ^^^           <- Name
+	"""
 	pass
 
 
 @export
 class Constraint(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for symbols carrying a constraint.
+	"""
 	pass
 
 
 @export
 class ScalarConstraint(Constraint, mixin=True):
+	"""
+	A mixin-class for a scalar constraint: a range.
+
+	The range is available as :data:`Constraint`.
+	"""
 	_constraint: Nullable[Range]
 
 	def __init__(self, constraint: Nullable[Range]) -> None:
@@ -720,12 +757,17 @@ class ScalarConstraint(Constraint, mixin=True):
 @export
 class ConstrainedScalarSubtypeSymbol(SubtypeSymbol, ScalarConstraint):
 	"""
+	Represents a reference to a scalar subtype narrowed by a range.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      signal s : integer range 0 to 15;
-	      --         ^^^^^^^^^^^^^^^^^^^^^^
+	      for i in integer range 0 to 3 loop
+	      --       ^^^^^^^                     <- Name
+	      --                     ^^^^^^        <- Constraint
 	"""
 
 	def __init__(self, name: Name, constraint: Nullable[Range] = None) -> None:
@@ -735,6 +777,11 @@ class ConstrainedScalarSubtypeSymbol(SubtypeSymbol, ScalarConstraint):
 
 @export
 class ArrayConstraint(Constraint, mixin=True):
+	"""
+	A mixin-class for an array constraint: one range per dimension.
+
+	The ranges are available as :data:`Constraints`.
+	"""
 	_constraints: List[Range]
 
 	def __init__(self, constraints: Iterable[Range]) -> None:
@@ -752,6 +799,11 @@ class ArrayConstraint(Constraint, mixin=True):
 
 @export
 class RecordConstraint(Constraint, mixin=True):
+	"""
+	A mixin-class for a record constraint: one constraint per element.
+
+	The constraints are available as :data:`Constraints`.
+	"""
 	_constraints: Dict[RecordElementSymbol, Range]
 
 	def __init__(self, constraints: Mapping[RecordElementSymbol, Range]) -> None:
@@ -769,11 +821,29 @@ class RecordConstraint(Constraint, mixin=True):
 
 @export
 class ConstrainedCompositeSubtypeSymbol(SubtypeSymbol):
+	"""
+	Represents the base-class of references to constrained composite subtypes.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+	"""
 	pass
 
 
 @export
 class ConstrainedArraySubtypeSymbol(ConstrainedCompositeSubtypeSymbol, ArrayConstraint):
+	"""
+	Represents a reference to an array subtype narrowed by index ranges.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      signal v : bit_vector(7 downto 0);
+	      --         ^^^^^^^^^^                <- Name
+	      --                    ^^^^^^^^^^     <- Constraints
+	"""
 	_constraints: List
 
 	def __init__(self, name: Name, constraints: Iterable) -> None:
@@ -783,6 +853,11 @@ class ConstrainedArraySubtypeSymbol(ConstrainedCompositeSubtypeSymbol, ArrayCons
 
 @export
 class ConstrainedRecordSubtypeSymbol(ConstrainedCompositeSubtypeSymbol, RecordConstraint):
+	"""
+	Represents a reference to a record subtype with constrained elements.
+
+	The referenced language entity is available as :data:`Reference` once resolved.
+	"""
 	_constraints: Dict[RecordElementSymbol, Any]
 
 	def __init__(self, name: Name, constraints: Mapping) -> None:
@@ -792,11 +867,23 @@ class ConstrainedRecordSubtypeSymbol(ConstrainedCompositeSubtypeSymbol, RecordCo
 
 @export
 class SimpleObjectOrFunctionCallSymbol(Symbol):
+	"""
+	Represents a reference that is either an object or a parameterless function call.
+
+	Which of the two it is cannot be decided before the name is resolved. The referenced language
+	entity is available as :data:`Reference` once resolved.
+	"""
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.SimpleNameInExpression)
 
 
 @export
 class IndexedObjectOrFunctionCallSymbol(Symbol):
+	"""
+	Represents a reference that is either an indexed object or a function call.
+
+	An expression like ``f(0)`` may index an array or call a function; both look identical until the
+	name is resolved. The referenced language entity is available as :data:`Reference` once resolved.
+	"""
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.Object | PossibleReference.Function)

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -218,19 +218,26 @@ class PackageReferenceSymbol(Symbol):
 @export
 class ModeViewSymbol(Symbol):
 	"""
-	Represents a reference (name) to a mode view declaration.
+	Represents a reference to a mode view (VHDL-2019).
 
-	The internal name will be a :class:`~pyVHDLModel.Name.SimpleName` (or an
-	:class:`~pyVHDLModel.Name.AttributeName` for the ``'converse`` case).
+	The referenced mode view is available as :data:`Reference` once resolved. A reference may also
+	select the converse view.
 
 	.. admonition:: Example
 
+	   Referencing a mode view:
+
 	   .. code-block:: VHDL
 
-	      port (p : view MyView);
-	      --          ^^^^^^
-	      port (p : view MyView'converse);
-	      --          ^^^^^^^^^^^^^^^^^^
+	      port (p : view MasterView);
+	      --             ^^^^^^^^^^     <- Name
+
+	   Referencing its converse:
+
+	   .. code-block:: VHDL
+
+	      port (p : view MasterView'converse);
+	      --             ^^^^^^^^^^^^^^^^^^^     <- Name
 	"""
 
 	def __init__(self, name: Name) -> None:
@@ -253,15 +260,16 @@ class ModeViewSymbol(Symbol):
 @export
 class SubprogramReferenceSymbol(Symbol):
 	"""
-	Represents a reference (name) to a subprogram (procedure or function), e.g. the uninstantiated
-	subprogram named by a subprogram instantiation.
+	Represents a reference to a subprogram.
+
+	The referenced subprogram is available as :data:`Reference` once resolved.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      function f is new g generic map (...);
-	      --                  ^
+	      function f is new gen_fun generic map (N => 1);
+	      --                ^^^^^^^                         <- Name
 	"""
 
 	def __init__(self, name: Name) -> None:
@@ -284,15 +292,16 @@ class SubprogramReferenceSymbol(Symbol):
 @export
 class ConfigurationSymbol(Symbol):
 	"""
-	Represents a reference (name) to a configuration declaration, e.g. in an entity aspect of a
-	binding indication.
+	Represents a reference to a configuration.
+
+	The referenced configuration is available as :data:`Reference` once resolved.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      for U1 : comp use configuration work.cfg;
-	      --                              ^^^^^^^
+	      --                              ^^^^^^^^    <- Name
 	"""
 
 	def __init__(self, name: Name) -> None:
@@ -692,9 +701,9 @@ class SubtypeSymbol(Symbol):
 
 	.. seealso::
 
-	   * :class:`Constrained composite subtype symbol <pyVHDLModel.Symbol.ConstrainedCompositeSubtypeSymbol>`
-	   * :class:`Constrained scalar subtype symbol <pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol>`
 	   * :class:`Simple subtype symbol <pyVHDLModel.Symbol.SimpleSubtypeSymbol>`
+	   * :class:`Constrained scalar subtype symbol <pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol>`
+	   * :class:`Constrained composite subtype symbol <pyVHDLModel.Symbol.ConstrainedCompositeSubtypeSymbol>`
 	"""
 	def __init__(self, name: Name) -> None:
 		super().__init__(name, PossibleReference.Type | PossibleReference.Subtype)
@@ -737,9 +746,9 @@ class Constraint(metaclass=ExtendedType, mixin=True):
 
 	.. seealso::
 
+	   * :class:`Scalar constraint <pyVHDLModel.Symbol.ScalarConstraint>`
 	   * :class:`Array constraint <pyVHDLModel.Symbol.ArrayConstraint>`
 	   * :class:`Record constraint <pyVHDLModel.Symbol.RecordConstraint>`
-	   * :class:`Scalar constraint <pyVHDLModel.Symbol.ScalarConstraint>`
 	"""
 	pass
 

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -566,7 +566,7 @@ class RecordType(CompositeType):
 @export
 class ProtectedType(FullType):
 	"""
-	Represents a protected type declaration (VHDL-2002).
+	Represents a protected type declaration.
 
 	A protected type is a named entity (:data:`Identifier`) exposing only its methods
 	(:data:`Methods`). The implementation lives in a separate :class:`ProtectedTypeBody`.
@@ -605,7 +605,7 @@ class ProtectedType(FullType):
 @export
 class ProtectedTypeBody(FullType):
 	"""
-	Represents a protected type body (VHDL-2002).
+	Represents a protected type body.
 
 	A protected type body implements the methods (:data:`Methods`) declared by the
 	:class:`ProtectedType` of the same identifier (:data:`Identifier`).

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -48,7 +48,10 @@ from pyVHDLModel.Expression import EnumerationLiteral, PhysicalIntegerLiteral
 @export
 class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	"""
-	A base-class for all type entities: full types, subtypes and anonymous types.
+	Represents the base-class of all type entities: full types, subtypes and anonymous types.
+
+	Every type is a named entity (:data:`Identifier`, :data:`NormalizedIdentifier`) and can carry
+	documentation (:data:`Documentation`).
 	"""
 
 	_objectVertex: Vertex
@@ -70,7 +73,7 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 @export
 class Type(BaseType):
 	"""
-	A base-class for types that are named by a type declaration.
+	Represents a base-class for types introduced by a type declaration.
 
 	Besides real type declarations, this is also the base-class of a generic type interface item, which
 	introduces a type name without defining the type itself.
@@ -81,16 +84,17 @@ class Type(BaseType):
 @export
 class AnonymousType(Type):
 	"""
-	A base-class for types that have no type definition of their own.
+	Represents a base-class for types without a type definition of their own.
 
-	An incomplete type is the typical case: it names a type whose definition appears later.
+	An incomplete type is the typical case: it names a type whose definition follows later in the same
+	declarative part.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type ptr;              -- incomplete, completed further down
-	      --   ^^^
+	      --   ^^^   <- Identifier
 	"""
 	pass
 
@@ -98,10 +102,10 @@ class AnonymousType(Type):
 @export
 class FullType(BaseType):
 	"""
-	A base-class for all full type definitions, as opposed to a :class:`Subtype`.
+	Represents a base-class for all full type definitions, as opposed to a :class:`Subtype`.
 
-	This is the distinction the declaration regions index on: a full type goes into ``Types``, a subtype
-	into ``Subtypes``.
+	This is the distinction the declaration regions index on: a full type is registered in ``Types``, a
+	subtype in ``Subtypes``.
 	"""
 	pass
 
@@ -109,16 +113,35 @@ class FullType(BaseType):
 @export
 class Subtype(BaseType):
 	"""
-	A subtype declaration: a type mark, optionally narrowed by a constraint and/or a resolution function.
+	Represents a subtype declaration.
+
+	A subtype is a named entity (:data:`Identifier`, :data:`NormalizedIdentifier`) referencing a type
+	(:data:`Type`). Optionally, the subtype can be narrowed by a constraint (:data:`Range`) and/or
+	resolved by a resolution function (:data:`ResolutionFunction`).
 
 	.. admonition:: Example
 
+	   Without a constraint:
+
 	   .. code-block:: VHDL
 
-	      subtype byte is bit_vector(7 downto 0);
-	      --      ^^^^                              <- Identifier
-	      --              ^^^^^^^^^^                <- Type (the type mark)
-	      --                        ^^^^^^^^^^^^   <- Range (the constraint)
+	      subtype byte is bit_vector;
+	      --      ^^^^                 <- Identifier
+	      --              ^^^^^^^^^^   <- Type
+
+	   With a constraint:
+
+	   .. code-block:: VHDL
+
+	      subtype nibble is bit_vector(3 downto 0);
+	      --                          ^^^^^^^^^^^^   <- Range
+
+	   With a resolution function:
+
+	   .. code-block:: VHDL
+
+	      subtype wired is resolved std_ulogic;
+	      --               ^^^^^^^^              <- ResolutionFunction
 	"""
 	_type:               Symbol
 	_baseType:           BaseType
@@ -176,17 +199,17 @@ class Subtype(BaseType):
 @export
 class ScalarType(FullType):
 	"""
-	A base-class for all scalar types: enumerated, integer, real and physical types.
+	Represents a base-class for all scalar types: enumerated, integer, real and physical types.
 	"""
 
 
 @export
 class RangedScalarType(ScalarType):
 	"""
-	A base-class for all scalar types constrained by a range: integer, real and physical types.
+	Represents a base-class for all scalar types constrained by a range (:data:`Range`).
 
-	An enumerated type is scalar but not ranged, which is why it derives from :class:`ScalarType`
-	directly.
+	Integer, real and physical types are ranged. An enumerated type is scalar but not ranged, so it
+	derives from :class:`ScalarType` directly.
 	"""
 
 	_range: Range
@@ -236,14 +259,18 @@ class DiscreteTypeMixin(metaclass=ExtendedType, mixin=True):
 @export
 class EnumeratedType(ScalarType, DiscreteTypeMixin):
 	"""
-	An enumerated type definition, listing its literals in declaration order.
+	Represents an enumerated type definition.
+
+	An enumerated type is a named entity (:data:`Identifier`) listing its enumeration literals
+	(:data:`Literals`) in declaration order.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type state is (Idle, Running, Done);
-	      --             ^^^^^^^^^^^^^^^^^^^   <- Literals
+	      --   ^^^^^                            <- Identifier
+	      --             ^^^^^^^^^^^^^^^^^^^    <- Literals
 	"""
 	_literals: List[EnumerationLiteral]
 
@@ -272,14 +299,17 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 @export
 class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
 	"""
-	An integer type definition, constrained by a range.
+	Represents an integer type definition.
+
+	An integer type is a named entity (:data:`Identifier`) constrained by a range (:data:`Range`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type nibble is range 0 to 15;
-	      --                   ^^^^^^^   <- Range
+	      --   ^^^^^^                     <- Identifier
+	      --                   ^^^^^^^    <- Range
 	"""
 	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, documentation, parent)
@@ -291,14 +321,18 @@ class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
 @export
 class RealType(RangedScalarType, NumericTypeMixin):
 	"""
-	A floating-point type definition, constrained by a range.
+	Represents a floating-point type definition.
+
+	A floating-point type is a named entity (:data:`Identifier`) constrained by a range
+	(:data:`Range`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type fraction is range 0.0 to 1.0;
-	      --                     ^^^^^^^^^^   <- Range
+	      --   ^^^^^^^^                        <- Identifier
+	      --                     ^^^^^^^^^^    <- Range
 	"""
 	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, documentation, parent)
@@ -310,15 +344,21 @@ class RealType(RangedScalarType, NumericTypeMixin):
 @export
 class PhysicalType(RangedScalarType, NumericTypeMixin):
 	"""
-	A physical type definition: a range, a primary unit and any number of secondary units.
+	Represents a physical type definition.
+
+	A physical type is a named entity (:data:`Identifier`) constrained by a range (:data:`Range`), and
+	defines a primary unit (:data:`PrimaryUnit`) plus any number of secondary units
+	(:data:`SecondaryUnits`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      type distance is range 0 to 1e9 units
-	        um;                                  -- PrimaryUnit
-	        mm = 1000 um;                        -- SecondaryUnits
+	      type distance is range 0 to 1000000 units
+	      --   ^^^^^^^^                              <- Identifier
+	      --                     ^^^^^^^^^^^^        <- Range
+	        um;                                      -- PrimaryUnit
+	        mm = 1000 um;                            -- SecondaryUnits
 	        m  = 1000 mm;
 	      end units;
 	"""
@@ -368,22 +408,35 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 @export
 class CompositeType(FullType):
 	"""
-	A base-class for all composite types: array and record types.
+	Represents a base-class for all composite types: array and record types.
 	"""
 
 
 @export
 class ArrayType(CompositeType):
 	"""
-	An array type definition: one or more index ranges and an element subtype.
+	Represents an array type definition.
+
+	An array type is a named entity (:data:`Identifier`) defining one or more index ranges
+	(:data:`Dimensions`) and the subtype of its elements (:data:`ElementType`).
 
 	.. admonition:: Example
+
+	   One dimension:
 
 	   .. code-block:: VHDL
 
 	      type memory is array (0 to 255) of bit_vector(7 downto 0);
+	      --   ^^^^^^                                                 <- Identifier
 	      --                    ^^^^^^^^                              <- Dimensions
 	      --                                 ^^^^^^^^^^^^^^^^^^^^^^   <- ElementType
+
+	   Two dimensions, both unconstrained:
+
+	   .. code-block:: VHDL
+
+	      type matrix is array (natural range <>, natural range <>) of bit;
+	      --                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      <- Dimensions
 	"""
 	_dimensions:  List[Range]
 	_elementType: Symbol
@@ -431,10 +484,10 @@ class ArrayType(CompositeType):
 @export
 class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 	"""
-	One element declaration inside a record type definition.
+	Represents one element declaration inside a record type definition.
 
-	A single declaration may name several elements at once, hence ``Identifiers`` rather than one
-	identifier.
+	A single declaration may name several elements at once, hence :data:`Identifiers` rather than one
+	identifier. All of them share the same subtype (:data:`Subtype`).
 
 	.. admonition:: Example
 
@@ -471,14 +524,18 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 @export
 class RecordType(CompositeType):
 	"""
-	A record type definition, holding its elements in declaration order.
+	Represents a record type definition.
+
+	A record type is a named entity (:data:`Identifier`) holding its element declarations
+	(:data:`Elements`) in declaration order.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type frame is record
-	        header : bit_vector(7 downto 0);   -- Elements
+	      --   ^^^^^              <- Identifier
+	        a, b    : bit;        -- Elements
 	        payload : bit_vector(31 downto 0);
 	      end record;
 	"""
@@ -509,16 +566,18 @@ class RecordType(CompositeType):
 @export
 class ProtectedType(FullType):
 	"""
-	A protected type declaration, exposing only its methods (VHDL-2002).
+	Represents a protected type declaration (VHDL-2002).
 
-	The implementation lives in a separate :class:`ProtectedTypeBody`.
+	A protected type is a named entity (:data:`Identifier`) exposing only its methods
+	(:data:`Methods`). The implementation lives in a separate :class:`ProtectedTypeBody`.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type counter is protected
-	        procedure increment;             -- Methods
+	      --   ^^^^^^^                             <- Identifier
+	        procedure increment;                   -- Methods
 	        impure function value return natural;
 	      end protected;
 	"""
@@ -546,15 +605,19 @@ class ProtectedType(FullType):
 @export
 class ProtectedTypeBody(FullType):
 	"""
-	A protected type body, implementing the methods declared by its :class:`ProtectedType`.
+	Represents a protected type body (VHDL-2002).
+
+	A protected type body implements the methods (:data:`Methods`) declared by the
+	:class:`ProtectedType` of the same identifier (:data:`Identifier`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type counter is protected body
+	      --   ^^^^^^^                        <- Identifier
 	        variable count : natural := 0;
-	        procedure increment is           -- Methods
+	        procedure increment is            -- Methods
 	        begin
 	          count := count + 1;
 	        end procedure;
@@ -585,14 +648,18 @@ class ProtectedTypeBody(FullType):
 @export
 class AccessType(FullType):
 	"""
-	An access type definition, pointing at values of its designated subtype.
+	Represents an access type definition.
+
+	An access type is a named entity (:data:`Identifier`) pointing at values of its designated subtype
+	(:data:`DesignatedSubtype`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type ptr is access integer;
-	      --                 ^^^^^^^   <- DesignatedSubtype
+	      --   ^^^                      <- Identifier
+	      --                 ^^^^^^^    <- DesignatedSubtype
 	"""
 	_designatedSubtype: Symbol
 
@@ -618,14 +685,18 @@ class AccessType(FullType):
 @export
 class FileType(FullType):
 	"""
-	A file type definition, holding values of its designated subtype.
+	Represents a file type definition.
+
+	A file type is a named entity (:data:`Identifier`) holding values of its designated subtype
+	(:data:`DesignatedSubtype`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type text_file is file of string;
-	      --                        ^^^^^^   <- DesignatedSubtype
+	      --   ^^^^^^^^^                      <- Identifier
+	      --                        ^^^^^^    <- DesignatedSubtype
 	"""
 	_designatedSubtype: Symbol
 

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -52,6 +52,12 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	Every type is a named entity (:data:`Identifier`, :data:`NormalizedIdentifier`) and can carry
 	documentation (:data:`Documentation`).
+
+	.. seealso::
+
+	   * :class:`Full type <pyVHDLModel.Type.FullType>`
+	   * :class:`Subtype <pyVHDLModel.Type.Subtype>`
+	   * :class:`Type <pyVHDLModel.Type.Type>`
 	"""
 
 	_objectVertex: Vertex
@@ -77,6 +83,11 @@ class Type(BaseType):
 
 	Besides real type declarations, this is also the base-class of a generic type interface item, which
 	introduces a type name without defining the type itself.
+
+	.. seealso::
+
+	   * :class:`Anonymous type <pyVHDLModel.Type.AnonymousType>`
+	   * :class:`Generic type interface item <pyVHDLModel.Interface.GenericTypeInterfaceItem>`
 	"""
 	pass
 
@@ -106,6 +117,15 @@ class FullType(BaseType):
 
 	This is the distinction the declaration regions index on: a full type is registered in ``Types``, a
 	subtype in ``Subtypes``.
+
+	.. seealso::
+
+	   * :class:`Access type <pyVHDLModel.Type.AccessType>`
+	   * :class:`Composite type <pyVHDLModel.Type.CompositeType>`
+	   * :class:`File type <pyVHDLModel.Type.FileType>`
+	   * :class:`Protected type <pyVHDLModel.Type.ProtectedType>`
+	   * :class:`Protected type body <pyVHDLModel.Type.ProtectedTypeBody>`
+	   * :class:`Scalar type <pyVHDLModel.Type.ScalarType>`
 	"""
 	pass
 
@@ -142,6 +162,10 @@ class Subtype(BaseType):
 
 	      subtype wired is resolved std_ulogic;
 	      --               ^^^^^^^^              <- ResolutionFunction
+
+	.. seealso::
+
+	   * :class:`Reference to a type or subtype <pyVHDLModel.Symbol.SubtypeSymbol>`
 	"""
 	_type:               Symbol
 	_baseType:           BaseType
@@ -200,6 +224,11 @@ class Subtype(BaseType):
 class ScalarType(FullType):
 	"""
 	Represents a base-class for all scalar types: enumerated, integer, real and physical types.
+
+	.. seealso::
+
+	   * :class:`Enumerated type <pyVHDLModel.Type.EnumeratedType>`
+	   * :class:`Ranged scalar type <pyVHDLModel.Type.RangedScalarType>`
 	"""
 
 
@@ -210,6 +239,12 @@ class RangedScalarType(ScalarType):
 
 	Integer, real and physical types are ranged. An enumerated type is scalar but not ranged, so it
 	derives from :class:`ScalarType` directly.
+
+	.. seealso::
+
+	   * :class:`Integer type <pyVHDLModel.Type.IntegerType>`
+	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
+	   * :class:`Real type <pyVHDLModel.Type.RealType>`
 	"""
 
 	_range: Range
@@ -240,6 +275,12 @@ class RangedScalarType(ScalarType):
 class NumericTypeMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for all numeric types: integer, real and physical types.
+
+	.. seealso::
+
+	   * :class:`Integer type <pyVHDLModel.Type.IntegerType>`
+	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
+	   * :class:`Real type <pyVHDLModel.Type.RealType>`
 	"""
 
 	def __init__(self) -> None:
@@ -250,6 +291,11 @@ class NumericTypeMixin(metaclass=ExtendedType, mixin=True):
 class DiscreteTypeMixin(metaclass=ExtendedType, mixin=True):
 	"""
 	A mixin-class for all discrete types: enumerated and integer types.
+
+	.. seealso::
+
+	   * :class:`Enumerated type <pyVHDLModel.Type.EnumeratedType>`
+	   * :class:`Integer type <pyVHDLModel.Type.IntegerType>`
 	"""
 
 	def __init__(self) -> None:
@@ -409,6 +455,11 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 class CompositeType(FullType):
 	"""
 	Represents a base-class for all composite types: array and record types.
+
+	.. seealso::
+
+	   * :class:`Array type <pyVHDLModel.Type.ArrayType>`
+	   * :class:`Record type <pyVHDLModel.Type.RecordType>`
 	"""
 
 
@@ -437,6 +488,10 @@ class ArrayType(CompositeType):
 
 	      type matrix is array (natural range <>, natural range <>) of bit;
 	      --                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      <- Dimensions
+
+	.. seealso::
+
+	   * :class:`Reference to a constrained array subtype <pyVHDLModel.Symbol.ConstrainedArraySubtypeSymbol>`
 	"""
 	_dimensions:  List[Range]
 	_elementType: Symbol
@@ -498,6 +553,10 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 	      --^^^^         <- Identifiers
 	      --       ^^^   <- Subtype
 	      end record;
+
+	.. seealso::
+
+	   * :class:`Record type <pyVHDLModel.Type.RecordType>`
 	"""
 	_subtype: Symbol
 
@@ -538,6 +597,11 @@ class RecordType(CompositeType):
 	        a, b    : bit;        -- Elements
 	        payload : bit_vector(31 downto 0);
 	      end record;
+
+	.. seealso::
+
+	   * :class:`Record element <pyVHDLModel.Type.RecordTypeElement>`
+	   * :class:`Reference to a record element <pyVHDLModel.Symbol.RecordElementSymbol>`
 	"""
 	_elements: List[RecordTypeElement]
 
@@ -580,6 +644,11 @@ class ProtectedType(FullType):
 	        procedure increment;                   -- Methods
 	        impure function value return natural;
 	      end protected;
+
+	.. seealso::
+
+	   * :class:`Protected type body <pyVHDLModel.Type.ProtectedTypeBody>`
+	   * :class:`Method of a protected type <pyVHDLModel.Subprogram.ProcedureMethod>`
 	"""
 	_methods: List[Union['Procedure', 'Function']]
 
@@ -622,6 +691,10 @@ class ProtectedTypeBody(FullType):
 	          count := count + 1;
 	        end procedure;
 	      end protected body;
+
+	.. seealso::
+
+	   * :class:`Protected type declaration <pyVHDLModel.Type.ProtectedType>`
 	"""
 	_methods: List[Union['Procedure', 'Function']]
 

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -97,15 +97,20 @@ class AnonymousType(Type):
 	"""
 	Represents a base-class for types without a type definition of their own.
 
-	An incomplete type is the typical case: it names a type whose definition follows later in the same
-	declarative part.
+	An incomplete type is the typical case: it names a type (:data:`Identifier`) whose full
+	definition follows later in the same declarative part.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
-	      type ptr;              -- incomplete, completed further down
-	      --   ^^^   <- Identifier
+	      type node;
+	      --   ^^^^                  <- Identifier
+	      type ptr is access node;
+	      type node is record
+	        value    : integer;
+	        nextNode : ptr;
+	      end record;
 	"""
 	pass
 
@@ -146,22 +151,22 @@ class Subtype(BaseType):
 	   .. code-block:: VHDL
 
 	      subtype byte is bit_vector;
-	      --      ^^^^                 <- Identifier
-	      --              ^^^^^^^^^^   <- Type
+	      --      ^^^^                  <- Identifier
+	      --              ^^^^^^^^^^    <- Type
 
 	   With a constraint:
 
 	   .. code-block:: VHDL
 
 	      subtype nibble is bit_vector(3 downto 0);
-	      --                          ^^^^^^^^^^^^   <- Range
+	      --                          ^^^^^^^^^^^^    <- Range
 
 	   With a resolution function:
 
 	   .. code-block:: VHDL
 
 	      subtype wired is resolved std_ulogic;
-	      --               ^^^^^^^^              <- ResolutionFunction
+	      --               ^^^^^^^^               <- ResolutionFunction
 
 	.. seealso::
 
@@ -315,8 +320,8 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 	   .. code-block:: VHDL
 
 	      type state is (Idle, Running, Done);
-	      --   ^^^^^                            <- Identifier
-	      --             ^^^^^^^^^^^^^^^^^^^    <- Literals
+	      --   ^^^^^                             <- Identifier
+	      --             ^^^^^^^^^^^^^^^^^^^     <- Literals
 	"""
 	_literals: List[EnumerationLiteral]
 
@@ -394,18 +399,22 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 
 	A physical type is a named entity (:data:`Identifier`) constrained by a range (:data:`Range`), and
 	defines a primary unit (:data:`PrimaryUnit`) plus any number of secondary units
-	(:data:`SecondaryUnits`).
+	(:data:`SecondaryUnits`). The model holds the secondary units in a list and has no distinct field
+	per unit, so the markers below name list elements.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type distance is range 0 to 1000000 units
-	      --   ^^^^^^^^                              <- Identifier
-	      --                     ^^^^^^^^^^^^        <- Range
-	        um;                                      -- PrimaryUnit
-	        mm = 1000 um;                            -- SecondaryUnits
+	      --   ^^^^^^^^                               <- Identifier
+	      --                     ^^^^^^^^^^^^         <- Range
+	        um;
+	      --^^^                                       <- PrimaryUnit
+	        mm = 1000 um;
+	      --^^^^^^^^^^^^^                             <- SecondaryUnits[0]
 	        m  = 1000 mm;
+	      --^^^^^^^^^^^^^                             <- SecondaryUnits[1]
 	      end units;
 	"""
 	_primaryUnit:    str
@@ -478,16 +487,16 @@ class ArrayType(CompositeType):
 	   .. code-block:: VHDL
 
 	      type memory is array (0 to 255) of bit_vector(7 downto 0);
-	      --   ^^^^^^                                                 <- Identifier
-	      --                    ^^^^^^^^                              <- Dimensions
-	      --                                 ^^^^^^^^^^^^^^^^^^^^^^   <- ElementType
+	      --   ^^^^^^                                                  <- Identifier
+	      --                    ^^^^^^^^                               <- Dimensions
+	      --                                 ^^^^^^^^^^^^^^^^^^^^^^    <- ElementType
 
 	   Two dimensions, both unconstrained:
 
 	   .. code-block:: VHDL
 
 	      type matrix is array (natural range <>, natural range <>) of bit;
-	      --                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      <- Dimensions
+	      --                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^            <- Dimensions
 
 	.. seealso::
 
@@ -550,8 +559,8 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 
 	      type frame is record
 	        a, b : bit;
-	      --^^^^         <- Identifiers
-	      --       ^^^   <- Subtype
+	      --^^^^                 <- Identifiers
+	      --       ^^^           <- Subtype
 	      end record;
 
 	.. seealso::
@@ -586,16 +595,19 @@ class RecordType(CompositeType):
 	Represents a record type definition.
 
 	A record type is a named entity (:data:`Identifier`) holding its element declarations
-	(:data:`Elements`) in declaration order.
+	(:data:`Elements`) in declaration order. The model holds them in a list and has no distinct
+	field per element, so the markers below name list elements.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type frame is record
-	      --   ^^^^^              <- Identifier
-	        a, b    : bit;        -- Elements
+	      --   ^^^^^                             <- Identifier
+	        a, b    : bit;
+	      --^^^^^^^^^^^^^^                       <- Elements[0]
 	        payload : bit_vector(31 downto 0);
+	      --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   <- Elements[1]
 	      end record;
 
 	.. seealso::
@@ -634,15 +646,19 @@ class ProtectedType(FullType):
 
 	A protected type is a named entity (:data:`Identifier`) exposing only its methods
 	(:data:`Methods`). The implementation lives in a separate :class:`ProtectedTypeBody`.
+	The model holds the methods in a list and has no distinct field per method, so the markers
+	below name list elements.
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	      type counter is protected
-	      --   ^^^^^^^                             <- Identifier
-	        procedure increment;                   -- Methods
+	      --   ^^^^^^^                              <- Identifier
+	        procedure increment;
+	      --^^^^^^^^^^^^^^^^^^^^                    <- Methods[0]
 	        impure function value return natural;
+	      --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   <- Methods[1]
 	      end protected;
 
 	.. seealso::
@@ -684,13 +700,20 @@ class ProtectedTypeBody(FullType):
 	   .. code-block:: VHDL
 
 	      type counter is protected body
-	      --   ^^^^^^^                        <- Identifier
+	      --   ^^^^^^^                       <- Identifier
 	        variable count : natural := 0;
-	        procedure increment is            -- Methods
+	        procedure increment is
+	      --^^^^^^^^^^^^^^^^^^^^^^           <- Methods[0]
 	        begin
 	          count := count + 1;
 	        end procedure;
 	      end protected body;
+
+	.. note::
+
+	   A protected type body may also declare non-subprogram items - ``variable count`` above. The
+	   model currently stores every declared item in :data:`Methods`, so such declarations are
+	   conflated with the methods and have no marker of their own.
 
 	.. seealso::
 

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -55,9 +55,9 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 	.. seealso::
 
+	   * :class:`Type <pyVHDLModel.Type.Type>`
 	   * :class:`Full type <pyVHDLModel.Type.FullType>`
 	   * :class:`Subtype <pyVHDLModel.Type.Subtype>`
-	   * :class:`Type <pyVHDLModel.Type.Type>`
 	"""
 
 	_objectVertex: Vertex
@@ -86,8 +86,8 @@ class Type(BaseType):
 
 	.. seealso::
 
-	   * :class:`Anonymous type <pyVHDLModel.Type.AnonymousType>`
 	   * :class:`Generic type interface item <pyVHDLModel.Interface.GenericTypeInterfaceItem>`
+	   * :class:`Anonymous type <pyVHDLModel.Type.AnonymousType>`
 	"""
 	pass
 
@@ -120,12 +120,12 @@ class FullType(BaseType):
 
 	.. seealso::
 
-	   * :class:`Access type <pyVHDLModel.Type.AccessType>`
+	   * :class:`Scalar type <pyVHDLModel.Type.ScalarType>`
 	   * :class:`Composite type <pyVHDLModel.Type.CompositeType>`
-	   * :class:`File type <pyVHDLModel.Type.FileType>`
 	   * :class:`Protected type <pyVHDLModel.Type.ProtectedType>`
 	   * :class:`Protected type body <pyVHDLModel.Type.ProtectedTypeBody>`
-	   * :class:`Scalar type <pyVHDLModel.Type.ScalarType>`
+	   * :class:`Access type <pyVHDLModel.Type.AccessType>`
+	   * :class:`File type <pyVHDLModel.Type.FileType>`
 	"""
 	pass
 
@@ -227,8 +227,8 @@ class ScalarType(FullType):
 
 	.. seealso::
 
-	   * :class:`Enumerated type <pyVHDLModel.Type.EnumeratedType>`
 	   * :class:`Ranged scalar type <pyVHDLModel.Type.RangedScalarType>`
+	   * :class:`Enumerated type <pyVHDLModel.Type.EnumeratedType>`
 	"""
 
 
@@ -243,8 +243,8 @@ class RangedScalarType(ScalarType):
 	.. seealso::
 
 	   * :class:`Integer type <pyVHDLModel.Type.IntegerType>`
-	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
 	   * :class:`Real type <pyVHDLModel.Type.RealType>`
+	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
 	"""
 
 	_range: Range
@@ -279,8 +279,8 @@ class NumericTypeMixin(metaclass=ExtendedType, mixin=True):
 	.. seealso::
 
 	   * :class:`Integer type <pyVHDLModel.Type.IntegerType>`
-	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
 	   * :class:`Real type <pyVHDLModel.Type.RealType>`
+	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
 	"""
 
 	def __init__(self) -> None:

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -47,7 +47,9 @@ from pyVHDLModel.Expression import EnumerationLiteral, PhysicalIntegerLiteral
 
 @export
 class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
-	"""``BaseType`` is the base-class of all type entities in this model."""
+	"""
+	A base-class for all type entities: full types, subtypes and anonymous types.
+	"""
 
 	_objectVertex: Vertex
 
@@ -67,21 +69,57 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 
 @export
 class Type(BaseType):
+	"""
+	A base-class for types that are named by a type declaration.
+
+	Besides real type declarations, this is also the base-class of a generic type interface item, which
+	introduces a type name without defining the type itself.
+	"""
 	pass
 
 
 @export
 class AnonymousType(Type):
+	"""
+	A base-class for types that have no type definition of their own.
+
+	An incomplete type is the typical case: it names a type whose definition appears later.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type ptr;              -- incomplete, completed further down
+	      --   ^^^
+	"""
 	pass
 
 
 @export
 class FullType(BaseType):
+	"""
+	A base-class for all full type definitions, as opposed to a :class:`Subtype`.
+
+	This is the distinction the declaration regions index on: a full type goes into ``Types``, a subtype
+	into ``Subtypes``.
+	"""
 	pass
 
 
 @export
 class Subtype(BaseType):
+	"""
+	A subtype declaration: a type mark, optionally narrowed by a constraint and/or a resolution function.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      subtype byte is bit_vector(7 downto 0);
+	      --      ^^^^                              <- Identifier
+	      --              ^^^^^^^^^^                <- Type (the type mark)
+	      --                        ^^^^^^^^^^^^   <- Range (the constraint)
+	"""
 	_type:               Symbol
 	_baseType:           BaseType
 	_range:              Range
@@ -137,12 +175,19 @@ class Subtype(BaseType):
 
 @export
 class ScalarType(FullType):
-	"""A ``ScalarType`` is a base-class for all scalar types."""
+	"""
+	A base-class for all scalar types: enumerated, integer, real and physical types.
+	"""
 
 
 @export
 class RangedScalarType(ScalarType):
-	"""A ``RangedScalarType`` is a base-class for all scalar types with a range."""
+	"""
+	A base-class for all scalar types constrained by a range: integer, real and physical types.
+
+	An enumerated type is scalar but not ranged, which is why it derives from :class:`ScalarType`
+	directly.
+	"""
 
 	_range: Range
 
@@ -170,7 +215,9 @@ class RangedScalarType(ScalarType):
 
 @export
 class NumericTypeMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``NumericType`` is a mixin class for all numeric types."""
+	"""
+	A mixin-class for all numeric types: integer, real and physical types.
+	"""
 
 	def __init__(self) -> None:
 		pass
@@ -178,7 +225,9 @@ class NumericTypeMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class DiscreteTypeMixin(metaclass=ExtendedType, mixin=True):
-	"""A ``DiscreteType`` is a mixin class for all discrete types."""
+	"""
+	A mixin-class for all discrete types: enumerated and integer types.
+	"""
 
 	def __init__(self) -> None:
 		pass
@@ -186,6 +235,16 @@ class DiscreteTypeMixin(metaclass=ExtendedType, mixin=True):
 
 @export
 class EnumeratedType(ScalarType, DiscreteTypeMixin):
+	"""
+	An enumerated type definition, listing its literals in declaration order.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type state is (Idle, Running, Done);
+	      --             ^^^^^^^^^^^^^^^^^^^   <- Literals
+	"""
 	_literals: List[EnumerationLiteral]
 
 	def __init__(self, identifier: str, literals: Iterable[EnumerationLiteral], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -212,6 +271,16 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 
 @export
 class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
+	"""
+	An integer type definition, constrained by a range.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type nibble is range 0 to 15;
+	      --                   ^^^^^^^   <- Range
+	"""
 	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, documentation, parent)
 
@@ -221,6 +290,16 @@ class IntegerType(RangedScalarType, NumericTypeMixin, DiscreteTypeMixin):
 
 @export
 class RealType(RangedScalarType, NumericTypeMixin):
+	"""
+	A floating-point type definition, constrained by a range.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type fraction is range 0.0 to 1.0;
+	      --                     ^^^^^^^^^^   <- Range
+	"""
 	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, rng, documentation, parent)
 
@@ -230,6 +309,19 @@ class RealType(RangedScalarType, NumericTypeMixin):
 
 @export
 class PhysicalType(RangedScalarType, NumericTypeMixin):
+	"""
+	A physical type definition: a range, a primary unit and any number of secondary units.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type distance is range 0 to 1e9 units
+	        um;                                  -- PrimaryUnit
+	        mm = 1000 um;                        -- SecondaryUnits
+	        m  = 1000 mm;
+	      end units;
+	"""
 	_primaryUnit:    str
 	_secondaryUnits: List[Tuple[str, PhysicalIntegerLiteral]]
 
@@ -275,11 +367,24 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 
 @export
 class CompositeType(FullType):
-	"""A ``CompositeType`` is a base-class for all composite types."""
+	"""
+	A base-class for all composite types: array and record types.
+	"""
 
 
 @export
 class ArrayType(CompositeType):
+	"""
+	An array type definition: one or more index ranges and an element subtype.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type memory is array (0 to 255) of bit_vector(7 downto 0);
+	      --                    ^^^^^^^^                              <- Dimensions
+	      --                                 ^^^^^^^^^^^^^^^^^^^^^^   <- ElementType
+	"""
 	_dimensions:  List[Range]
 	_elementType: Symbol
 
@@ -325,6 +430,22 @@ class ArrayType(CompositeType):
 
 @export
 class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
+	"""
+	One element declaration inside a record type definition.
+
+	A single declaration may name several elements at once, hence ``Identifiers`` rather than one
+	identifier.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type frame is record
+	        a, b : bit;
+	      --^^^^         <- Identifiers
+	      --       ^^^   <- Subtype
+	      end record;
+	"""
 	_subtype: Symbol
 
 	def __init__(self, identifiers: Iterable[str], subtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
@@ -349,6 +470,18 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 
 @export
 class RecordType(CompositeType):
+	"""
+	A record type definition, holding its elements in declaration order.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type frame is record
+	        header : bit_vector(7 downto 0);   -- Elements
+	        payload : bit_vector(31 downto 0);
+	      end record;
+	"""
 	_elements: List[RecordTypeElement]
 
 	def __init__(self, identifier: str, elements: Nullable[Iterable[RecordTypeElement]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -375,6 +508,20 @@ class RecordType(CompositeType):
 
 @export
 class ProtectedType(FullType):
+	"""
+	A protected type declaration, exposing only its methods (VHDL-2002).
+
+	The implementation lives in a separate :class:`ProtectedTypeBody`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type counter is protected
+	        procedure increment;             -- Methods
+	        impure function value return natural;
+	      end protected;
+	"""
 	_methods: List[Union['Procedure', 'Function']]
 
 	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -398,6 +545,21 @@ class ProtectedType(FullType):
 
 @export
 class ProtectedTypeBody(FullType):
+	"""
+	A protected type body, implementing the methods declared by its :class:`ProtectedType`.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type counter is protected body
+	        variable count : natural := 0;
+	        procedure increment is           -- Methods
+	        begin
+	          count := count + 1;
+	        end procedure;
+	      end protected body;
+	"""
 	_methods: List[Union['Procedure', 'Function']]
 
 	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -422,6 +584,16 @@ class ProtectedTypeBody(FullType):
 
 @export
 class AccessType(FullType):
+	"""
+	An access type definition, pointing at values of its designated subtype.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type ptr is access integer;
+	      --                 ^^^^^^^   <- DesignatedSubtype
+	"""
 	_designatedSubtype: Symbol
 
 	def __init__(self, identifier: str, designatedSubtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
@@ -445,6 +617,16 @@ class AccessType(FullType):
 
 @export
 class FileType(FullType):
+	"""
+	A file type definition, holding values of its designated subtype.
+
+	.. admonition:: Example
+
+	   .. code-block:: VHDL
+
+	      type text_file is file of string;
+	      --                        ^^^^^^   <- DesignatedSubtype
+	"""
 	_designatedSubtype: Symbol
 
 	def __init__(self, identifier: str, designatedSubtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -2199,7 +2199,13 @@ class Design(ModelEntity, AllowBlackboxMixin):
 
 @export
 class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
-	"""A ``Library`` represents a VHDL library. It contains all *primary* and *secondary* design units."""
+	"""
+	A ``Library`` represents a VHDL library. It contains all *primary* and *secondary* design units.
+
+	.. seealso::
+
+	   * :class:`Predefined library <pyVHDLModel.Predefined.PredefinedLibrary>`
+	"""
 
 	_allowBlackbox:  Nullable[bool]                      #: Allow blackboxes for components in this library.
 	_contexts:       Dict[str, Context]                  #: Dictionary of all contexts defined in a library.


### PR DESCRIPTION
**All 429 classes now carry a doc-string with descriptive prose**, up from 245. **205 of them show the VHDL construct they abstract.** `interrogate` passes for the first time: **34.8% at the start of this work → 70.1%**, against a `fail-under` of 59.

## Conventions applied

- **Describes the class, not the initializer.** Constructor parameters stay on `__init__`.
- **`Represents a ...` summary**, then a paragraph describing the class through its properties, cross-referenced with `:data:`.
- **A VHDL example** in an `.. admonition:: Example`, underlining the part each property maps to.
- **Example variants** where a construct genuinely has different shapes — `Subtype` (no constraint / constraint / resolution function), `ArrayType` (one dimension / two unconstrained), `IfStatement` (bare `if` / with `elsif` and `else`).
- **Revisions**: pre-2019 no longer named — VHDL-2008 is the minimum supported and 87/93/2000/2002 are history. 17 such mentions removed. VHDL-2019 is still called out (mode views).

```
Represents a subtype declaration.

A subtype is a named entity (:data:`Identifier`, :data:`NormalizedIdentifier`) referencing a type
(:data:`Type`). Optionally, the subtype can be narrowed by a constraint (:data:`Range`) and/or
resolved by a resolution function (:data:`ResolutionFunction`).

.. admonition:: Example

   Without a constraint:

   .. code-block:: VHDL

      subtype byte is bit_vector;
      --      ^^^^                 <- Identifier
      --              ^^^^^^^^^^   <- Type
   ...
```

Classes that abstract no single construct — abstract bases, mixins, exceptions, the `BitStringBase` enum, the PSL classes — get prose describing their role instead of an example.

## Every snippet was verified with GHDL

Each example was analysed with `ghdl -a` before being written into a doc-string. That rejected **seven invalid drafts**: an access type as a signal, `o"240"` being nine bits not eight, a `wait` in a sensitized process, a shared variable of a non-protected type, `library work` inside a context declaration, a file type used before declaration, and a two-run label ambiguity.

## Underlines are computed, not typed

A generator derives caret columns and arrow alignment from the code line. Two bugs in it were caught by a checker rather than by reading — a target starting in the first columns collided with the `--` marker and produced negative padding, and targets on later lines of a multi-line snippet weren't found.

**The same checker found three misaligned underlines in *pre-existing* hand-written examples** (`ConditionalWaveform`, `ConditionalExpression`, `SelectedWaveform` in `Common.py`) — the ones this style was modelled on:

```
s <= '1' when cond else '0';
--   ^^^^^^^^^^^^         <- ...
```

The first run stopped one character short (`'1' when con`) and the second pointed at `' el'` — whitespace between tokens — rather than the final `'0'`. Regenerated, so every underline in the package now sits on real code.

## Verification

- 429/429 classes documented; 0 caret or arrow misalignments
- 0 structural RST problems (with Sphinx's `seealso`/`todo`/`pycode`/`|br|` registered — the ones bare docutils rejects are all pre-existing Sphinx constructs)
- 0 doc-string lines over 120 characters among those added
- 428 tests pass; pyGHDL.dom cross-checked at **185 passed, 0 failed**
- Verified from a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)