### PR TITLE
Make protected types and their bodies declaration regions

### DIFF
--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -34,14 +34,15 @@ This module contains parts of an abstract document language model for VHDL.
 
 A helper class to implement namespaces and scopes.
 """
-from typing import TypeVar, Generic, Dict, Optional as Nullable, Any, Tuple
+from typing import TYPE_CHECKING, TypeVar, Generic, Dict, Optional as Nullable, Any, Tuple
 
 from pyTooling.Common     import getFullyQualifiedName
 from pyTooling.Decorators import readonly
 
 from pyVHDLModel.Object   import Obj, Signal, Constant, Variable
 from pyVHDLModel.Symbol   import ComponentInstantiationSymbol, Symbol, PossibleReference
-from pyVHDLModel.Type     import Subtype, FullType, BaseType
+if TYPE_CHECKING:
+	from pyVHDLModel.Type   import Subtype, FullType, BaseType
 
 K = TypeVar("K")
 O = TypeVar("O")
@@ -159,7 +160,9 @@ class Namespace(Generic[K, O]):
 				searchedNamespaces = (self, *ex.searchedNamespaces)
 				raise ExtendedKeyError(key, searchedNamespaces, f"Component '{key}' not found in: {', '.join(ns._name for ns in searchedNamespaces)}.") from ex
 
-	def FindSubtype(self, subtypeSymbol: Symbol) -> BaseType:
+	def FindSubtype(self, subtypeSymbol: Symbol) -> 'BaseType':
+		from pyVHDLModel.Type import Subtype, FullType
+
 		try:
 			element = self._elements[subtypeSymbol._name._normalizedIdentifier]
 			if isinstance(element, Subtype):

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -34,7 +34,7 @@ This module contains parts of an abstract document language model for VHDL.
 
 tbd.
 """
-from typing                 import List, Dict, Iterable, Optional as Nullable, Any
+from typing                 import TYPE_CHECKING, List, Dict, Iterable, Optional as Nullable, Any
 
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType
@@ -44,7 +44,8 @@ from pyVHDLModel.Base       import normalizedIdentifiersOf
 from pyVHDLModel.Exception  import NotImplementedWarning
 from pyVHDLModel.Namespace  import Namespace
 from pyVHDLModel.Object     import Constant, SharedVariable, File, Variable, Signal
-from pyVHDLModel.Type       import Subtype, FullType
+if TYPE_CHECKING:
+	from pyVHDLModel.Type     import Subtype, FullType
 
 # `pyVHDLModel.Subprogram` imports this module (Subprogram is a sequential declaration region), so
 # `Function`/`Procedure` are quoted in annotations and imported lazily where they're needed at runtime.
@@ -125,8 +126,8 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 
 	# _attributes:     Dict[str, Attribute]
 	# _aliases:        Dict[str, Alias]
-	_types:           Dict[str, FullType]               #: Dictionary of all types declared in this concurrent declaration region.
-	_subtypes:        Dict[str, Subtype]                #: Dictionary of all subtypes declared in this concurrent declaration region.
+	_types:           Dict[str, 'FullType']               #: Dictionary of all types declared in this concurrent declaration region.
+	_subtypes:        Dict[str, 'Subtype']                #: Dictionary of all subtypes declared in this concurrent declaration region.
 	# _objects:        Dict[str, Union[Constant, Variable, Signal]]
 	_constants:       Dict[str, Constant]               #: Dictionary of all constants declared in this concurrent declaration region.
 	_signals:         Dict[str, Signal]                 #: Dictionary of all signals declared in this concurrent declaration region.
@@ -173,7 +174,7 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		return self._declaredItems
 
 	@readonly
-	def Types(self) -> Dict[str, FullType]:
+	def Types(self) -> Dict[str, 'FullType']:
 		"""
 		Read-only property to access the types (:attr:`_types`).
 
@@ -182,7 +183,7 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		return self._types
 
 	@readonly
-	def Subtypes(self) -> Dict[str, Subtype]:
+	def Subtypes(self) -> Dict[str, 'Subtype']:
 		"""
 		Read-only property to access the subtypes (:attr:`_subtypes`).
 
@@ -293,6 +294,7 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		"""
 		from pyVHDLModel.DesignUnit import Component
 		from pyVHDLModel.Subprogram import Function, Procedure
+		from pyVHDLModel.Type       import Subtype, FullType
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -364,8 +366,8 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	_declaredItems: List                          #: List of all declared items in this sequential declaration region.
 	_namespace:     Namespace                     #: The namespace of this sequential declaration region.
 
-	_types:         Dict[str, FullType]           #: Dictionary of all types declared in this sequential declaration region.
-	_subtypes:      Dict[str, Subtype]            #: Dictionary of all subtypes declared in this sequential declaration region.
+	_types:         Dict[str, 'FullType']           #: Dictionary of all types declared in this sequential declaration region.
+	_subtypes:      Dict[str, 'Subtype']            #: Dictionary of all subtypes declared in this sequential declaration region.
 	_constants:     Dict[str, Constant]           #: Dictionary of all constants declared in this sequential declaration region.
 	_variables:     Dict[str, Variable]           #: Dictionary of all variables declared in this sequential declaration region.
 	_files:         Dict[str, File]               #: Dictionary of all files declared in this sequential declaration region.
@@ -415,7 +417,7 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		return self._namespace
 
 	@readonly
-	def Types(self) -> Dict[str, FullType]:
+	def Types(self) -> Dict[str, 'FullType']:
 		"""
 		Read-only property to access the declared types (:attr:`_types`).
 
@@ -424,7 +426,7 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		return self._types
 
 	@readonly
-	def Subtypes(self) -> Dict[str, Subtype]:
+	def Subtypes(self) -> Dict[str, 'Subtype']:
 		"""
 		Read-only property to access the declared subtypes (:attr:`_subtypes`).
 
@@ -490,6 +492,7 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		     The same algorithm for a concurrent declaration region.
 		"""
 		from pyVHDLModel.Subprogram import Function, Procedure
+		from pyVHDLModel.Type       import Subtype, FullType
 
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
@@ -520,5 +523,109 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._files[normalizedIdentifier] = item
 					self._namespace._elements[normalizedIdentifier] = item
+			else:
+				self._IndexOtherDeclaredItem(item)
+
+
+@export
+class ProtectedTypeDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
+	"""
+	A mixin-class for the declarative region of a protected type declaration.
+
+	.. note::
+
+	   VHDL's ``protected_type_declarative_item`` rule admits **subprogram declarations only** - it is the
+	   narrowest declarative region in the language. Verified with the analyzer: a protected type
+	   declaration rejects variables, constants, signals, shared variables, types, subtypes, aliases,
+	   files, attributes, use clauses and even a subprogram *body*, while a subprogram *declaration* is
+	   accepted. That is the exact complement of a protected type **body**, which shares the sequential
+	   region (:class:`SequentialDeclarationRegionMixin`) with subprogram bodies.
+
+	.. seealso::
+
+	   * :class:`Protected type <pyVHDLModel.Type.ProtectedType>`
+	   * :class:`Protected type body <pyVHDLModel.Type.ProtectedTypeBody>`
+	   * :class:`Sequential declaration region <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
+	   * :class:`Namespace <pyVHDLModel.Namespace.Namespace>`
+	"""
+
+	_declaredItems: List                          #: List of all declared items in this protected type declaration.
+	_namespace:     Namespace                     #: The namespace of this protected type declaration.
+
+	# FIXME: overloads are only collected into a list, not matched/resolved by signature.
+	_functions:     Dict[str, List['Function']]   #: All declared functions, indexed by name; each is a list of overloads.
+	_procedures:    Dict[str, List['Procedure']]  #: All declared procedures by name; each is a list of overloads.
+
+	def __init__(self, namespaceName: Nullable[str] = None, declaredItems: Nullable[Iterable] = None) -> None:
+		"""
+		Initialize a protected type declaration region.
+
+		:param namespaceName: Name of this region's namespace, usually the protected type's identifier.
+		:param declaredItems: The items declared in this region.
+		"""
+		self._namespace = Namespace(namespaceName)
+
+		self._declaredItems = []  # TODO: convert to dict
+		if declaredItems is not None:
+			for item in declaredItems:
+				self._declaredItems.append(item)
+				item.Parent = self
+
+		self._functions =  {}
+		self._procedures = {}
+
+	@readonly
+	def DeclaredItems(self) -> List:
+		"""
+		Read-only property to access the declared items (:attr:`_declaredItems`).
+
+		:returns: List of all declared items.
+		"""
+		return self._declaredItems
+
+	@readonly
+	def Functions(self) -> Dict[str, List['Function']]:
+		"""
+		Read-only property to access the declared functions (:attr:`_functions`).
+
+		:returns: Dictionary of all functions, indexed by name; each entry is a list of overloads.
+		"""
+		return self._functions
+
+	@readonly
+	def Procedures(self) -> Dict[str, List['Procedure']]:
+		"""
+		Read-only property to access the declared procedures (:attr:`_procedures`).
+
+		:returns: Dictionary of all procedures, indexed by name; each entry is a list of overloads.
+		"""
+		return self._procedures
+
+	def IndexDeclaredItems(self) -> None:
+		"""
+		Index declared items listed in the protected type declaration.
+
+		Only subprogram declarations are legal here, so anything else is passed to
+		:meth:`_IndexOtherDeclaredItem`.
+
+		.. seealso::
+
+		   :meth:`SequentialDeclarationRegionMixin.IndexDeclaredItems`
+		     The same algorithm for the protected type's body.
+		"""
+		from pyVHDLModel.Subprogram import Function, Procedure
+		from pyVHDLModel.Type       import Subtype, FullType
+
+		for item in self._declaredItems:
+			if isinstance(item, Function):
+				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
+				#        real overload resolution yet).
+				self._functions.setdefault(item._normalizedIdentifier, []).append(item)
+				self._namespace._elements[item._normalizedIdentifier] = item
+			elif isinstance(item, Procedure):
+				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
+				#        real overload resolution yet).
+				self._procedures.setdefault(item._normalizedIdentifier, []).append(item)
+				self._namespace._elements[item._normalizedIdentifier] = item
 			else:
 				self._IndexOtherDeclaredItem(item)

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -126,8 +126,8 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 
 	# _attributes:     Dict[str, Attribute]
 	# _aliases:        Dict[str, Alias]
-	_types:           Dict[str, 'FullType']               #: Dictionary of all types declared in this concurrent declaration region.
-	_subtypes:        Dict[str, 'Subtype']                #: Dictionary of all subtypes declared in this concurrent declaration region.
+	_types:           Dict[str, 'FullType']             #: Dictionary of all types declared in this concurrent declaration region.
+	_subtypes:        Dict[str, 'Subtype']              #: Dictionary of all subtypes declared in this concurrent declaration region.
 	# _objects:        Dict[str, Union[Constant, Variable, Signal]]
 	_constants:       Dict[str, Constant]               #: Dictionary of all constants declared in this concurrent declaration region.
 	_signals:         Dict[str, Signal]                 #: Dictionary of all signals declared in this concurrent declaration region.
@@ -366,8 +366,8 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	_declaredItems: List                          #: List of all declared items in this sequential declaration region.
 	_namespace:     Namespace                     #: The namespace of this sequential declaration region.
 
-	_types:         Dict[str, 'FullType']           #: Dictionary of all types declared in this sequential declaration region.
-	_subtypes:      Dict[str, 'Subtype']            #: Dictionary of all subtypes declared in this sequential declaration region.
+	_types:         Dict[str, 'FullType']         #: Dictionary of all types declared in this sequential declaration region.
+	_subtypes:      Dict[str, 'Subtype']          #: Dictionary of all subtypes declared in this sequential declaration region.
 	_constants:     Dict[str, Constant]           #: Dictionary of all constants declared in this sequential declaration region.
 	_variables:     Dict[str, Variable]           #: Dictionary of all variables declared in this sequential declaration region.
 	_files:         Dict[str, File]               #: Dictionary of all files declared in this sequential declaration region.
@@ -532,14 +532,9 @@ class ProtectedTypeDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 	"""
 	A mixin-class for the declarative region of a protected type declaration.
 
-	.. note::
-
-	   VHDL's ``protected_type_declarative_item`` rule admits **subprogram declarations only** - it is the
-	   narrowest declarative region in the language. Verified with the analyzer: a protected type
-	   declaration rejects variables, constants, signals, shared variables, types, subtypes, aliases,
-	   files, attributes, use clauses and even a subprogram *body*, while a subprogram *declaration* is
-	   accepted. That is the exact complement of a protected type **body**, which shares the sequential
-	   region (:class:`SequentialDeclarationRegionMixin`) with subprogram bodies.
+	VHDL's ``protected_type_declarative_item`` rule admits subprogram declarations only, making this the
+	narrowest declarative region in the language. A protected type *body* differs: its declarative part
+	matches a subprogram's, so it uses :class:`SequentialDeclarationRegionMixin`.
 
 	.. seealso::
 

--- a/pyVHDLModel/Subprogram.py
+++ b/pyVHDLModel/Subprogram.py
@@ -43,6 +43,7 @@ from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, DocumentedEnti
 from pyVHDLModel.Symbol     import SubtypeSymbol
 from pyVHDLModel.Type       import ProtectedType
 from pyVHDLModel.Regions    import ConcurrentDeclarationRegionMixin, SequentialDeclarationRegionMixin
+from pyVHDLModel.Regions    import ProtectedTypeDeclarationRegionMixin
 from pyVHDLModel.Sequential import SequentialStatement
 
 
@@ -118,10 +119,11 @@ class Subprogram(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, Sequentia
 		ModelEntity.Parent.fset(self, parent)
 
 		# Connect the subprogram's namespace to the enclosing declaration region's namespace, so a
-		# declaration inside the subprogram hides a same-named one from the scope around it. A subprogram
-		# can also be a protected type's method, and a protected type is no declaration region, hence the
-		# check.
-		if isinstance(parent, (ConcurrentDeclarationRegionMixin, SequentialDeclarationRegionMixin)):
+		# declaration inside the subprogram hides a same-named one from the scope around it. Protected
+		# types and their bodies are declaration regions too, so a method chains like any other
+		# subprogram; the check remains because a parent need not be a region at all.
+		regions = (ConcurrentDeclarationRegionMixin, SequentialDeclarationRegionMixin, ProtectedTypeDeclarationRegionMixin)
+		if isinstance(parent, regions):
 			self._namespace.ParentNamespace = parent._namespace
 
 	@readonly

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -837,11 +837,9 @@ class ProtectedTypeBody(FullType, SequentialDeclarationRegionMixin):
 	A protected type body implements the methods (:data:`Methods`) declared by the
 	:class:`ProtectedType` of the same identifier (:data:`Identifier`).
 
-	It is a declarative region and owns a namespace. Its declarative part is identical to a subprogram's
-	- variables, constants, types, subtypes, aliases, files and nested subprogram bodies are legal,
-	signals and shared variables are not - so it shares
-	:class:`~pyVHDLModel.Regions.SequentialDeclarationRegionMixin` with subprogram bodies. Everything
-	declared is available as :data:`DeclaredItems`; :data:`Methods` is its subprogram subset.
+	It is a declarative region and owns a namespace. Its declarative part matches a subprogram's, so it
+	shares :class:`~pyVHDLModel.Regions.SequentialDeclarationRegionMixin` with subprogram bodies.
+	Everything declared is available as :data:`DeclaredItems`; :data:`Methods` is its subprogram subset.
 
 	.. admonition:: Example
 

--- a/pyVHDLModel/Type.py
+++ b/pyVHDLModel/Type.py
@@ -43,6 +43,7 @@ from pyTooling.Graph        import Vertex
 from pyVHDLModel.Base       import ModelEntity, NamedEntityMixin, MultipleNamedEntityMixin, DocumentedEntityMixin, ExpressionUnion, Range
 from pyVHDLModel.Symbol     import Symbol
 from pyVHDLModel.Expression import EnumerationLiteral, PhysicalIntegerLiteral
+from pyVHDLModel.Regions    import ProtectedTypeDeclarationRegionMixin, SequentialDeclarationRegionMixin
 
 
 @export
@@ -771,14 +772,17 @@ class RecordType(CompositeType):
 
 
 @export
-class ProtectedType(FullType):
+class ProtectedType(FullType, ProtectedTypeDeclarationRegionMixin):
 	"""
 	Represents a protected type declaration.
 
 	A protected type is a named entity (:data:`Identifier`) exposing only its methods
 	(:data:`Methods`). The implementation lives in a separate :class:`ProtectedTypeBody`.
-	The model holds the methods in a list and has no distinct field per method, so the markers
-	below name list elements.
+
+	It is a declarative region and owns a namespace. VHDL's ``protected_type_declarative_item`` admits
+	subprogram declarations and nothing else - the narrowest declarative region in the language - so
+	:data:`DeclaredItems` and :data:`Methods` hold the same items. The markers below name list elements,
+	because the model has no distinct field per method.
 
 	.. admonition:: Example
 
@@ -797,42 +801,47 @@ class ProtectedType(FullType):
 	   * :class:`Protected type body <pyVHDLModel.Type.ProtectedTypeBody>`
 	   * :class:`Method of a protected type <pyVHDLModel.Subprogram.ProcedureMethod>`
 	"""
-	_methods: List[Union['Procedure', 'Function']]  #: All methods, in declaration order.
-
-	def __init__(self, identifier: str, methods: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
+	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
 		Initializes a protected type declaration.
 
 		:param identifier:    The identifier of a model entity.
-		:param methods:       All methods, in declaration order.
+		:param declaredItems: All items declared by this protected type; only subprograms are legal.
 		:param documentation: The documentation comment associated with this declaration.
 		:param parent:        The parent model entity of this entity.
 		"""
 		super().__init__(identifier, documentation, parent)
-
-		self._methods = []
-		if methods is not None:
-			for method in methods:
-				self._methods.append(method)
-				method.Parent = self
+		ProtectedTypeDeclarationRegionMixin.__init__(self, self._normalizedIdentifier, declaredItems)
 
 	@readonly
 	def Methods(self) -> List[Union['Procedure', 'Function']]:
 		"""
-		Read-only property to access the methods (:attr:`_methods`).
+		Read-only property to access the declared methods, in declaration order.
 
-		:returns: List of methods.
+		A protected type declares nothing but subprograms, so this is every declared item
+		(:attr:`_declaredItems`). It is kept as a named view because "method" is the VHDL term for a
+		protected type's subprograms.
+
+		:returns: List of methods, in declaration order.
 		"""
-		return self._methods
+		from pyVHDLModel.Subprogram import Function, Procedure
+
+		return [item for item in self._declaredItems if isinstance(item, (Function, Procedure))]
 
 
 @export
-class ProtectedTypeBody(FullType):
+class ProtectedTypeBody(FullType, SequentialDeclarationRegionMixin):
 	"""
 	Represents a protected type body.
 
 	A protected type body implements the methods (:data:`Methods`) declared by the
 	:class:`ProtectedType` of the same identifier (:data:`Identifier`).
+
+	It is a declarative region and owns a namespace. Its declarative part is identical to a subprogram's
+	- variables, constants, types, subtypes, aliases, files and nested subprogram bodies are legal,
+	signals and shared variables are not - so it shares
+	:class:`~pyVHDLModel.Regions.SequentialDeclarationRegionMixin` with subprogram bodies. Everything
+	declared is available as :data:`DeclaredItems`; :data:`Methods` is its subprogram subset.
 
 	.. admonition:: Example
 
@@ -848,18 +857,10 @@ class ProtectedTypeBody(FullType):
 	        end procedure;
 	      end protected body;
 
-	.. note::
-
-	   A protected type body may also declare non-subprogram items - ``variable count`` above. The
-	   model currently stores every declared item in :data:`Methods`, so such declarations are
-	   conflated with the methods and have no marker of their own.
-
 	.. seealso::
 
 	   * :class:`Protected type declaration <pyVHDLModel.Type.ProtectedType>`
 	"""
-	_methods: List[Union['Procedure', 'Function']]  #: All declared items; see the class docs on the conflation.
-
 	def __init__(self, identifier: str, declaredItems: Union[List, Iterator] = None, documentation: Nullable[str] = None, parent: Nullable[ModelEntity] = None) -> None:
 		"""
 		Initializes a protected type body.
@@ -870,22 +871,22 @@ class ProtectedTypeBody(FullType):
 		:param parent:        The parent model entity of this entity.
 		"""
 		super().__init__(identifier, documentation, parent)
-
-		self._methods = []
-		if declaredItems is not None:
-			for method in declaredItems:
-				self._methods.append(method)
-				method.Parent = self
+		SequentialDeclarationRegionMixin.__init__(self, self._normalizedIdentifier, declaredItems)
 
 	# FIXME: needs to be declared items or so
 	@readonly
 	def Methods(self) -> List[Union['Procedure', 'Function']]:
 		"""
-		Read-only property to access the methods (:attr:`_methods`).
+		Read-only property to access the implemented methods, in declaration order.
 
-		:returns: List of methods.
+		A protected type body may also declare variables, types, subtypes, aliases and files, so this is
+		the subprogram subset of :attr:`_declaredItems` rather than all of them.
+
+		:returns: List of methods, in declaration order.
 		"""
-		return self._methods
+		from pyVHDLModel.Subprogram import Function, Procedure
+
+		return [item for item in self._declaredItems if isinstance(item, (Function, Procedure))]
 
 
 @export

--- a/tests/unit/Instantiation/Type.py
+++ b/tests/unit/Instantiation/Type.py
@@ -35,6 +35,8 @@ from pyVHDLModel.Base       import ModelEntity, Direction, RangeFromName, Simple
 from pyVHDLModel.Name       import SimpleName, AttributeName
 from pyVHDLModel.Symbol     import RangeAttributeSymbol, SimpleSubtypeSymbol
 from pyVHDLModel.Expression import IntegerLiteral, EnumerationLiteral, PhysicalIntegerLiteral
+from pyVHDLModel.Object     import Variable
+from pyVHDLModel.Subprogram import Procedure
 from pyVHDLModel.Type       import (
 	Subtype, RangedScalarType,
 	EnumeratedType, IntegerType, RealType, PhysicalType,
@@ -257,34 +259,65 @@ class RecordTypes(TestCase):
 
 
 class ProtectedTypes(TestCase):
-	"""``methods`` accepts any pre-built ``ModelEntity`` for its parent-wiring; a plain ``ModelEntity``
-	stand-in keeps this test independent from Subprogram.py, which gets its own dedicated slice."""
+	"""A protected type declaration admits subprogram declarations only, so ``DeclaredItems`` and
+	``Methods`` hold the same items. Real ``Procedure`` instances are needed because ``Methods`` is
+	defined by type, not by position."""
 
 	def test_WithMethods(self) -> None:
-		method = ModelEntity()
+		method = Procedure("increment")
 		protectedType = ProtectedType("my_protected", [method])
 
+		self.assertEqual(1, len(protectedType.DeclaredItems))
 		self.assertEqual(1, len(protectedType.Methods))
+		self.assertIs(method, protectedType.Methods[0])
 		self.assertIs(protectedType, method.Parent)
 
 	def test_NoMethods(self) -> None:
 		protectedType = ProtectedType("my_protected")
 
+		self.assertEqual(0, len(protectedType.DeclaredItems))
 		self.assertEqual(0, len(protectedType.Methods))
+
+	def test_IndexDeclaredItems(self) -> None:
+		method = Procedure("increment")
+		protectedType = ProtectedType("my_protected", [method])
+		protectedType.IndexDeclaredItems()
+
+		self.assertIn("increment", protectedType.Procedures)
+		self.assertIn("increment", protectedType._namespace._elements)
 
 
 class ProtectedTypeBodies(TestCase):
-	def test_WithDeclaredItems(self) -> None:
-		method = ModelEntity()
-		body = ProtectedTypeBody("my_protected", [method])
+	"""A protected type body's declarative part matches a subprogram's, so it may declare more than
+	methods. ``Methods`` is the subprogram subset of ``DeclaredItems``, not all of them."""
 
+	def test_WithDeclaredItems(self) -> None:
+		variable = Variable(["count"], _subtypeSymbol("natural"))
+		method = Procedure("increment")
+		body = ProtectedTypeBody("my_protected", [variable, method])
+
+		self.assertEqual(2, len(body.DeclaredItems))
 		self.assertEqual(1, len(body.Methods))
+		self.assertIs(method, body.Methods[0])
+		self.assertIs(body, variable.Parent)
 		self.assertIs(body, method.Parent)
 
 	def test_NoDeclaredItems(self) -> None:
 		body = ProtectedTypeBody("my_protected")
 
+		self.assertEqual(0, len(body.DeclaredItems))
 		self.assertEqual(0, len(body.Methods))
+
+	def test_IndexDeclaredItems(self) -> None:
+		variable = Variable(["count"], _subtypeSymbol("natural"))
+		method = Procedure("increment")
+		body = ProtectedTypeBody("my_protected", [variable, method])
+		body.IndexDeclaredItems()
+
+		self.assertIn("count", body.Variables)
+		self.assertIn("increment", body.Procedures)
+		self.assertIn("count", body._namespace._elements)
+		self.assertIn("increment", body._namespace._elements)
 
 
 class AccessTypes(TestCase):


### PR DESCRIPTION
Findings item 3. Branched off `dev`, so it is independent of #157.

## What the analyzer says

Measured with `ghdl -a --std=19`, one declaration at a time, to settle whether either half can share an existing region rather than guessing:

| Declaration | protected type | protected type **body** | subprogram body |
|---|---|---|---|
| variable, constant | rejected | allowed | allowed |
| **signal, shared variable** | rejected | **rejected** | **rejected** |
| type, subtype, alias, file | rejected | allowed | allowed |
| nested subprogram *body* | rejected | allowed | allowed |
| subprogram *declaration* | **allowed** | rejected | rejected |
| attribute, use clause | rejected | allowed | allowed |

Your instinct was right, and it cuts cleanly both ways:

* A protected type **body** and a subprogram declarative part **agree on all twelve items**, so `ProtectedTypeBody` reuses `SequentialDeclarationRegionMixin`. Its indexed kinds - types, subtypes, constants, variables, files, functions, procedures, and notably *no* signals and *no* shared variables - match the measured set exactly.
* A protected type **declaration** is the exact complement: subprogram declarations and nothing else, the narrowest declarative region in VHDL. It gets a new `ProtectedTypeDeclarationRegionMixin`.

## The `_methods` conflation is resolved

`ProtectedTypeBody` stored **every** declared item in `_methods`, so a variable was indistinguishable from a method. Both classes now have a real `_declaredItems`, and `Methods` is its subprogram subset.

`ProtectedType.__init__`'s first list parameter is renamed `methods` -> `declaredItems` to match. pyGHDL passes it positionally and is unaffected (its suite is green).

## `Subprogram.Parent` no longer special-cases protected types

The isinstance guard carried a comment saying "a protected type is no declaration region, hence the check". That is no longer true. A method's namespace now chains to its enclosing region like any other subprogram, so **a method variable hides a body variable of the same name** - the `-Whide` case that motivated this finding in the first place. Verified directly.

## One thing worth reviewing carefully: the import cycle

`Type` must inherit the region mixins, but `Regions` **and** `Namespace` both imported `Type` at module level. I deferred their `Type` imports into the methods that need them - the same pattern `IndexDeclaredItems` already used for `Subprogram` - and quoted the affected annotations.

Quoting matters beyond style here: an unquoted `-> BaseType` or `Dict[str, FullType]` is evaluated **eagerly on Python 3.11-3.13** and would raise `NameError` there while passing on 3.14, exactly the CI failure pattern from #145. I checked by forcing evaluation of every annotation in the package: all clean.

## Verification

| Check | Result |
|---|---|
| Forced annotation evaluation (3.11-3.13 behaviour) | all clean |
| Method variable hides body variable | works |
| `pytest tests/unit` | **430** passed (+2), 69 subtests |
| pyGHDL `testsuite/pyunit` | 185 passed, 17 xfailed |
| ReST parse | 0 problems |
| `interrogate` | 97.3% (minimum 90.0%) |
| New lines > 120 chars | 0 (the remaining long lines were already over on `dev`) |

The two protected-type tests passed a bare `ModelEntity` as a method stand-in, which `Methods` now correctly excludes. Rewritten with real `Procedure` instances and extended to cover the `DeclaredItems`/`Methods` distinction and namespace indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)