### PR TITLE
Document every class field with a `#:` comment

### DIFF
--- a/pyVHDLModel/Association.py
+++ b/pyVHDLModel/Association.py
@@ -65,8 +65,8 @@ class AssociationItem(ModelEntity):
 	   * :class:`Parameter association item <pyVHDLModel.Association.ParameterAssociationItem>`
 	"""
 
-	_formal: Nullable[Symbol]
-	_actual: ExpressionUnion
+	_formal: Nullable[Symbol]  #: Reference to the formal part, or ``None`` for a positional association.
+	_actual: ExpressionUnion   #: The actual part of this association.
 
 	def __init__(self, formal: Nullable[Symbol], actual: ExpressionUnion) -> None:
 		super().__init__()

--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -451,7 +451,7 @@ class ConditionalMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Wait statement <pyVHDLModel.Sequential.WaitStatement>`
 	"""
 
-	_condition: ExpressionUnion
+	_condition: ExpressionUnion  #: The condition guarding this statement.
 
 	def __init__(self, condition: Nullable[ExpressionUnion] = None) -> None:
 		"""
@@ -552,8 +552,8 @@ class ReportStatementMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Sequential report statement <pyVHDLModel.Sequential.SequentialReportStatement>`
 	"""
 
-	_message:  Nullable[ExpressionUnion]
-	_severity: Nullable[ExpressionUnion]
+	_message:  Nullable[ExpressionUnion]  #: The reported message, or ``None`` if none was given.
+	_severity: Nullable[ExpressionUnion]  #: The reported severity level, or ``None`` if none was given.
 
 	def __init__(self, message: Nullable[ExpressionUnion] = None, severity: Nullable[ExpressionUnion] = None) -> None:
 		self._message = message
@@ -653,7 +653,7 @@ class ChoicesMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
 	"""
 
-	_choices: List[BaseChoice]
+	_choices: List[BaseChoice]  #: List of all choices selecting this alternative.
 
 	def __init__(self, choices: Nullable[Iterable[BaseChoice]] = None) -> None:
 		self._choices = []
@@ -693,9 +693,9 @@ class SimpleRange(Range):
 	A range with both bounds given as expressions, e.g. ``0 to 7``.
 	"""
 
-	_leftBound:  ExpressionUnion
-	_rightBound: ExpressionUnion
-	_direction:  Direction
+	_leftBound:  ExpressionUnion  #: The range's left bound.
+	_rightBound: ExpressionUnion  #: The range's right bound.
+	_direction:  Direction        #: The range's direction, either ascending (``to``) or descending (``downto``).
 
 	def __init__(self, leftBound: ExpressionUnion, rightBound: ExpressionUnion, direction: Direction, parent: Nullable[ModelEntity] = None) -> None:
 		"""
@@ -768,7 +768,7 @@ class RangeFromName(Range):
 	   range``), so representing both as a range deviates from the rule split deliberately.
 	"""
 
-	_symbol: 'Symbol'
+	_symbol: 'Symbol'  #: Reference to the name the range's bounds are inferred from.
 
 	def __init__(self, symbol: 'Symbol', parent: Nullable[ModelEntity] = None) -> None:
 		"""
@@ -816,8 +816,8 @@ class WaveformElement(ModelEntity):
 	   * :class:`Waveform of one conditional branch <pyVHDLModel.Common.ConditionalWaveform>`
 	   * :class:`Waveform of one selected alternative <pyVHDLModel.Common.SelectedWaveform>`
 	"""
-	_expression: ExpressionUnion
-	_after: ExpressionUnion
+	_expression: ExpressionUnion  #: The value this waveform element assigns.
+	_after: ExpressionUnion       #: The delay after which the value is assigned, or ``None`` if none was given.
 
 	def __init__(self, expression: ExpressionUnion, after: Nullable[ExpressionUnion] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)

--- a/pyVHDLModel/Common.py
+++ b/pyVHDLModel/Common.py
@@ -137,8 +137,9 @@ class ProcedureCallMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Concurrent procedure call <pyVHDLModel.Concurrent.ConcurrentProcedureCall>`
 	   * :class:`Sequential procedure call <pyVHDLModel.Sequential.SequentialProcedureCall>`
 	"""
-	_procedure:                 Symbol  # TODO: implement a ProcedureSymbol
-	_parameterAssociationItems: List[ParameterAssociationItem]
+	# TODO: implement a ProcedureSymbol
+	_procedure:                 Symbol  #: Reference to the called procedure.
+	_parameterAssociationItems: List[ParameterAssociationItem]  #: List of all parameter associations of the call.
 
 	def __init__(self, procedureName: Symbol, parameterAssociationItems: Nullable[Iterable[ParameterAssociationItem]] = None) -> None:
 		self._procedure = procedureName
@@ -183,7 +184,7 @@ class AssignmentMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
 	"""
 
-	_target: Symbol
+	_target: Symbol  #: Reference to the assignment's destination.
 
 	def __init__(self, target: Symbol) -> None:
 		self._target = target
@@ -235,7 +236,7 @@ class VariableAssignmentMixin(AssignmentMixin, mixin=True):
 	"""
 
 	# FIXME: move to sequential?
-	_expression: ExpressionUnion
+	_expression: ExpressionUnion  #: The assigned expression.
 
 	def __init__(self, target: VariableSymbol, expression: ExpressionUnion) -> None:
 		super().__init__(target)
@@ -277,7 +278,7 @@ class WaveformMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Waveform element <pyVHDLModel.Base.WaveformElement>`
 	"""
 
-	_waveform: List[WaveformElement]
+	_waveform: List[WaveformElement]  #: List of all waveform elements, in the order they were written.
 
 	def __init__(self, waveform: Iterable[WaveformElement]) -> None:
 		self._waveform = []
@@ -311,7 +312,7 @@ class ExpressionMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Signal force assignment <pyVHDLModel.Sequential.SignalForceAssignment>`
 	"""
 
-	_expression: ExpressionUnion
+	_expression: ExpressionUnion  #: The expression held by this construct.
 
 	def __init__(self, expression: ExpressionUnion) -> None:
 		self._expression = expression
@@ -403,7 +404,7 @@ class ConditionalWaveformsMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Conditional signal assignment <pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment>`
 	   * :class:`Conditional signal assignment <pyVHDLModel.Sequential.SequentialConditionalSignalAssignment>`	"""
 
-	_conditionalWaveforms: List[ConditionalWaveform]
+	_conditionalWaveforms: List[ConditionalWaveform]  #: All alternatives, in order.
 
 	def __init__(self, conditionalWaveforms: Iterable[ConditionalWaveform]) -> None:
 		self._conditionalWaveforms = []
@@ -537,7 +538,7 @@ class SelectedWaveformsMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Sequential selected signal assignment <pyVHDLModel.Sequential.SequentialSelectedSignalAssignment>`
 	"""
 
-	_selectedWaveforms: List[Union[SelectedWaveform, OthersSelectedWaveform]]
+	_selectedWaveforms: List[Union[SelectedWaveform, OthersSelectedWaveform]]  #: All alternatives, in order.
 
 	def __init__(self, selectedWaveforms: Iterable[Union[SelectedWaveform, OthersSelectedWaveform]]) -> None:
 		self._selectedWaveforms = []
@@ -566,7 +567,7 @@ class SelectedExpressionsMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Sequential selected variable assignment <pyVHDLModel.Sequential.SequentialSelectedVariableAssignment>`
 	"""
 
-	_selectedExpressions: List[Union[SelectedExpression, OthersSelectedExpression]]
+	_selectedExpressions: List[Union[SelectedExpression, OthersSelectedExpression]]  #: All alternatives, in order.
 
 	def __init__(self, selectedExpressions: Iterable[Union[SelectedExpression, OthersSelectedExpression]]) -> None:
 		self._selectedExpressions = []

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -100,9 +100,10 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 	   .. todo:: concurrent declaration region
 	"""
 
-	_statements:     List[ConcurrentStatement]
+	_statements:     List[ConcurrentStatement]  #: List of all concurrent statements in this construct.
 
-	_instantiations: Dict[str, 'Instantiation']  # TODO: add another instantiation class level for entity/configuration/component inst.
+	# TODO: add another instantiation class level for entity/configuration/component inst.
+	_instantiations: Dict[str, 'Instantiation']  #: All instantiations, indexed by label.
 	_hierarchy:      Dict[str, Union['ConcurrentBlockStatement', 'GenerateStatement']]  #: All elements creating a hierarchy level (blocks and generates), in declaration order.
 
 	def __init__(self, statements: Nullable[Iterable[ConcurrentStatement]] = None) -> None:
@@ -157,8 +158,8 @@ class Instantiation(ConcurrentStatement):
 	   * :class:`Configuration instantiation <pyVHDLModel.Concurrent.ConfigurationInstantiation>`
 	"""
 
-	_genericAssociationItems: List[AssociationItem]
-	_portAssociationItems:    List[AssociationItem]
+	_genericAssociationItems: List[AssociationItem]  #: List of all generic associations in the generic map aspect.
+	_portAssociationItems:    List[AssociationItem]  #: List of all port associations in the port map aspect.
 
 	def __init__(
 		self,
@@ -219,7 +220,7 @@ class ComponentInstantiation(Instantiation):
 	      --                 ^^^^^^^    <- Component
 	"""
 
-	_component: ComponentInstantiationSymbol
+	_component: ComponentInstantiationSymbol  #: Reference to the instantiated component.
 
 	def __init__(
 		self,
@@ -262,8 +263,8 @@ class EntityInstantiation(Instantiation):
 	      --                           ^^^     <- optional Architecture
 	"""
 
-	_entity: EntityInstantiationSymbol
-	_architecture: ArchitectureSymbol
+	_entity: EntityInstantiationSymbol  #: Reference to the directly instantiated entity.
+	_architecture: ArchitectureSymbol   #: Reference to the selected architecture, if one was given.
 
 	def __init__(
 		self,
@@ -318,7 +319,7 @@ class ConfigurationInstantiation(Instantiation):
 	      --                     ^^^^^^^    <- Configuration
 	"""
 
-	_configuration: ConfigurationInstantiationSymbol
+	_configuration: ConfigurationInstantiationSymbol  #: Reference to the instantiated configuration.
 
 	def __init__(
 		self,
@@ -366,7 +367,8 @@ class ProcessStatement(ConcurrentStatement, SequentialDeclarationRegionMixin, Se
 	        end process;
 	"""
 
-	_sensitivityList: List[Name]  # TODO: implement a SignalSymbol
+	# TODO: implement a SignalSymbol
+	_sensitivityList: List[Name]  #: List of all signal names in the sensitivity list, or ``None`` if none was given.
 
 	def __init__(
 		self,
@@ -472,7 +474,7 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 
 	   * :class:`Generate statement <pyVHDLModel.Concurrent.GenerateStatement>`
 	"""
-	_namespace: Namespace
+	_namespace: Namespace  #: The namespace of this block's declarative region.
 
 	def __init__(
 		self,
@@ -524,10 +526,10 @@ class GenerateBranch(ModelEntity, ConcurrentDeclarationRegionMixin, ConcurrentSt
 	   * :class:`Else generate branch <pyVHDLModel.Concurrent.ElseGenerateBranch>`
 	"""
 
-	_alternativeLabel:           Nullable[str]
-	_normalizedAlternativeLabel: Nullable[str]
+	_alternativeLabel:           Nullable[str]  #: The branch's alternative label, if one was given.
+	_normalizedAlternativeLabel: Nullable[str]  #: The normalized (lower case) alternative label.
 
-	_namespace:                  Namespace
+	_namespace:                  Namespace      #: The namespace of this branch's declarative region.
 
 	def __init__(
 		self,
@@ -734,9 +736,9 @@ class IfGenerateStatement(GenerateStatement):
 	   * :class:`For-generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	"""
 
-	_ifBranch:      IfGenerateBranch
-	_elsifBranches: List[ElsifGenerateBranch]
-	_elseBranch:    Nullable[ElseGenerateBranch]
+	_ifBranch:      IfGenerateBranch              #: The mandatory ``if`` branch.
+	_elsifBranches: List[ElsifGenerateBranch]     #: List of all ``elsif`` branches, in the order they were written.
+	_elseBranch:    Nullable[ElseGenerateBranch]  #: The optional ``else`` branch, or ``None`` if none was given.
 
 	def __init__(
 		self,
@@ -850,7 +852,7 @@ class IndexedGenerateChoice(ConcurrentChoice):
 	      when 8 =>
 	      --   ^      <- Expression
 	"""
-	_expression: ExpressionUnion
+	_expression: ExpressionUnion  #: The expression this choice selects on.
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -885,7 +887,7 @@ class RangedGenerateChoice(ConcurrentChoice):
 	      when 0 to 3 =>
 	      --   ^^^^^^      <- Range
 	"""
-	_range: 'Range'
+	_range: 'Range'  #: The range this choice selects on.
 
 	def __init__(self, rng: 'Range', parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -916,7 +918,7 @@ class ConcurrentCase(BaseCase, LabeledEntityMixin, ConcurrentDeclarationRegionMi
 	   * :class:`Generate case <pyVHDLModel.Concurrent.GenerateCase>`
 	   * :class:`Others generate case <pyVHDLModel.Concurrent.OthersGenerateCase>`
 	"""
-	_namespace: Namespace
+	_namespace: Namespace  #: The namespace of this alternative's declarative region.
 
 	def __init__(
 		self,
@@ -1015,8 +1017,8 @@ class CaseGenerateStatement(GenerateStatement):
 	   * :class:`For-generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	"""
 
-	_expression: ExpressionUnion
-	_cases:      List[GenerateCase]
+	_expression: ExpressionUnion     #: The expression being tested; it must be static.
+	_cases:      List[GenerateCase]  #: List of all alternatives, in the order they were written.
 
 	def __init__(
 		self,
@@ -1099,10 +1101,10 @@ class ForGenerateStatement(GenerateStatement, ConcurrentDeclarationRegionMixin, 
 	   * :class:`Case-generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
 	"""
 
-	_loopIndex: str
-	_range:     Range
+	_loopIndex: str        #: The name of the generate loop's index.
+	_range:     Range      #: The range the generate loop iterates over.
 
-	_namespace: Namespace
+	_namespace: Namespace  #: The namespace of the generate loop's declarative region.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -81,8 +81,8 @@ class EntityAspectEntity(EntityAspect):
 	      --                     ^^^     <- Architecture
 	"""
 
-	_entity:       EntitySymbol
-	_architecture: Nullable[ArchitectureSymbol]
+	_entity:       EntitySymbol                  #: Reference to the named entity.
+	_architecture: Nullable[ArchitectureSymbol]  #: Reference to the selected architecture, or ``None`` if none was given.
 
 	def __init__(
 		self,
@@ -131,7 +131,7 @@ class EntityAspectConfiguration(EntityAspect):
 	      --                ^^^^^^^^    <- Configuration
 	"""
 
-	_configuration: ConfigurationSymbol
+	_configuration: ConfigurationSymbol  #: Reference to the named configuration.
 
 	def __init__(self, configuration: ConfigurationSymbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -172,9 +172,9 @@ class BindingIndication(ModelEntity):
 	(:data:`GenericAssociations`, :data:`PortAssociations`).
 	"""
 
-	_entityAspect:            Nullable[EntityAspect]
-	_genericAssociationItems: List[GenericAssociationItem]
-	_portAssociationItems:    List[PortAssociationItem]
+	_entityAspect:            Nullable[EntityAspect]        #: The bound design entity, or ``None`` if not given.
+	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations in the generic map aspect.
+	_portAssociationItems:    List[PortAssociationItem]     #: List of all port associations in the port map aspect.
 
 	def __init__(
 		self,
@@ -276,9 +276,9 @@ class ComponentConfiguration(ModelEntity):
 	      --  Instantiation list
 	"""
 
-	_instantiationList:  InstantiationListUnion
-	_componentName:      ComponentInstantiationSymbol
-	_bindingIndication:   Nullable[BindingIndication]
+	_instantiationList:  InstantiationListUnion        #: The instances this configuration applies to.
+	_componentName:      ComponentInstantiationSymbol  #: Reference to the component being configured.
+	_bindingIndication:   Nullable[BindingIndication]  #: The binding indication, or ``None`` if none was given.
 
 	def __init__(
 		self,
@@ -348,8 +348,8 @@ class BlockConfiguration(ModelEntity):
 	      end for;
 	"""
 
-	_blockSpecification: Symbol
-	_items:               List[Union["BlockConfiguration", ComponentConfiguration]]
+	_blockSpecification: Symbol                                                      #: The configured block.
+	_items:               List[Union["BlockConfiguration", ComponentConfiguration]]  #: Nested configurations.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Declaration.py
+++ b/pyVHDLModel/Declaration.py
@@ -96,7 +96,7 @@ class Attribute(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	      attribute TotalBits : natural;
 	"""
 
-	_subtype: Symbol
+	_subtype: Symbol  #: Reference to the attribute's subtype.
 
 	def __init__(
 		self,
@@ -134,10 +134,10 @@ class AttributeSpecification(ModelEntity, DocumentedEntityMixin):
 	      attribute TotalBits of BusType : subtype is 32;
 	"""
 
-	_identifiers: List[Name]
-	_attribute: Name
-	_entityClass: EntityClass
-	_expression: ExpressionUnion
+	_identifiers: List[Name]      #: List of all names the attribute is specified for.
+	_attribute: Name              #: Reference to the specified attribute.
+	_entityClass: EntityClass     #: The entity class the named items belong to.
+	_expression: ExpressionUnion  #: The value assigned to the attribute.
 
 	def __init__(
 		self,
@@ -230,8 +230,8 @@ class Alias(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	      --          Name
 	"""
 
-	_name:    Symbol
-	_subtype: Nullable[SubtypeSymbol]
+	_name:    Symbol                   #: Reference to the name being aliased.
+	_subtype: Nullable[SubtypeSymbol]  #: Reference to the alias' subtype, or ``None`` if none was given.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -64,7 +64,7 @@ class Reference(ModelEntity):
 	   * :class:`Context reference <pyVHDLModel.DesignUnit.ContextReference>`
 	"""
 
-	_symbols:       List[Symbol]
+	_symbols:       List[Symbol]  #: List of all symbols referenced by this clause.
 
 	def __init__(self, symbols: Iterable[Symbol], parent: Nullable[ModelEntity] = None) -> None:
 		"""
@@ -194,7 +194,7 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	_dependencyVertex:    Vertex[None, None, str, 'DesignUnit', None, None, None, None, None, None, None, None, None, None, None, None, None]  #: Reference to the vertex in the dependency graph representing the design unit. |br| This reference is set by :meth:`~pyVHDLModel.Design.CreateDependencyGraph`.
 	_hierarchyVertex:     Vertex[None, None, str, 'DesignUnit', None, None, None, None, None, None, None, None, None, None, None, None, None]  #: The vertex in the hierarchy graph
 
-	_namespace:           'Namespace'
+	_namespace:           'Namespace'  #: The namespace of this design unit's declarative region.
 
 	def __init__(self, identifier: str, contextItems: Nullable[Iterable[ContextUnion]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
@@ -411,7 +411,7 @@ class Context(PrimaryUnit):
 	   * :class:`Use clause <pyVHDLModel.DesignUnit.UseClause>`
 	"""
 
-	_references:        List[ContextUnion]
+	_references:        List[ContextUnion]  #: All context items, in declaration order.
 
 	def __init__(self, identifier: str, references: Nullable[Iterable[ContextUnion]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, None, documentation, parent)
@@ -488,10 +488,10 @@ class Package(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, Concur
 	   * :class:`Package body implementing it <pyVHDLModel.DesignUnit.PackageBody>`
 	"""
 
-	_packageBody:       Nullable["PackageBody"]
+	_packageBody:       Nullable["PackageBody"]      #: The corresponding package body, or ``None`` if none was analyzed.
 
-	_deferredConstants: Dict[str, DeferredConstant]
-	_components:        Dict[str, 'Component']
+	_deferredConstants: Dict[str, DeferredConstant]  #: Deferred constants, indexed by name.
+	_components:        Dict[str, 'Component']       #: Components, indexed by name.
 
 	def __init__(
 		self,
@@ -607,7 +607,7 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarati
 	   * :class:`Package it implements <pyVHDLModel.DesignUnit.Package>`
 	"""
 
-	_package:       PackageSymbol
+	_package:       PackageSymbol  #: Reference to the package this body implements.
 
 	def __init__(
 		self,
@@ -676,7 +676,7 @@ class Entity(PrimaryUnit, DesignUnitWithContextMixin, WithGenericsMixin, WithPor
 	   * :class:`Configuration binding it <pyVHDLModel.DesignUnit.Configuration>`
 	"""
 
-	_architectures: Dict[str, 'Architecture']
+	_architectures: Dict[str, 'Architecture']  #: Dictionary of all architectures of this entity, indexed by name.
 
 	def __init__(
 		self,
@@ -750,7 +750,7 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarat
 	   * :class:`Entity it implements <pyVHDLModel.DesignUnit.Entity>`
 	"""
 
-	_entity:        EntitySymbol
+	_entity:        EntitySymbol  #: Reference to the entity this architecture implements.
 
 	def __init__(
 		self,
@@ -815,10 +815,10 @@ class Component(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, AllowBlack
 
 	_isBlackBox:        Nullable[bool]                    #: Component is a blackbox.
 
-	_genericItems:      List[GenericInterfaceItemMixin]
-	_portItems:         List[PortInterfaceItemMixin]
+	_genericItems:      List[GenericInterfaceItemMixin]  #: List of all generics of this component, in declaration order.
+	_portItems:         List[PortInterfaceItemMixin]     #: List of all ports of this component, in declaration order.
 
-	_entity:            Nullable[Entity]
+	_entity:            Nullable[Entity]                 #: Linked entity, or ``None`` if unresolved.
 
 	def __init__(
 		self,
@@ -926,8 +926,8 @@ class Configuration(PrimaryUnit, DesignUnitWithContextMixin):
 	   * :class:`Block configuration <pyVHDLModel.Configuration.BlockConfiguration>`
 	"""
 
-	_entity:            EntitySymbol
-	_blockConfiguration: BlockConfiguration
+	_entity:            EntitySymbol         #: Reference to the entity this configuration configures.
+	_blockConfiguration: BlockConfiguration  #: The configuration of the entity's architecture.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Exception.py
+++ b/pyVHDLModel/Exception.py
@@ -109,7 +109,7 @@ class LibraryExistsInDesignError(VHDLModelException):
 	Message: :pycode:`f"Library '{library._identifier}' already exists in design."`
 	"""
 
-	_library: 'Library'
+	_library: 'Library'  #: The library involved in this error.
 
 	def __init__(self, library: 'Library') -> None:
 		"""
@@ -138,7 +138,7 @@ class LibraryRegisteredToForeignDesignError(VHDLModelException):
 	Message: :pycode:`f"Library '{library._identifier}' already registered in design '{library.Parent}'."`
 	"""
 
-	_library: 'Library'
+	_library: 'Library'  #: The library involved in this error.
 
 	def __init__(self, library: 'Library') -> None:
 		"""
@@ -167,7 +167,7 @@ class LibraryNotRegisteredError(VHDLModelException):
 	Message: :pycode:`f"Library '{library._identifier}' is not registered in the design."`
 	"""
 
-	_library: 'Library'
+	_library: 'Library'  #: The library involved in this error.
 
 	def __init__(self, library: 'Library') -> None:
 		"""
@@ -196,8 +196,8 @@ class EntityExistsInLibraryError(VHDLModelException):
 	Message: :pycode:`f"Entity '{entity._identifier}' already exists in library '{library._identifier}'."`
 	"""
 
-	_library: 'Library'
-	_entity: 'Entity'
+	_library: 'Library'  #: The library involved in this error.
+	_entity: 'Entity'    #: The entity involved in this error.
 
 	def __init__(self, entity: 'Entity', library: 'Library') -> None:
 		"""
@@ -237,9 +237,9 @@ class ArchitectureExistsInLibraryError(VHDLModelException):
 	Message: :pycode:`f"Architecture '{architecture._identifier}' for entity '{entity._identifier}' already exists in library '{library._identifier}'."`
 	"""
 
-	_library: 'Library'
-	_entity: 'Entity'
-	_architecture: 'Architecture'
+	_library: 'Library'            #: The library involved in this error.
+	_entity: 'Entity'              #: The entity involved in this error.
+	_architecture: 'Architecture'  #: The architecture involved in this error.
 
 	def __init__(self, architecture: 'Architecture', entity: 'Entity', library: 'Library') -> None:
 		"""
@@ -290,8 +290,8 @@ class PackageExistsInLibraryError(VHDLModelException):
 	Message: :pycode:`f"Package '{package._identifier}' already exists in library '{library._identifier}'."`
 	"""
 
-	_library: 'Library'
-	_package: 'Package'
+	_library: 'Library'  #: The library involved in this error.
+	_package: 'Package'  #: The package involved in this error.
 
 	def __init__(self, package: 'Package', library: 'Library') -> None:
 		"""
@@ -331,8 +331,8 @@ class PackageBodyExistsError(VHDLModelException):
 	Message: :pycode:`f"Package body '{packageBody._identifier}' already exists in library '{library._identifier}'."`
 	"""
 
-	_library: 'Library'
-	_packageBody: 'PackageBody'
+	_library: 'Library'          #: The library involved in this error.
+	_packageBody: 'PackageBody'  #: The package body involved in this error.
 
 	def __init__(self, packageBody: 'PackageBody', library: 'Library') -> None:
 		"""
@@ -372,8 +372,8 @@ class ConfigurationExistsInLibraryError(VHDLModelException):
 	Message: :pycode:`f"Configuration '{configuration._identifier}' already exists in library '{library._identifier}'."`
 	"""
 
-	_library: 'Library'
-	_configuration: 'Configuration'
+	_library: 'Library'              #: The library involved in this error.
+	_configuration: 'Configuration'  #: The configuration involved in this error.
 
 	def __init__(self, configuration: 'Configuration', library: 'Library') -> None:
 		"""
@@ -413,8 +413,8 @@ class ContextExistsInLibraryError(VHDLModelException):
 	Message: :pycode:`f"Context '{context._identifier}' already exists in library '{library._identifier}'."`
 	"""
 
-	_library: 'Library'
-	_context: 'Context'
+	_library: 'Library'  #: The library involved in this error.
+	_context: 'Context'  #: The context involved in this error.
 
 	def __init__(self, context: 'Context', library: 'Library') -> None:
 		"""
@@ -454,8 +454,8 @@ class ReferencedLibraryNotExistingError(VHDLModelException):
 	Message: :pycode:`f"Library '{librarySymbol.Name._identifier}' referenced by library clause of context '{context._identifier}' doesn't exist in design."`
 	"""
 
-	_librarySymbol: Symbol
-	_context: 'Context'
+	_librarySymbol: Symbol  #: The library symbol that could not be resolved.
+	_context: 'Context'     #: The context involved in this error.
 
 	def __init__(self, context: 'Context', librarySymbol: Symbol) -> None:
 		"""

--- a/pyVHDLModel/Expression.py
+++ b/pyVHDLModel/Expression.py
@@ -121,7 +121,7 @@ class EnumerationLiteral(Literal):
 	      st <= Idle;
 	      --    ^^^^    <- Value
 	"""
-	_value: str
+	_value: str  #: The enumeration literal's name.
 
 	def __init__(self, value: str, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -170,7 +170,7 @@ class IntegerLiteral(NumericLiteral):
 	      res := a + 42;
 	      --         ^^    <- Value
 	"""
-	_value: int
+	_value: int  #: The literal's integer value.
 
 	def __init__(self, value: int) -> None:
 		super().__init__()
@@ -203,7 +203,7 @@ class FloatingPointLiteral(NumericLiteral):
 	      r <= 3.14;
 	      --   ^^^^    <- Value
 	"""
-	_value: float
+	_value: float  #: The literal's floating-point value.
 
 	def __init__(self, value: float) -> None:
 		super().__init__()
@@ -242,7 +242,7 @@ class PhysicalLiteral(NumericLiteral):
 	   * :class:`Physical integer literal <pyVHDLModel.Expression.PhysicalIntegerLiteral>`
 	   * :class:`Physical floating literal <pyVHDLModel.Expression.PhysicalFloatingLiteral>`
 	"""
-	_unitName: str
+	_unitName: str  #: The name of the physical unit the value is given in.
 
 	def __init__(self, unitName: str) -> None:
 		super().__init__()
@@ -276,7 +276,7 @@ class PhysicalIntegerLiteral(PhysicalLiteral):
 	      --   ^^       <- Value
 	      --      ^^    <- UnitName
 	"""
-	_value: int
+	_value: int  #: The literal's integer value, in units of :attr:`_unitName`.
 
 	def __init__(self, value: int, unitName: str) -> None:
 		super().__init__(unitName)
@@ -307,7 +307,7 @@ class PhysicalFloatingLiteral(PhysicalLiteral):
 	      --   ^^^       <- Value
 	      --       ^^    <- UnitName
 	"""
-	_value: float
+	_value: float  #: The literal's floating-point value, in units of :attr:`_unitName`.
 
 	def __init__(self, value: float, unitName: str) -> None:
 		super().__init__(unitName)
@@ -337,7 +337,7 @@ class CharacterLiteral(Literal):
 	      ch <= 'a';
 	      --    ^^^    <- Value
 	"""
-	_value: str
+	_value: str  #: The literal's character value.
 
 	def __init__(self, value: str) -> None:
 		super().__init__()
@@ -370,7 +370,7 @@ class StringLiteral(Literal):
 	      txt <= "text";
 	      --     ^^^^^^    <- Value
 	"""
-	_value: str
+	_value: str  #: The literal's string value, without the enclosing double quotes.
 
 	def __init__(self, value: str) -> None:
 		super().__init__()
@@ -427,11 +427,11 @@ class BitStringLiteral(Literal):
 	   * :class:`Decimal bit string literal <pyVHDLModel.Expression.DecimalBitStringLiteral>`
 	   * :class:`Hexadecimal bit string literal <pyVHDLModel.Expression.HexadecimalBitStringLiteral>`
 	"""
-	_value:       str
-	_binaryValue: str
-	_bits:        int
-	_length:      Nullable[int]
-	_signed:      Nullable[bool]
+	_value:       str             #: The literal as written in the source, without the enclosing double quotes.
+	_binaryValue: str             #: The literal's value expanded to base 2, one character per bit.
+	_bits:        int             #: The number of bits the literal represents.
+	_length:      Nullable[int]   #: The explicitly given length, or ``None`` if the literal has no length specification.
+	_signed:      Nullable[bool]  #: ``True`` if signed, ``False`` if unsigned, ``None`` if unspecified.
 
 	def __init__(self, value: str, length: Nullable[int] = None, signed: Nullable[bool] = None) -> None:
 		super().__init__()
@@ -515,7 +515,7 @@ class BinaryBitStringLiteral(BitStringLiteral):
 	      res := b"10100000";
 	      --     ^^^^^^^^^^^    <- Value
 	"""
-	_base: ClassVar[BitStringBase] = BitStringBase.Binary
+	_base: ClassVar[BitStringBase] = BitStringBase.Binary  #: The base this literal is written in.
 
 
 @export
@@ -532,7 +532,7 @@ class OctalBitStringLiteral(BitStringLiteral):
 	      nine := o"240";
 	      --      ^^^^^^    <- Value
 	"""
-	_base: ClassVar[BitStringBase] = BitStringBase.Octal
+	_base: ClassVar[BitStringBase] = BitStringBase.Octal  #: The base this literal is written in.
 
 
 @export
@@ -547,7 +547,7 @@ class DecimalBitStringLiteral(BitStringLiteral):
 	      res := d"160";
 	      --     ^^^^^^    <- Value
 	"""
-	_base: ClassVar[BitStringBase] = BitStringBase.Decimal
+	_base: ClassVar[BitStringBase] = BitStringBase.Decimal  #: The base this literal is written in.
 
 
 @export
@@ -564,7 +564,7 @@ class HexadecimalBitStringLiteral(BitStringLiteral):
 	      res := x"A0";
 	      --     ^^^^^    <- Value
 	"""
-	_base: ClassVar[BitStringBase] = BitStringBase.Hexadecimal
+	_base: ClassVar[BitStringBase] = BitStringBase.Hexadecimal  #: The base this literal is written in.
 
 
 @export
@@ -599,8 +599,8 @@ class UnaryExpression(BaseExpression):
 	The operand is available as :data:`Operand`.
 	"""
 
-	_FORMAT:  Tuple[str, str]
-	_operand: ExpressionUnion
+	_FORMAT:  Tuple[str, str]  #: The operator's string representation as (prefix, suffix) around the operand.
+	_operand: ExpressionUnion  #: The expression the operator is applied to.
 
 	def __init__(self, operand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -825,7 +825,7 @@ class TypeConversion(UnaryExpression):
 	      --             ^^^     <- Operand
 	"""
 
-	_targetSubtype: SubtypeSymbol
+	_targetSubtype: SubtypeSymbol  #: Reference to the subtype the expression is converted to.
 
 	def __init__(self, targetSubtype: SubtypeSymbol, operand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(operand, parent)
@@ -881,9 +881,9 @@ class BinaryExpression(BaseExpression):
 	   * :class:`Shift expression <pyVHDLModel.Expression.ShiftExpression>`
 	"""
 
-	_FORMAT: Tuple[str, str, str]
-	_leftOperand:  ExpressionUnion
-	_rightOperand: ExpressionUnion
+	_FORMAT: Tuple[str, str, str]   #: The operator's string representation as (prefix, infix, suffix).
+	_leftOperand:  ExpressionUnion  #: The expression left of the operator.
+	_rightOperand: ExpressionUnion  #: The expression right of the operator.
 
 	def __init__(self, leftOperand: ExpressionUnion, rightOperand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -935,7 +935,7 @@ class RangeExpression(BinaryExpression):
 	   * :class:`Ascending range expression <pyVHDLModel.Expression.AscendingRangeExpression>`
 	   * :class:`Descending range expression <pyVHDLModel.Expression.DescendingRangeExpression>`
 	"""
-	_direction: Direction
+	_direction: Direction  #: The range's direction, either ascending (``to``) or descending (``downto``).
 
 	@readonly
 	def Direction(self) -> Direction:
@@ -1766,8 +1766,8 @@ class QualifiedExpression(BaseExpression, ParenthesisExpression):
 	      --     ^^^^                    <- Subtype
 	      --          ^^^^^^^^^^^^^^^    <- Operand
 	"""
-	_operand:  ExpressionUnion
-	_subtype:  Symbol
+	_operand:  ExpressionUnion  #: The expression being qualified.
+	_subtype:  Symbol           #: Reference to the subtype qualifying the expression.
 
 	def __init__(self, subtype: Symbol, operand: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -1810,10 +1810,11 @@ class TernaryExpression(BaseExpression):
 	   * :class:`When else expression <pyVHDLModel.Expression.WhenElseExpression>`
 	"""
 
-	_FORMAT: Tuple[str, str, str, str]  # FIXME: needs ClassVar[...] when pyTooling gets fixed.
-	_firstOperand:  ExpressionUnion
-	_secondOperand: ExpressionUnion
-	_thirdOperand:  ExpressionUnion
+	# FIXME: needs ClassVar[...] when pyTooling gets fixed.
+	_FORMAT: Tuple[str, str, str, str]  #: The operator's string representation as four fragments.
+	_firstOperand:  ExpressionUnion  #: The operator's first operand.
+	_secondOperand: ExpressionUnion  #: The operator's second operand.
+	_thirdOperand:  ExpressionUnion  #: The operator's third operand.
 
 	def __init__(
 		self,
@@ -1946,7 +1947,7 @@ class SubtypeAllocation(Allocation):
 	      p := new integer;
 	      --       ^^^^^^^    <- Subtype
 	"""
-	_subtype: Symbol
+	_subtype: Symbol  #: Reference to the subtype being allocated.
 
 	def __init__(self, subtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -1981,7 +1982,7 @@ class QualifiedExpressionAllocation(Allocation):
 	      p := new integer'(5);
 	      --       ^^^^^^^^^^^    <- QualifiedExpression
 	"""
-	_qualifiedExpression: QualifiedExpression
+	_qualifiedExpression: QualifiedExpression  #: The qualified expression the allocated object is initialized with.
 
 	def __init__(self, qualifiedExpression: QualifiedExpression, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -2018,7 +2019,7 @@ class AggregateElement(ModelEntity):
 	   * :class:`Others aggregate element <pyVHDLModel.Expression.OthersAggregateElement>`
 	"""
 
-	_expression: ExpressionUnion
+	_expression: ExpressionUnion  #: The expression this aggregate element supplies.
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -2069,7 +2070,7 @@ class IndexedAggregateElement(AggregateElement):
 	      --      ^                           <- Index
 	      --           ^^^                    <- Expression
 	"""
-	_index: int
+	_index: int  #: The index selecting the element this value is assigned to.
 
 	def __init__(self, index: ExpressionUnion, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(expression, parent)
@@ -2104,7 +2105,7 @@ class RangedAggregateElement(AggregateElement):
 	      --      ^^^^^^                           <- Range
 	      --                ^^^                    <- Expression
 	"""
-	_range: Range
+	_range: Range  #: The range selecting the elements this value is assigned to.
 
 	def __init__(self, rng: Range, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(expression, parent)
@@ -2140,7 +2141,7 @@ class NamedAggregateElement(AggregateElement):
 	      --    ^                      <- Name
 	      --         ^^^               <- Expression
 	"""
-	_name: Symbol
+	_name: Symbol  #: Reference to the name selecting the element this value is assigned to.
 
 	def __init__(self, name: Symbol, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(expression, parent)
@@ -2200,7 +2201,7 @@ class Aggregate(BaseExpression):
 	      res := (0 => '1', 1 to 3 => '0', others => '1');
 	      --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    <- Elements
 	"""
-	_elements: List[AggregateElement]
+	_elements: List[AggregateElement]  #: List of all elements of this aggregate, in the order they were written.
 
 	def __init__(self, elements: Iterable[AggregateElement], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)

--- a/pyVHDLModel/IEEE.py
+++ b/pyVHDLModel/IEEE.py
@@ -100,7 +100,7 @@ class Ieee(PredefinedLibrary):
 	     * Library :class:`~pyVHDLModel.STD.Std`
 	"""
 
-	_flavor: IEEEFlavor
+	_flavor: IEEEFlavor  #: The flavor of the ``ieee`` library this instance provides.
 
 	def __init__(self, flavor: Nullable[IEEEFlavor] = None) -> None:
 		super().__init__(PACKAGES)

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -81,8 +81,8 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 	   * :class:`Procedure instantiation <pyVHDLModel.Instantiation.ProcedureInstantiation>`
 	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
 	"""
-	_subprogramReference:     SubprogramReferenceSymbol
-	_genericAssociationItems: List[GenericAssociationItem]
+	_subprogramReference:     SubprogramReferenceSymbol     #: Reference to the instantiated generic subprogram.
+	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations in the generic map aspect.
 
 	def __init__(
 		self,
@@ -207,8 +207,8 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 	      --      ^                                   <- Identifier
 	      --               ^^                         <- PackageReference
 	"""
-	_packageReference:        PackageReferenceSymbol
-	_genericAssociationItems: List[GenericAssociationItem]
+	_packageReference:        PackageReferenceSymbol        #: Reference to the instantiated generic package.
+	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations in the generic map aspect.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -81,7 +81,7 @@ class SimpleModeViewElement(ModeViewElement):
 	      end view;
 	"""
 
-	_mode: Mode
+	_mode: Mode  #: The element's mode.
 
 	def __init__(self, identifiers: Iterable[str], mode: Mode, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifiers, parent)
@@ -111,7 +111,7 @@ class CompositeModeViewElement(ModeViewElement):
 	      end view;
 	"""
 
-	_modeViewName: ModeViewSymbol
+	_modeViewName: ModeViewSymbol  #: Reference to the mode view applied to this element.
 
 	def __init__(self, identifiers: Iterable[str], modeViewName: ModeViewSymbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifiers, parent)
@@ -150,8 +150,8 @@ class ModeViewDeclaration(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	   * :class:`Reference to a mode view <pyVHDLModel.Symbol.ModeViewSymbol>`
 	"""
 
-	_subtype:  SubtypeSymbol
-	_elements: List[ModeViewElement]
+	_subtype:  SubtypeSymbol          #: Reference to the subtype this mode view applies to.
+	_elements: List[ModeViewElement]  #: List of all mode view elements, in declaration order.
 
 	def __init__(
 		self,
@@ -226,7 +226,7 @@ class InterfaceItemWithModeMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Parameter simple signal interface item <pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem>`
 	"""
 
-	_mode: Mode
+	_mode: Mode  #: The interface item's mode.
 
 	def __init__(self, mode: Mode) -> None:
 		self._mode = mode
@@ -684,7 +684,7 @@ class WithGenericsMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
 	   * :class:`Generic group <pyVHDLModel.Interface.GenericGroup>`
 	"""
-	_genericItems: List[GenericInterfaceItemMixin]
+	_genericItems: List[GenericInterfaceItemMixin]  #: List of all generics, in declaration order.
 
 	def __init__(
 		self,
@@ -726,7 +726,7 @@ class WithPortsMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Entity <pyVHDLModel.DesignUnit.Entity>`
 	   * :class:`Port group <pyVHDLModel.Interface.PortGroup>`
 	"""
-	_portItems: List[PortInterfaceItemMixin]
+	_portItems: List[PortInterfaceItemMixin]  #: List of all ports, in declaration order.
 
 	def __init__(
 		self,
@@ -766,7 +766,7 @@ class WithParametersMixin(metaclass=ExtendedType, mixin=True):
 
 	   * :class:`Parameter group <pyVHDLModel.Interface.ParameterGroup>`
 	"""
-	_parameterItems: List[ParameterInterfaceItemMixin]
+	_parameterItems: List[ParameterInterfaceItemMixin]  #: List of all parameters, in declaration order.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Name.py
+++ b/pyVHDLModel/Name.py
@@ -59,10 +59,11 @@ class Name(ModelEntity):
 	   * :class:`Open name <pyVHDLModel.Name.OpenName>`
 	"""
 
-	_identifier: str
-	_normalizedIdentifier: str
-	_root: Nullable['Name']     # TODO: seams to be unused. There is no reverse linking, or?
-	_prefix: Nullable['Name']
+	_identifier: str            #: The name's identifier.
+	_normalizedIdentifier: str  #: The normalized (lower case) identifier.
+	# TODO: seams to be unused. There is no reverse linking, or?
+	_root: Nullable['Name']  #: Reference to the root of the name chain.
+	_prefix: Nullable['Name']   #: Reference to the name's prefix, or ``None`` for a simple name.
 
 	def __init__(self, identifier: str, prefix: Nullable["Name"] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -151,7 +152,7 @@ class ParenthesisName(Name):
 
 	Used where indexing and a function call are indistinguishable before resolution.
 	"""
-	_associations: List
+	_associations: List  #: List of all associations in the parenthesis.
 
 	def __init__(self, prefix: Name, associations: Iterable, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__("", prefix, parent)
@@ -186,7 +187,7 @@ class IndexedName(Name):
 	      s <= v(0);
 	      --   ^^^^    <- the indexed name
 	"""
-	_indices: List[ExpressionUnion]
+	_indices: List[ExpressionUnion]  #: List of all index expressions, one per dimension.
 
 	def __init__(self, prefix: Name, indices: Iterable[ExpressionUnion], parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__("", prefix, parent)

--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -54,8 +54,8 @@ class ExtendedKeyError(KeyError):
 	Raised when a name cannot be resolved. Besides the key (:data:`key`), it carries every namespace
 	visited while walking outwards (:data:`searchedNamespaces`).
 	"""
-	key: str
-	searchedNamespaces: Tuple["Namespace", ...]
+	key: str                                     #: The key that was not found.
+	searchedNamespaces: Tuple["Namespace", ...]  #: The namespaces that were searched for the key.
 
 	def __init__(self, key: str, searchedNamespaces: Tuple["Namespace", ...], message: str) -> None:
 		super().__init__(message)
@@ -77,10 +77,10 @@ class Namespace(Generic[K, O]):
 	   * :class:`Concurrent declaration region <pyVHDLModel.Regions.ConcurrentDeclarationRegionMixin>`
 	   * :class:`Sequential declaration region <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
 	"""
-	_name:            str
-	_parentNamespace: "Namespace"
-	_subNamespaces:   Dict[str, "Namespace"]
-	_elements:        Dict[K, O]
+	_name:            str                     #: The namespace's name.
+	_parentNamespace: "Namespace"             #: Reference to the enclosing namespace, or ``None`` for the outermost one.
+	_subNamespaces:   Dict[str, "Namespace"]  #: Dictionary of all nested namespaces, indexed by name.
+	_elements:        Dict[K, O]              #: Dictionary of all elements declared in this namespace, indexed by name.
 
 	def __init__(self, name: str, parentNamespace: Nullable["Namespace"] = None) -> None:
 		self._name = name

--- a/pyVHDLModel/Object.py
+++ b/pyVHDLModel/Object.py
@@ -67,8 +67,8 @@ class Obj(ModelEntity, MultipleNamedEntityMixin, DocumentedEntityMixin):
 	   * :class:`File <pyVHDLModel.Object.File>`
 	"""
 
-	_subtype:      Symbol
-	_objectVertex: Nullable[Vertex]
+	_subtype:      Symbol            #: Reference to the object's subtype.
+	_objectVertex: Nullable[Vertex]  #: The vertex representing this object in the design's object graph.
 
 	def __init__(self, identifiers: Iterable[str], subtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -116,7 +116,7 @@ class WithDefaultExpressionMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Signal <pyVHDLModel.Object.Signal>`
 	"""
 
-	_defaultExpression: Nullable[ExpressionUnion]
+	_defaultExpression: Nullable[ExpressionUnion]  #: The default value, or ``None`` if none was given.
 
 	def __init__(self, defaultExpression: Nullable[ExpressionUnion] = None) -> None:
 		self._defaultExpression = defaultExpression
@@ -190,7 +190,7 @@ class DeferredConstant(BaseConstant):
 
 	      constant BITS : positive;
 	"""
-	_constantReference: Nullable[Constant]
+	_constantReference: Nullable[Constant]  #: The full declaration, or ``None`` if unlinked.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Sequential.py
+++ b/pyVHDLModel/Sequential.py
@@ -75,7 +75,7 @@ class SequentialStatementsMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Sequential case <pyVHDLModel.Sequential.SequentialCase>`
 	   * :class:`Loop statement <pyVHDLModel.Sequential.LoopStatement>`
 	"""
-	_statements: List[SequentialStatement]
+	_statements: List[SequentialStatement]  #: List of all sequential statements in this construct.
 
 	def __init__(self, statements: Nullable[Iterable[SequentialStatement]] = None) -> None:
 		# TODO: extract to mixin
@@ -209,7 +209,7 @@ class SequentialConditionalVariableAssignment(SequentialStatement, AssignmentMix
 	   * :class:`Conditional expression <pyVHDLModel.Common.ConditionalExpression>`
 	"""
 
-	_conditionalExpressions: List[ConditionalExpression]
+	_conditionalExpressions: List[ConditionalExpression]  #: List of all alternatives, in the order they were written.
 
 	def __init__(
 		self,
@@ -613,9 +613,9 @@ class IfStatement(CompoundStatement):
 
 	   * :class:`If-generate statement <pyVHDLModel.Concurrent.IfGenerateStatement>`
 	"""
-	_ifBranch: IfBranch
-	_elsifBranches: List['ElsifBranch']
-	_elseBranch: Nullable[ElseBranch]
+	_ifBranch: IfBranch                  #: The mandatory ``if`` branch.
+	_elsifBranches: List['ElsifBranch']  #: List of all ``elsif`` branches, in the order they were written.
+	_elseBranch: Nullable[ElseBranch]    #: The optional ``else`` branch, or ``None`` if none was given.
 
 	def __init__(
 		self,
@@ -696,7 +696,7 @@ class IndexedChoice(SequentialChoice):
 	      when 0      => v := '1';
 	      --   ^                     <- Expression
 	"""
-	_expression: ExpressionUnion
+	_expression: ExpressionUnion  #: The expression this choice selects on.
 
 	def __init__(self, expression: ExpressionUnion, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -731,7 +731,7 @@ class RangedChoice(SequentialChoice):
 	      when 1 to 2 => v := '0';
 	      --   ^^^^^^                <- Range
 	"""
-	_range: 'Range'
+	_range: 'Range'  #: The range this choice selects on.
 
 	def __init__(self, rng: 'Range', parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -836,8 +836,8 @@ class CaseStatement(CompoundStatement):
 
 	   * :class:`Case-generate statement <pyVHDLModel.Concurrent.CaseGenerateStatement>`
 	"""
-	_expression: ExpressionUnion
-	_cases:      List[SequentialCase]
+	_expression: ExpressionUnion       #: The expression being tested.
+	_cases:      List[SequentialCase]  #: List of all alternatives, in the order they were written.
 
 	def __init__(self, expression: ExpressionUnion, cases: Iterable[SequentialCase], label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(label, parent)
@@ -939,8 +939,8 @@ class ForLoopStatement(LoopStatement):
 	   * :class:`While loop statement <pyVHDLModel.Sequential.WhileLoopStatement>`
 	   * :class:`For-generate statement <pyVHDLModel.Concurrent.ForGenerateStatement>`
 	"""
-	_loopIndex: str
-	_range:     Range
+	_loopIndex: str    #: The name of the loop's index.
+	_range:     Range  #: The range the loop iterates over.
 
 	def __init__(self, loopIndex: str, rng: Range, statements: Nullable[Iterable[SequentialStatement]] = None, label: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(statements, label, parent)
@@ -1016,7 +1016,7 @@ class LoopControlStatement(SequentialStatement, ConditionalMixin):
 	   * :class:`Exit statement <pyVHDLModel.Sequential.ExitStatement>`
 	"""
 
-	_loopReference: LoopStatement
+	_loopReference: LoopStatement  #: Reference to the loop this statement controls.
 
 	def __init__(self, condition: Nullable[ExpressionUnion] = None, loopLabel: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:  # TODO: is this label (currently str) a Name or a Label class?
 		super().__init__(parent)
@@ -1111,7 +1111,7 @@ class ReturnStatement(SequentialStatement):
 	      --^^^               <- optional Label
 	      --             ^    <- optional ReturnValue
 	"""
-	_returnValue: Nullable[ExpressionUnion]
+	_returnValue: Nullable[ExpressionUnion]  #: The returned expression, or ``None`` for a procedure.
 
 	def __init__(
 		self,
@@ -1152,8 +1152,8 @@ class WaitStatement(SequentialStatement, ConditionalMixin):
 	      --                 ^^^^^^^^^^^              <- optional Condition
 	      --                                 ^^^^^    <- optional Timeout
 	"""
-	_sensitivityList: Nullable[List[Symbol]]
-	_timeout:         ExpressionUnion
+	_sensitivityList: Nullable[List[Symbol]]  #: List of all signal names to wait on, or ``None`` if none was given.
+	_timeout:         ExpressionUnion         #: The timeout expression, or ``None`` if none was given.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -60,10 +60,10 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, Sequentia
 	   * :class:`Procedure <pyVHDLModel.Subprogram.Procedure>`
 	   * :class:`Function <pyVHDLModel.Subprogram.Function>`
 	"""
-	_genericItems:   List['GenericInterfaceItemMixin']
-	_parameterItems: List['ParameterInterfaceItemMixin']
-	_statements:     List[SequentialStatement]
-	_isPure:         bool
+	_genericItems:   List['GenericInterfaceItemMixin']    #: List of all generics, in declaration order.
+	_parameterItems: List['ParameterInterfaceItemMixin']  #: List of all parameters, in declaration order.
+	_statements:     List[SequentialStatement]            #: List of all sequential statements in the subprogram's body.
+	_isPure:         bool                                 #: ``True`` if the subprogram was declared pure.
 
 	def __init__(
 		self,
@@ -232,7 +232,7 @@ class Function(Subprogram):
 	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
 	   * :class:`Procedure <pyVHDLModel.Subprogram.Procedure>`
 	"""
-	_returnType: SubtypeSymbol
+	_returnType: SubtypeSymbol  #: Reference to the subtype of the function's return value.
 
 	def __init__(
 		self,
@@ -272,7 +272,7 @@ class MethodMixin(metaclass=ExtendedType, mixin=True):
 	   * :class:`Function method <pyVHDLModel.Subprogram.FunctionMethod>`
 	"""
 
-	_protectedType: ProtectedType
+	_protectedType: ProtectedType  #: Reference to the protected type this method belongs to.
 
 	def __init__(self, protectedType: Nullable[ProtectedType] = None) -> None:
 		self._protectedType = protectedType

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -764,7 +764,7 @@ class ScalarConstraint(Constraint, mixin=True):
 
 	   * :class:`Constrained scalar subtype symbol <pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol>`
 	"""
-	_constraint: Nullable[Range]
+	_constraint: Nullable[Range]  #: The range constraining the scalar subtype, or ``None`` if unconstrained.
 
 	def __init__(self, constraint: Nullable[Range]) -> None:
 		self._constraint = constraint
@@ -811,7 +811,7 @@ class ArrayConstraint(Constraint, mixin=True):
 
 	   * :class:`Constrained array subtype symbol <pyVHDLModel.Symbol.ConstrainedArraySubtypeSymbol>`
 	"""
-	_constraints: List[Range]
+	_constraints: List[Range]  #: List of all index ranges, one per dimension.
 
 	def __init__(self, constraints: Iterable[Range]) -> None:
 		self._constraints = [constraint for constraint in constraints]
@@ -837,7 +837,7 @@ class RecordConstraint(Constraint, mixin=True):
 
 	   * :class:`Constrained record subtype symbol <pyVHDLModel.Symbol.ConstrainedRecordSubtypeSymbol>`
 	"""
-	_constraints: Dict[RecordElementSymbol, Range]
+	_constraints: Dict[RecordElementSymbol, Range]  #: Dictionary of the constraint per constrained record element.
 
 	def __init__(self, constraints: Mapping[RecordElementSymbol, Range]) -> None:
 		self._constraints = {key: value for key, value in constraints.items()}
@@ -882,7 +882,7 @@ class ConstrainedArraySubtypeSymbol(ConstrainedCompositeSubtypeSymbol, ArrayCons
 	      --         ^^^^^^^^^^                <- Name
 	      --                    ^^^^^^^^^^     <- Constraints
 	"""
-	_constraints: List
+	_constraints: List  #: List of all index ranges, one per dimension.
 
 	def __init__(self, name: Name, constraints: Iterable) -> None:
 		super().__init__(name)
@@ -896,7 +896,7 @@ class ConstrainedRecordSubtypeSymbol(ConstrainedCompositeSubtypeSymbol, RecordCo
 
 	The referenced language entity is available as :data:`Reference` once resolved.
 	"""
-	_constraints: Dict[RecordElementSymbol, Any]
+	_constraints: Dict[RecordElementSymbol, Any]  #: Dictionary of the constraint per constrained record element.
 
 	def __init__(self, name: Name, constraints: Mapping) -> None:
 		super().__init__(name)

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -60,7 +60,7 @@ class BaseType(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	   * :class:`Subtype <pyVHDLModel.Type.Subtype>`
 	"""
 
-	_objectVertex: Vertex
+	_objectVertex: Vertex  #: The vertex representing this type in the design's object graph.
 
 	def __init__(self, identifier: str, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
@@ -172,10 +172,10 @@ class Subtype(BaseType):
 
 	   * :class:`Reference to a type or subtype <pyVHDLModel.Symbol.SubtypeSymbol>`
 	"""
-	_type:               Symbol
-	_baseType:           BaseType
-	_range:              Range
-	_resolutionFunction: 'Function'
+	_type:               Symbol      #: Reference to the type or subtype this subtype is derived from.
+	_baseType:           BaseType    #: The resolved base type of this subtype.
+	_range:              Range       #: The constraint narrowing the base type, or ``None`` if unconstrained.
+	_resolutionFunction: 'Function'  #: The resolution function, or ``None`` if the subtype is unresolved.
 
 	def __init__(self, identifier: str, symbol: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
@@ -252,7 +252,7 @@ class RangedScalarType(ScalarType):
 	   * :class:`Physical type <pyVHDLModel.Type.PhysicalType>`
 	"""
 
-	_range: Range
+	_range: Range  #: The range constraining this scalar type.
 
 	def __init__(self, identifier: str, rng: Range, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
@@ -323,7 +323,7 @@ class EnumeratedType(ScalarType, DiscreteTypeMixin):
 	      --   ^^^^^                             <- Identifier
 	      --             ^^^^^^^^^^^^^^^^^^^     <- Literals
 	"""
-	_literals: List[EnumerationLiteral]
+	_literals: List[EnumerationLiteral]  #: List of all enumeration literals, in declaration order.
 
 	def __init__(self, identifier: str, literals: Iterable[EnumerationLiteral], documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
@@ -417,8 +417,8 @@ class PhysicalType(RangedScalarType, NumericTypeMixin):
 	      --^^^^^^^^^^^^^                             <- SecondaryUnits[1]
 	      end units;
 	"""
-	_primaryUnit:    str
-	_secondaryUnits: List[Tuple[str, PhysicalIntegerLiteral]]
+	_primaryUnit:    str                                       #: The name of the type's primary unit.
+	_secondaryUnits: List[Tuple[str, PhysicalIntegerLiteral]]  #: Secondary units as (name, value) pairs.
 
 	def __init__(
 		self,
@@ -502,8 +502,8 @@ class ArrayType(CompositeType):
 
 	   * :class:`Reference to a constrained array subtype <pyVHDLModel.Symbol.ConstrainedArraySubtypeSymbol>`
 	"""
-	_dimensions:  List[Range]
-	_elementType: Symbol
+	_dimensions:  List[Range]  #: List of all index ranges, one per dimension.
+	_elementType: Symbol       #: Reference to the subtype of the array's elements.
 
 	def __init__(
 		self,
@@ -567,7 +567,7 @@ class RecordTypeElement(ModelEntity, MultipleNamedEntityMixin):
 
 	   * :class:`Record type <pyVHDLModel.Type.RecordType>`
 	"""
-	_subtype: Symbol
+	_subtype: Symbol  #: Reference to the subtype shared by all identifiers of this element declaration.
 
 	def __init__(self, identifiers: Iterable[str], subtype: Symbol, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(parent)
@@ -615,7 +615,7 @@ class RecordType(CompositeType):
 	   * :class:`Record element <pyVHDLModel.Type.RecordTypeElement>`
 	   * :class:`Reference to a record element <pyVHDLModel.Symbol.RecordElementSymbol>`
 	"""
-	_elements: List[RecordTypeElement]
+	_elements: List[RecordTypeElement]  #: List of all element declarations, in declaration order.
 
 	def __init__(self, identifier: str, elements: Nullable[Iterable[RecordTypeElement]] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
@@ -666,7 +666,7 @@ class ProtectedType(FullType):
 	   * :class:`Protected type body <pyVHDLModel.Type.ProtectedTypeBody>`
 	   * :class:`Method of a protected type <pyVHDLModel.Subprogram.ProcedureMethod>`
 	"""
-	_methods: List[Union['Procedure', 'Function']]
+	_methods: List[Union['Procedure', 'Function']]  #: All methods, in declaration order.
 
 	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
@@ -719,7 +719,7 @@ class ProtectedTypeBody(FullType):
 
 	   * :class:`Protected type declaration <pyVHDLModel.Type.ProtectedType>`
 	"""
-	_methods: List[Union['Procedure', 'Function']]
+	_methods: List[Union['Procedure', 'Function']]  #: All declared items; see the class docs on the conflation.
 
 	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
@@ -757,7 +757,7 @@ class AccessType(FullType):
 	      --   ^^^                      <- Identifier
 	      --                 ^^^^^^^    <- DesignatedSubtype
 	"""
-	_designatedSubtype: Symbol
+	_designatedSubtype: Symbol  #: Reference to the subtype the access values designate.
 
 	def __init__(self, identifier: str, designatedSubtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)
@@ -794,7 +794,7 @@ class FileType(FullType):
 	      --   ^^^^^^^^^                      <- Identifier
 	      --                        ^^^^^^    <- DesignatedSubtype
 	"""
-	_designatedSubtype: Symbol
+	_designatedSubtype: Symbol  #: Reference to the subtype of the values stored in the file.
 
 	def __init__(self, identifier: str, designatedSubtype: Symbol, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		super().__init__(identifier, documentation, parent)


### PR DESCRIPTION
First of the follow-up items from the findings file after #151.

## What

All **204 undocumented class fields** now carry a `#:` comment, taking the package from **78/282 (27.7%)** to **282/282 (100%)**.

`Regions.py` and `__init__.py` were already complete and served as the style model: a `#:` comment on the same line, aligned per class.

## Why this is a separate workstream from the interrogate number

Worth being explicit, because it looks like the coverage should have moved: **interrogate does not count class fields at all.** Its 1207 items are modules, classes, functions/methods and properties only. So this PR leaves the number at 70.1% while closing a gap that is entirely invisible to it. The interrogate-visible work (361 misses, dominated by 246 `__init__` doc-strings) is the next PR.

The findings file recommends this order deliberately: most `__init__` parameters map 1:1 onto a field, so having the field docs first makes the `__init__` `:param:` pass substantially mechanical instead of 246 independent acts of authorship.

## Preserved TODO/FIXME notes

Five fields already carried a `# TODO:`/`# FIXME:` comment on the same line. Rather than drop the note or lose the documentation, the note moved to its own line above the field:

* `TernaryExpression._FORMAT`
* `ConcurrentStatementsMixin._instantiations`
* `ProcessStatement._sensitivityList`
* `ProcedureCallMixin._procedure`
* `Name._root`

## Verification

This change is **comment-only**, and that is checked rather than asserted: for every module, the Python token stream with comments removed is byte-identical to the one on `dev`.

| Check | Result |
|---|---|
| Modules whose code (comments stripped) changed | **0** |
| Class fields documented | 282/282 (100%) |
| Unbalanced ``` `` ``` or unterminated roles in `#:` comments | 0 |
| Added lines > 120 chars (tab = 2) | 0 |
| `pytest tests/unit` | 428 passed, 69 subtests |
| `interrogate` | 70.1% (unchanged, as expected) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)