### PR TITLE
Give the naming mixins a `__str__`, let the interface groups delegate

### DIFF
--- a/pyVHDLModel/Base.py
+++ b/pyVHDLModel/Base.py
@@ -213,6 +213,19 @@ class NamedEntityMixin(metaclass=ExtendedType, mixin=True):
 		"""
 		return self._normalizedIdentifier
 
+	def __str__(self) -> str:
+		"""
+		Formats the named entity as its identifier.
+
+		Derived classes rendering more than their name - a full declaration, say - override this and take
+		priority via the MRO.
+
+		**Format:** ``myEntity``
+
+		:returns: The entity's identifier.
+		"""
+		return self._identifier
+
 
 @export
 class OptionallyNamedEntityMixin(metaclass=ExtendedType, mixin=True):
@@ -303,6 +316,19 @@ class MultipleNamedEntityMixin(metaclass=ExtendedType, mixin=True):
 		:returns: Tuple of normalized identifiers.
 		"""
 		return self._normalizedIdentifiers
+
+	def __str__(self) -> str:
+		"""
+		Formats the named entity as its identifiers.
+
+		A single declaration may name several entities at once, so all identifiers are rendered. Derived
+		classes rendering more than their names override this and take priority via the MRO.
+
+		**Format:** ``a, b``
+
+		:returns: The entity's identifiers, comma-separated.
+		"""
+		return ", ".join(self._identifiers)
 
 
 @export

--- a/pyVHDLModel/Interface.py
+++ b/pyVHDLModel/Interface.py
@@ -41,7 +41,7 @@ from pyTooling.MetaClasses  import ExtendedType
 
 from pyVHDLModel.Symbol     import Symbol, SubtypeSymbol, ModeViewSymbol
 from pyVHDLModel.Base       import ModelEntity, DocumentedEntityMixin, NamedEntityMixin, OptionallyNamedEntityMixin
-from pyVHDLModel.Base       import MultipleNamedEntityMixin, identifiersOf
+from pyVHDLModel.Base       import MultipleNamedEntityMixin
 from pyVHDLModel.Base       import ExpressionUnion, Mode
 from pyVHDLModel.Object     import Constant, Signal, Variable, File
 from pyVHDLModel.Subprogram import Procedure, Function
@@ -1046,7 +1046,7 @@ class GenericGroup(InterfaceGroup, WithGenericsMixin):
 
 		:returns: Formatted generic group.
 		"""
-		names = ", ".join(name for item in self._genericItems for name in identifiersOf(item))
+		names = ", ".join(str(item) for item in self._genericItems)
 		return f"GenericGroup: {self._identifier} ({len(self._genericItems)}): {names}"
 
 
@@ -1104,7 +1104,7 @@ class PortGroup(InterfaceGroup, WithPortsMixin):
 
 		:returns: Formatted port group.
 		"""
-		names = ", ".join(name for item in self._portItems for name in identifiersOf(item))
+		names = ", ".join(str(item) for item in self._portItems)
 		return f"PortGroup: {self._identifier} ({len(self._portItems)}): {names}"
 
 
@@ -1162,5 +1162,5 @@ class ParameterGroup(InterfaceGroup, WithParametersMixin):
 
 		:returns: Formatted parameter group.
 		"""
-		names = ", ".join(name for item in self._parameterItems for name in identifiersOf(item))
+		names = ", ".join(str(item) for item in self._parameterItems)
 		return f"ParameterGroup: {self._identifier} ({len(self._parameterItems)}): {names}"

--- a/tests/unit/Instantiation/Interface.py
+++ b/tests/unit/Instantiation/Interface.py
@@ -303,7 +303,8 @@ class Groups(TestCase):
 	once: ``port (p1, p2 : in bit);``). ``PortGroup``/``ParameterGroup.__str__`` crashed for
 	essentially any realistic content, and ``GenericGroup.__str__`` crashed the moment a
 	``GenericConstantInterfaceItem`` was included or a group mixed both item shapes. Fixed via the
-	shared ``_identifiersOf()`` helper, which flattens either shape into a plain tuple of names."""
+	shared ``identifiersOf()`` helper, which flattens either shape into a plain tuple of names.
+	Since then both naming mixins render themselves, so the groups simply join ``str(item)``."""
 
 	def test_GenericGroup(self) -> None:
 		item = GenericTypeInterfaceItem("T")


### PR DESCRIPTION
The findings item queued for its own branch, now that the group `__str__` methods have settled.

## What

`NamedEntityMixin` and `MultipleNamedEntityMixin` render themselves - the identifier, and the comma-joined identifiers respectively.

**56 classes gained a `__str__`.** Every one of them previously fell back to Python's default `<pyVHDLModel.X.Y object at 0x...>`:

```
Signal                        <pyVHDLModel.Object.Signal object at 0x...>   ->  s1, s2
Procedure                     <pyVHDLModel.Subprogram.Procedure object ...>  ->  myProcedure
PortSimpleSignalInterfaceItem <pyVHDLModel.Interface.Port... object at ...>  ->  p
```

Classes with a more specific `__str__` (`Entity`, `Architecture`, `Subtype`, `DeferredConstant`, `RecordTypeElement`, the predefined packages, ...) keep priority via the MRO and are untouched.

## The payoff

`GenericGroup`/`PortGroup`/`ParameterGroup.__str__` now simply join `str(item)` instead of reaching into identifier internals via `identifiersOf()`:

```py
names = ", ".join(name for item in self._genericItems for name in identifiersOf(item))
names = ", ".join(str(item) for item in self._genericItems)
```

**Rendered output is unchanged** - `identifiersOf` flattened an item's identifiers into separate names, and `MultipleNamedEntityMixin.__str__` joins them with the same separator, so a two-identifier item still contributes `G2, G3`.

`identifiersOf()` is kept - it is exported public API - but is no longer used inside the package.

## The risk this carried, and why it does not materialize

The finding flagged that adding `__str__` to two mixins inherited by dozens of classes could change something currently user-visible. One case looked exactly like that: `Library` renders `Library: 'mylib'` today, which is *not* a default object repr.

It turns out `Design`, `Library` and `Document` alias **`__str__ = __repr__`** explicitly, so the mixin never applies to them. My initial static scan missed this by looking only for `def __str__`; running the code caught it.

Verified properly: I recorded `str()` for an instance of every affected class before and after the change. **The only differences are default object reprs becoming names** - nothing that already rendered sensibly changed.

## Verification

| Check | Result |
|---|---|
| Classes whose `str()` changed | 56, all from `<object at 0x...>` to a name |
| Previously-sensible `str()` output that regressed | **0** |
| Group rendering vs before | identical |
| `pytest tests/unit` | 428 passed, 69 subtests |
| pyGHDL `testsuite/pyunit` | 185 passed, 17 xfailed |
| ReST parse | 0 problems |
| `interrogate` | 97.3% (minimum 90.0%) |
| Added lines > 120 chars | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)