### PR TITLE
Detect duplicate declarations within a declarative region

### DIFF
--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -34,7 +34,7 @@ This module contains parts of an abstract document language model for VHDL.
 
 Design units are contexts, entities, architectures, packages and their bodies as well as configurations.
 """
-from typing import List, Dict, Union, Iterable, Optional as Nullable
+from typing import ClassVar, List, Dict, Union, Iterable, Optional as Nullable
 
 from pyTooling.Decorators   import export, readonly
 from pyTooling.MetaClasses  import ExtendedType, abstractmethod
@@ -182,6 +182,8 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	     * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
 	"""
 
+	_continuesParentRegion: ClassVar[bool] = False  #: ``True`` if it continues its parent's declarative region.
+
 	_document: 'Document'                                  #: The VHDL library, the design unit was analyzed into.
 
 	# Either written as statements before (e.g. entity, architecture, package, ...), or as statements inside (context)
@@ -236,7 +238,7 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		self._dependencyVertex = None
 		self._hierarchyVertex = None
 
-		self._namespace = Namespace(self._normalizedIdentifier)
+		self._namespace = Namespace(self._normalizedIdentifier, sharesRegion=self._continuesParentRegion)
 
 	@property
 	def Document(self) -> 'Document':
@@ -650,6 +652,8 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarati
 	   * :class:`Package it implements <pyVHDLModel.DesignUnit.Package>`
 	"""
 
+	_continuesParentRegion: ClassVar[bool] = True
+
 	_package:       PackageSymbol  #: Reference to the package this body implements.
 
 	def __init__(
@@ -844,6 +848,8 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarat
 
 	   * :class:`Entity it implements <pyVHDLModel.DesignUnit.Entity>`
 	"""
+
+	_continuesParentRegion: ClassVar[bool] = True
 
 	_entity:        EntitySymbol  #: Reference to the entity this architecture implements.
 

--- a/pyVHDLModel/DesignUnit.py
+++ b/pyVHDLModel/DesignUnit.py
@@ -182,7 +182,7 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 	     * :class:`Package body <pyVHDLModel.DesignUnit.PackageBody>`
 	"""
 
-	_continuesParentRegion: ClassVar[bool] = False  #: ``True`` if it continues its parent's declarative region.
+	_continuesParentRegion: ClassVar[bool] = False         #: ``True`` if it continues its parent's declarative region.
 
 	_document: 'Document'                                  #: The VHDL library, the design unit was analyzed into.
 
@@ -238,7 +238,7 @@ class DesignUnit(ModelEntity, NamedEntityMixin, DocumentedEntityMixin):
 		self._dependencyVertex = None
 		self._hierarchyVertex = None
 
-		self._namespace = Namespace(self._normalizedIdentifier, sharesRegion=self._continuesParentRegion)
+		self._namespace = Namespace(self._normalizedIdentifier, sharesRegionWithParent=self._continuesParentRegion)
 
 	@property
 	def Document(self) -> 'Document':
@@ -652,9 +652,9 @@ class PackageBody(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarati
 	   * :class:`Package it implements <pyVHDLModel.DesignUnit.Package>`
 	"""
 
-	_continuesParentRegion: ClassVar[bool] = True
+	_continuesParentRegion: ClassVar[bool] = True   #: A package body continues its package's declarative region.
 
-	_package:       PackageSymbol  #: Reference to the package this body implements.
+	_package:               PackageSymbol           #: Reference to the package this body implements.
 
 	def __init__(
 		self,
@@ -849,9 +849,9 @@ class Architecture(SecondaryUnit, DesignUnitWithContextMixin, ConcurrentDeclarat
 	   * :class:`Entity it implements <pyVHDLModel.DesignUnit.Entity>`
 	"""
 
-	_continuesParentRegion: ClassVar[bool] = True
+	_continuesParentRegion: ClassVar[bool] = True  #: An architecture continues its entity's declarative region.
 
-	_entity:        EntitySymbol  #: Reference to the entity this architecture implements.
+	_entity:                EntitySymbol           #: Reference to the entity this architecture implements.
 
 	def __init__(
 		self,

--- a/pyVHDLModel/Exception.py
+++ b/pyVHDLModel/Exception.py
@@ -74,6 +74,17 @@ class VHDLModelCriticalWarning(Warning):
 
 
 @export
+class DuplicateDeclarationWarning(VHDLModelCriticalWarning):
+	"""
+	Raised when two declarations in one declarative region share an identifier.
+
+	VHDL rejects this as *identifier already used for a declaration*. Overloadable declarations -
+	subprograms differing in signature - are not reported.
+	"""
+	pass
+
+
+@export
 class BlackboxWarning(VHDLModelCriticalWarning):
 	"""
 	Raised when a component could not be bound and is treated as a blackbox.

--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -87,13 +87,18 @@ class Namespace(Generic[K, O]):
 	   * :class:`Concurrent declaration region <pyVHDLModel.Regions.ConcurrentDeclarationRegionMixin>`
 	   * :class:`Sequential declaration region <pyVHDLModel.Regions.SequentialDeclarationRegionMixin>`
 	"""
-	_name:            str                     #: The namespace's name.
-	_parentNamespace: "Namespace"             #: Reference to the enclosing namespace, or ``None`` for the outermost one.
-	_subNamespaces:   Dict[str, "Namespace"]  #: Dictionary of all nested namespaces, indexed by name.
-	_elements:        Dict[K, O]              #: Dictionary of all elements declared in this namespace, indexed by name.
-	_sharesRegion:    bool                    #: ``True`` if the parent namespace is the same VHDL declarative region.
+	_name:                   str                     #: The namespace's name.
+	_parentNamespace:        "Namespace"             #: Reference to the enclosing namespace, ``None`` if outermost.
+	_subNamespaces:          Dict[str, "Namespace"]  #: Dictionary of all nested namespaces, indexed by name.
+	_elements:               Dict[K, O]              #: All elements declared in this namespace, indexed by name.
+	_sharesRegionWithParent: bool                    #: ``True`` if the parent namespace is the same declarative region.
 
-	def __init__(self, name: str, parentNamespace: Nullable["Namespace"] = None, sharesRegion: bool = False) -> None:
+	def __init__(
+		self,
+		name: str,
+		parentNamespace: Nullable["Namespace"] = None,
+		sharesRegionWithParent: bool = False
+	) -> None:
 		"""
 		Initializes a namespace.
 
@@ -104,7 +109,7 @@ class Namespace(Generic[K, O]):
 		self._parentNamespace = parentNamespace
 		self._subNamespaces = {}
 		self._elements = {}
-		self._sharesRegion = sharesRegion
+		self._sharesRegionWithParent = sharesRegionWithParent
 
 	@readonly
 	def Name(self) -> str:
@@ -130,18 +135,20 @@ class Namespace(Generic[K, O]):
 		value._subNamespaces[self._name] = self
 
 	@readonly
-	def SharesRegion(self) -> bool:
+	def SharesRegionWithParent(self) -> bool:
 		"""
 		Read-only property to access whether this namespace continues its parent's declarative region
-		(:attr:`_sharesRegion`).
+		(:attr:`_sharesRegionWithParent`).
 
-		An entity and its architecture form one VHDL declarative region, as do a package and its body,
-		even though each owns a namespace. A duplicate declaration is reported across such a link, while a
-		genuinely nested region - a process, a block - hides instead.
+		.. hint::
+
+		   An entity and its architecture form one VHDL declarative region, as do a package and its body,
+		   even though each owns a namespace. A duplicate declaration is reported across such a link, while
+		   a genuinely nested region - a process, a block - hides instead.
 
 		:returns: ``True`` if the parent namespace is the same declarative region.
 		"""
-		return self._sharesRegion
+		return self._sharesRegionWithParent
 
 	@readonly
 	def SubNamespaces(self) -> Dict[str, 'Namespace']:
@@ -182,7 +189,7 @@ class Namespace(Generic[K, O]):
 				))
 				break
 
-			namespace = namespace._parentNamespace if namespace._sharesRegion else None
+			namespace = namespace._parentNamespace if namespace._sharesRegionWithParent else None
 
 		self._elements[normalizedIdentifier] = element
 

--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -38,9 +38,11 @@ from typing import TYPE_CHECKING, TypeVar, Generic, Dict, Optional as Nullable, 
 
 from pyTooling.Common     import getFullyQualifiedName
 from pyTooling.Decorators import readonly
+from pyTooling.Warning    import WarningCollector
 
 from pyVHDLModel.Object   import Obj, Signal, Constant, Variable
 from pyVHDLModel.Symbol   import ComponentInstantiationSymbol, Symbol, PossibleReference
+from pyVHDLModel.Exception import DuplicateDeclarationWarning
 if TYPE_CHECKING:
 	from pyVHDLModel.Type   import Subtype, FullType, BaseType
 
@@ -89,6 +91,7 @@ class Namespace(Generic[K, O]):
 	_parentNamespace: "Namespace"             #: Reference to the enclosing namespace, or ``None`` for the outermost one.
 	_subNamespaces:   Dict[str, "Namespace"]  #: Dictionary of all nested namespaces, indexed by name.
 	_elements:        Dict[K, O]              #: Dictionary of all elements declared in this namespace, indexed by name.
+	_sharesRegionWithParent: bool             #: ``True`` if the parent namespace is the same VHDL declarative region.
 
 	def __init__(self, name: str, parentNamespace: Nullable["Namespace"] = None) -> None:
 		"""
@@ -101,6 +104,7 @@ class Namespace(Generic[K, O]):
 		self._parentNamespace = parentNamespace
 		self._subNamespaces = {}
 		self._elements = {}
+		self._sharesRegionWithParent = False
 
 	@readonly
 	def Name(self) -> str:
@@ -133,6 +137,40 @@ class Namespace(Generic[K, O]):
 		:returns: Dictionary of sub namespaces.
 		"""
 		return self._subNamespaces
+
+	def AddElement(self, normalizedIdentifier: K, element: O, overloadable: bool = False) -> None:
+		"""
+		Add a declared item to this namespace, reporting a duplicate declaration.
+
+		VHDL rejects two declarations sharing an identifier in one declarative region. A region can span
+		more than one namespace - an entity and its architecture form one, as do a package and its body -
+		so enclosing namespaces are searched too, but only while they share this one's region.
+
+		Overloadable declarations are exempt: several subprograms may share a name as long as their
+		signatures differ. Signatures are not compared yet, so two subprograms sharing a name are always
+		accepted (see the overload-resolution finding).
+
+		:param normalizedIdentifier: The normalized (lower case) identifier being declared.
+		:param element:              The declared item.
+		:param overloadable:         ``True`` if this declaration may legally share its name.
+		"""
+		from pyVHDLModel.Subprogram import Function, Procedure
+
+		namespace = self
+		while namespace is not None:
+			existing = namespace._elements.get(normalizedIdentifier)
+			# `existing is element` means the region is being re-indexed, not that the name is declared twice.
+			isReindex = existing is element
+			isOverload = overloadable and isinstance(existing, (Function, Procedure))
+			if existing is not None and not isReindex and not isOverload:
+				WarningCollector.Raise(DuplicateDeclarationWarning(
+					f"Identifier '{normalizedIdentifier}' is already used for a declaration in '{namespace._name}'."
+				))
+				break
+
+			namespace = namespace._parentNamespace if namespace._sharesRegionWithParent else None
+
+		self._elements[normalizedIdentifier] = element
 
 	def Elements(self) -> Dict[K, O]:
 		return self._elements

--- a/pyVHDLModel/Namespace.py
+++ b/pyVHDLModel/Namespace.py
@@ -91,9 +91,9 @@ class Namespace(Generic[K, O]):
 	_parentNamespace: "Namespace"             #: Reference to the enclosing namespace, or ``None`` for the outermost one.
 	_subNamespaces:   Dict[str, "Namespace"]  #: Dictionary of all nested namespaces, indexed by name.
 	_elements:        Dict[K, O]              #: Dictionary of all elements declared in this namespace, indexed by name.
-	_sharesRegionWithParent: bool             #: ``True`` if the parent namespace is the same VHDL declarative region.
+	_sharesRegion:    bool                    #: ``True`` if the parent namespace is the same VHDL declarative region.
 
-	def __init__(self, name: str, parentNamespace: Nullable["Namespace"] = None) -> None:
+	def __init__(self, name: str, parentNamespace: Nullable["Namespace"] = None, sharesRegion: bool = False) -> None:
 		"""
 		Initializes a namespace.
 
@@ -104,7 +104,7 @@ class Namespace(Generic[K, O]):
 		self._parentNamespace = parentNamespace
 		self._subNamespaces = {}
 		self._elements = {}
-		self._sharesRegionWithParent = False
+		self._sharesRegion = sharesRegion
 
 	@readonly
 	def Name(self) -> str:
@@ -128,6 +128,20 @@ class Namespace(Generic[K, O]):
 	def ParentNamespace(self, value: 'Namespace') -> None:
 		self._parentNamespace = value
 		value._subNamespaces[self._name] = self
+
+	@readonly
+	def SharesRegion(self) -> bool:
+		"""
+		Read-only property to access whether this namespace continues its parent's declarative region
+		(:attr:`_sharesRegion`).
+
+		An entity and its architecture form one VHDL declarative region, as do a package and its body,
+		even though each owns a namespace. A duplicate declaration is reported across such a link, while a
+		genuinely nested region - a process, a block - hides instead.
+
+		:returns: ``True`` if the parent namespace is the same declarative region.
+		"""
+		return self._sharesRegion
 
 	@readonly
 	def SubNamespaces(self) -> Dict[str, 'Namespace']:
@@ -168,7 +182,7 @@ class Namespace(Generic[K, O]):
 				))
 				break
 
-			namespace = namespace._parentNamespace if namespace._sharesRegionWithParent else None
+			namespace = namespace._parentNamespace if namespace._sharesRegion else None
 
 		self._elements[normalizedIdentifier] = element
 

--- a/pyVHDLModel/Regions.py
+++ b/pyVHDLModel/Regions.py
@@ -80,19 +80,19 @@ class DeclarationRegionMixin(metaclass=ExtendedType, mixin=True):
 		"""Add this region's generics to its namespace."""
 		for item in self._genericItems:
 			for normalizedIdentifier in normalizedIdentifiersOf(item):
-				self._namespace._elements[normalizedIdentifier] = item
+				self._namespace.AddElement(normalizedIdentifier, item)
 
 	def _IndexPortItems(self) -> None:
 		"""Add this region's ports to its namespace."""
 		for item in self._portItems:
 			for normalizedIdentifier in normalizedIdentifiersOf(item):
-				self._namespace._elements[normalizedIdentifier] = item
+				self._namespace.AddElement(normalizedIdentifier, item)
 
 	def _IndexParameterItems(self) -> None:
 		"""Add this region's parameters to its namespace."""
 		for item in self._parameterItems:
 			for normalizedIdentifier in normalizedIdentifiersOf(item):
-				self._namespace._elements[normalizedIdentifier] = item
+				self._namespace.AddElement(normalizedIdentifier, item)
 
 	def _IndexOtherDeclaredItem(self, item) -> None:
 		"""Hook for declared items the region doesn't handle itself. Derived classes may override it."""
@@ -299,29 +299,29 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
 				self._types[item._normalizedIdentifier] = item
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item)
 			elif isinstance(item, Subtype):
 				self._subtypes[item._normalizedIdentifier] = item
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item)
 			elif isinstance(item, Function):
 				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
 				#        real overload resolution yet).
 				self._functions.setdefault(item._normalizedIdentifier, []).append(item)
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item, overloadable=True)
 			elif isinstance(item, Procedure):
 				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
 				#        real overload resolution yet).
 				self._procedures.setdefault(item._normalizedIdentifier, []).append(item)
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item, overloadable=True)
 			elif isinstance(item, Constant):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._constants[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 					# self._objects[normalizedIdentifier] = item
 			elif isinstance(item, Signal):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._signals[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 			elif isinstance(item, Variable):
 				# TODO: variables declared in a concurrent declaration region (e.g. shared variables outside a
 				#       protected type) are not yet indexed into a dedicated namespace/lookup table.
@@ -330,14 +330,14 @@ class ConcurrentDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 			elif isinstance(item, SharedVariable):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._sharedVariables[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 			elif isinstance(item, File):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._files[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 			elif isinstance(item, Component):
 				self._components[item._normalizedIdentifier] = item
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item)
 			else:
 				self._IndexOtherDeclaredItem(item)
 
@@ -497,32 +497,32 @@ class SequentialDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 		for item in self._declaredItems:
 			if isinstance(item, FullType):
 				self._types[item._normalizedIdentifier] = item
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item)
 			elif isinstance(item, Subtype):
 				self._subtypes[item._normalizedIdentifier] = item
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item)
 			elif isinstance(item, Function):
 				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
 				#        real overload resolution yet).
 				self._functions.setdefault(item._normalizedIdentifier, []).append(item)
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item, overloadable=True)
 			elif isinstance(item, Procedure):
 				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
 				#        real overload resolution yet).
 				self._procedures.setdefault(item._normalizedIdentifier, []).append(item)
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item, overloadable=True)
 			elif isinstance(item, Constant):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._constants[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 			elif isinstance(item, Variable):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._variables[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 			elif isinstance(item, File):
 				for normalizedIdentifier in item._normalizedIdentifiers:
 					self._files[normalizedIdentifier] = item
-					self._namespace._elements[normalizedIdentifier] = item
+					self._namespace.AddElement(normalizedIdentifier, item)
 			else:
 				self._IndexOtherDeclaredItem(item)
 
@@ -616,11 +616,11 @@ class ProtectedTypeDeclarationRegionMixin(DeclarationRegionMixin, mixin=True):
 				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
 				#        real overload resolution yet).
 				self._functions.setdefault(item._normalizedIdentifier, []).append(item)
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item, overloadable=True)
 			elif isinstance(item, Procedure):
 				# FIXME: overloads are only appended to a list, not matched/resolved by signature (no
 				#        real overload resolution yet).
 				self._procedures.setdefault(item._normalizedIdentifier, []).append(item)
-				self._namespace._elements[item._normalizedIdentifier] = item
+				self._namespace.AddElement(item._normalizedIdentifier, item, overloadable=True)
 			else:
 				self._IndexOtherDeclaredItem(item)

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -2409,7 +2409,6 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 				entity._architectures[architecture._normalizedIdentifier] = architecture
 				architecture._entity.Entity = entity
 				architecture._namespace._parentNamespace = entity._namespace
-				architecture._namespace._sharesRegionWithParent = True   # one declarative region (LRM 12.1)
 
 				# add "architecture -> entity" relation in dependency graph
 				dependency = architecture._dependencyVertex.EdgeToVertex(entity._dependencyVertex)
@@ -2446,7 +2445,6 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 			package._packageBody = packageBody    # TODO: add warning if package had already a body, which is now replaced
 			packageBody._package.Package = package
 			packageBody._namespace._parentNamespace = package._namespace
-			packageBody._namespace._sharesRegionWithParent = True   # one declarative region (LRM 12.1)
 
 			# add "package body -> package" relation in dependency graph
 			dependency = packageBody._dependencyVertex.EdgeToVertex(package._dependencyVertex)

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -2409,6 +2409,7 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 				entity._architectures[architecture._normalizedIdentifier] = architecture
 				architecture._entity.Entity = entity
 				architecture._namespace._parentNamespace = entity._namespace
+				architecture._namespace._sharesRegionWithParent = True   # one declarative region (LRM 12.1)
 
 				# add "architecture -> entity" relation in dependency graph
 				dependency = architecture._dependencyVertex.EdgeToVertex(entity._dependencyVertex)
@@ -2445,6 +2446,7 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 			package._packageBody = packageBody    # TODO: add warning if package had already a body, which is now replaced
 			packageBody._package.Package = package
 			packageBody._namespace._parentNamespace = package._namespace
+			packageBody._namespace._sharesRegionWithParent = True   # one declarative region (LRM 12.1)
 
 			# add "package body -> package" relation in dependency graph
 			dependency = packageBody._dependencyVertex.EdgeToVertex(package._dependencyVertex)

--- a/tests/unit/Instantiation/Assignment.py
+++ b/tests/unit/Instantiation/Assignment.py
@@ -49,19 +49,13 @@ from pyVHDLModel.Sequential  import (
 	SignalForceAssignment, SignalReleaseAssignment,
 )
 
+from tests.unit             import _signalSymbol, _variableSymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _signalTarget() -> SignalSymbol:
-	return SignalSymbol(SimpleName("s"))
-
-
-def _variableTarget() -> VariableSymbol:
-	return VariableSymbol(SimpleName("v"))
 
 
 class ConditionalAndSelectedBuildingBlocks(TestCase):
@@ -124,7 +118,7 @@ class ConcurrentAssignments(TestCase):
 		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
 		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = ConcurrentConditionalSignalAssignment("lbl", _signalTarget(), [cw1, cw2])
+		assignment = ConcurrentConditionalSignalAssignment("lbl", _signalSymbol(), [cw1, cw2])
 
 		self.assertEqual(2, len(assignment.ConditionalWaveforms))
 		self.assertIsNone(assignment.ConditionalWaveforms[-1].Condition)
@@ -134,7 +128,7 @@ class ConcurrentAssignments(TestCase):
 		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
 		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = ConcurrentSelectedSignalAssignment("lbl", _signalTarget(), IntegerLiteral(0), [sw, osw])
+		assignment = ConcurrentSelectedSignalAssignment("lbl", _signalSymbol(), IntegerLiteral(0), [sw, osw])
 
 		self.assertEqual(2, len(assignment.SelectedWaveforms))
 
@@ -142,7 +136,7 @@ class ConcurrentAssignments(TestCase):
 class SequentialAssignments(TestCase):
 	def test_SimpleVariableAssignment(self) -> None:
 		"""``v := '1';``"""
-		assignment = SequentialVariableAssignment(_variableTarget(), CharacterLiteral("'1'"))
+		assignment = SequentialVariableAssignment(_variableSymbol(), CharacterLiteral("'1'"))
 
 		self.assertEqual("'1'", str(assignment.Expression))
 
@@ -151,7 +145,7 @@ class SequentialAssignments(TestCase):
 		ce1 = ConditionalExpression(CharacterLiteral("'1'"), IntegerLiteral(1))
 		ce2 = ConditionalExpression(CharacterLiteral("'0'"))
 
-		assignment = SequentialConditionalVariableAssignment(_variableTarget(), [ce1, ce2])
+		assignment = SequentialConditionalVariableAssignment(_variableSymbol(), [ce1, ce2])
 
 		self.assertEqual(2, len(assignment.ConditionalExpressions))
 		self.assertIsNotNone(assignment.Target)
@@ -161,7 +155,7 @@ class SequentialAssignments(TestCase):
 		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
 		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = SequentialConditionalSignalAssignment(_signalTarget(), [cw1, cw2])
+		assignment = SequentialConditionalSignalAssignment(_signalSymbol(), [cw1, cw2])
 
 		self.assertEqual(2, len(assignment.ConditionalWaveforms))
 
@@ -170,7 +164,7 @@ class SequentialAssignments(TestCase):
 		se = SelectedExpression([IndexedChoice(IntegerLiteral(0))], CharacterLiteral("'1'"))
 		ose = OthersSelectedExpression(CharacterLiteral("'0'"))
 
-		assignment = SequentialSelectedVariableAssignment(_variableTarget(), IntegerLiteral(0), [se, ose])
+		assignment = SequentialSelectedVariableAssignment(_variableSymbol(), IntegerLiteral(0), [se, ose])
 
 		self.assertEqual(2, len(assignment.SelectedExpressions))
 
@@ -179,18 +173,18 @@ class SequentialAssignments(TestCase):
 		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
 		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = SequentialSelectedSignalAssignment(_signalTarget(), IntegerLiteral(0), [sw, osw])
+		assignment = SequentialSelectedSignalAssignment(_signalSymbol(), IntegerLiteral(0), [sw, osw])
 
 		self.assertEqual(2, len(assignment.SelectedWaveforms))
 
 	def test_SignalForceAssignment(self) -> None:
 		"""``s <= force '1';`` (VHDL-2008)"""
-		assignment = SignalForceAssignment(_signalTarget(), CharacterLiteral("'1'"))
+		assignment = SignalForceAssignment(_signalSymbol(), CharacterLiteral("'1'"))
 
 		self.assertEqual("'1'", str(assignment.Expression))
 
 	def test_SignalReleaseAssignment(self) -> None:
 		"""``s <= release;`` (VHDL-2008) - no expression at all."""
-		assignment = SignalReleaseAssignment(_signalTarget())
+		assignment = SignalReleaseAssignment(_signalSymbol())
 
 		self.assertIsNotNone(assignment.Target)

--- a/tests/unit/Instantiation/Assignment.py
+++ b/tests/unit/Instantiation/Assignment.py
@@ -49,7 +49,7 @@ from pyVHDLModel.Sequential  import (
 	SignalForceAssignment, SignalReleaseAssignment,
 )
 
-from tests.unit             import _signalSymbol, _variableSymbol
+from tests.unit              import _signalSymbol, _variableSymbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -118,7 +118,7 @@ class ConcurrentAssignments(TestCase):
 		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
 		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = ConcurrentConditionalSignalAssignment("lbl", _signalSymbol(), [cw1, cw2])
+		assignment = ConcurrentConditionalSignalAssignment("lbl", _signalSymbol("s"), [cw1, cw2])
 
 		self.assertEqual(2, len(assignment.ConditionalWaveforms))
 		self.assertIsNone(assignment.ConditionalWaveforms[-1].Condition)
@@ -128,7 +128,7 @@ class ConcurrentAssignments(TestCase):
 		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
 		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = ConcurrentSelectedSignalAssignment("lbl", _signalSymbol(), IntegerLiteral(0), [sw, osw])
+		assignment = ConcurrentSelectedSignalAssignment("lbl", _signalSymbol("s"), IntegerLiteral(0), [sw, osw])
 
 		self.assertEqual(2, len(assignment.SelectedWaveforms))
 
@@ -136,7 +136,7 @@ class ConcurrentAssignments(TestCase):
 class SequentialAssignments(TestCase):
 	def test_SimpleVariableAssignment(self) -> None:
 		"""``v := '1';``"""
-		assignment = SequentialVariableAssignment(_variableSymbol(), CharacterLiteral("'1'"))
+		assignment = SequentialVariableAssignment(_variableSymbol("v"), CharacterLiteral("'1'"))
 
 		self.assertEqual("'1'", str(assignment.Expression))
 
@@ -145,7 +145,7 @@ class SequentialAssignments(TestCase):
 		ce1 = ConditionalExpression(CharacterLiteral("'1'"), IntegerLiteral(1))
 		ce2 = ConditionalExpression(CharacterLiteral("'0'"))
 
-		assignment = SequentialConditionalVariableAssignment(_variableSymbol(), [ce1, ce2])
+		assignment = SequentialConditionalVariableAssignment(_variableSymbol("v"), [ce1, ce2])
 
 		self.assertEqual(2, len(assignment.ConditionalExpressions))
 		self.assertIsNotNone(assignment.Target)
@@ -155,7 +155,7 @@ class SequentialAssignments(TestCase):
 		cw1 = ConditionalWaveform([WaveformElement(CharacterLiteral("'1'"))], IntegerLiteral(1))
 		cw2 = ConditionalWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = SequentialConditionalSignalAssignment(_signalSymbol(), [cw1, cw2])
+		assignment = SequentialConditionalSignalAssignment(_signalSymbol("s"), [cw1, cw2])
 
 		self.assertEqual(2, len(assignment.ConditionalWaveforms))
 
@@ -164,7 +164,7 @@ class SequentialAssignments(TestCase):
 		se = SelectedExpression([IndexedChoice(IntegerLiteral(0))], CharacterLiteral("'1'"))
 		ose = OthersSelectedExpression(CharacterLiteral("'0'"))
 
-		assignment = SequentialSelectedVariableAssignment(_variableSymbol(), IntegerLiteral(0), [se, ose])
+		assignment = SequentialSelectedVariableAssignment(_variableSymbol("v"), IntegerLiteral(0), [se, ose])
 
 		self.assertEqual(2, len(assignment.SelectedExpressions))
 
@@ -173,18 +173,18 @@ class SequentialAssignments(TestCase):
 		sw = SelectedWaveform([IndexedChoice(IntegerLiteral(0))], [WaveformElement(CharacterLiteral("'1'"))])
 		osw = OthersSelectedWaveform([WaveformElement(CharacterLiteral("'0'"))])
 
-		assignment = SequentialSelectedSignalAssignment(_signalSymbol(), IntegerLiteral(0), [sw, osw])
+		assignment = SequentialSelectedSignalAssignment(_signalSymbol("s"), IntegerLiteral(0), [sw, osw])
 
 		self.assertEqual(2, len(assignment.SelectedWaveforms))
 
 	def test_SignalForceAssignment(self) -> None:
 		"""``s <= force '1';`` (VHDL-2008)"""
-		assignment = SignalForceAssignment(_signalSymbol(), CharacterLiteral("'1'"))
+		assignment = SignalForceAssignment(_signalSymbol("s"), CharacterLiteral("'1'"))
 
 		self.assertEqual("'1'", str(assignment.Expression))
 
 	def test_SignalReleaseAssignment(self) -> None:
 		"""``s <= release;`` (VHDL-2008) - no expression at all."""
-		assignment = SignalReleaseAssignment(_signalSymbol())
+		assignment = SignalReleaseAssignment(_signalSymbol("s"))
 
 		self.assertIsNotNone(assignment.Target)

--- a/tests/unit/Instantiation/Concurrent.py
+++ b/tests/unit/Instantiation/Concurrent.py
@@ -54,15 +54,13 @@ from pyVHDLModel.Concurrent  import (
 	ForGenerateStatement, ConcurrentSimpleSignalAssignment, ConcurrentAssertStatement,
 )
 
+from tests.unit             import _entitySymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _entitySymbol(name: str = "e") -> EntitySymbol:
-	return EntitySymbol(SimpleName(name))
 
 
 class Instantiations(TestCase):

--- a/tests/unit/Instantiation/Concurrent.py
+++ b/tests/unit/Instantiation/Concurrent.py
@@ -54,7 +54,7 @@ from pyVHDLModel.Concurrent  import (
 	ForGenerateStatement, ConcurrentSimpleSignalAssignment, ConcurrentAssertStatement,
 )
 
-from tests.unit             import _entitySymbol
+from tests.unit              import _entitySymbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -321,7 +321,7 @@ class ConcurrentStatementsMixinIndexing(TestCase):
 	def test_IndexStatements_BucketsByKind(self) -> None:
 		"""Blocks and generates both land in the single, unified ``_hierarchy`` dict (in source/
 		declaration order), not separate per-kind dicts."""
-		entitySymbol = _entitySymbol()
+		entitySymbol = _entitySymbol("e")
 		instance = ComponentInstantiation("inst", ComponentInstantiationSymbol(SimpleName("comp")))
 		block = ConcurrentBlockStatement("blk")
 		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
@@ -336,7 +336,7 @@ class ConcurrentStatementsMixinIndexing(TestCase):
 		self.assertEqual(["blk", "gen"], list(architecture._hierarchy.keys()))
 
 	def test_IterateInstantiations_RecursesIntoBlocksAndGenerates(self) -> None:
-		entitySymbol = _entitySymbol()
+		entitySymbol = _entitySymbol("e")
 		nestedInstance = ComponentInstantiation("nested_inst", ComponentInstantiationSymbol(SimpleName("comp")))
 		block = ConcurrentBlockStatement("blk", statements=[nestedInstance])
 

--- a/tests/unit/Instantiation/DesignUnit.py
+++ b/tests/unit/Instantiation/DesignUnit.py
@@ -52,15 +52,13 @@ from pyVHDLModel.DesignUnit import (
 	Package, PackageBody, Entity, Architecture, Component, Configuration,
 )
 
+from tests.unit             import _entitySymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _entitySymbol(name: str = "ent") -> EntitySymbol:
-	return EntitySymbol(SimpleName(name))
 
 
 class References(TestCase):
@@ -241,7 +239,7 @@ class Entities(TestCase):
 
 class Architectures(TestCase):
 	def test_Minimal(self) -> None:
-		entitySymbol = _entitySymbol()
+		entitySymbol = _entitySymbol("ent")
 		architecture = Architecture("rtl", entitySymbol)
 
 		self.assertIs(entitySymbol, architecture.Entity)
@@ -250,7 +248,7 @@ class Architectures(TestCase):
 		self.assertEqual(0, len(architecture.Statements))
 
 	def test_RegionStartsEmpty(self) -> None:
-		architecture = Architecture("rtl", _entitySymbol())
+		architecture = Architecture("rtl", _entitySymbol("ent"))
 
 		self.assertEqual(0, len(architecture.Types))
 		self.assertEqual(0, len(architecture.Subtypes))
@@ -273,7 +271,7 @@ class Architectures(TestCase):
 		procedure = Procedure("p_proc")
 
 		architecture = Architecture(
-			"rtl", _entitySymbol(),
+			"rtl", _entitySymbol("ent"),
 			declaredItems=[fullType, subtype, constant, signal, sharedVariable, file, function, procedure],
 		)
 		architecture.IndexDeclaredItems()
@@ -294,7 +292,7 @@ class Architectures(TestCase):
 		concurrent declaration region raise a warning instead of being indexed anywhere - locked in as
 		current behaviour, not a regression."""
 		variable = Variable(["v"], SimpleSubtypeSymbol(SimpleName("natural")))
-		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[variable])
+		architecture = Architecture("rtl", _entitySymbol("ent"), declaredItems=[variable])
 
 		architecture.IndexDeclaredItems()  # must not raise, only warn
 
@@ -311,7 +309,7 @@ class Architectures(TestCase):
 		overload found under a given name, unresolved."""
 		overload1 = Function("f", SimpleSubtypeSymbol(SimpleName("integer")))
 		overload2 = Function("f", SimpleSubtypeSymbol(SimpleName("boolean")))
-		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[overload1, overload2])
+		architecture = Architecture("rtl", _entitySymbol("ent"), declaredItems=[overload1, overload2])
 		architecture.IndexDeclaredItems()
 
 		self.assertEqual(1, len(architecture.Functions))
@@ -321,7 +319,7 @@ class Architectures(TestCase):
 		"""Same as above, but for procedures."""
 		overload1 = Procedure("p")
 		overload2 = Procedure("p")
-		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[overload1, overload2])
+		architecture = Architecture("rtl", _entitySymbol("ent"), declaredItems=[overload1, overload2])
 		architecture.IndexDeclaredItems()
 
 		self.assertEqual(1, len(architecture.Procedures))
@@ -372,7 +370,7 @@ class Configurations(TestCase):
 		from pyVHDLModel.Configuration import BlockConfiguration
 		from pyVHDLModel.Symbol import Symbol, PossibleReference
 
-		entitySymbol = _entitySymbol()
+		entitySymbol = _entitySymbol("ent")
 		blockSpec = Symbol(SimpleName("rtl"), PossibleReference.Architecture | PossibleReference.Label)
 		blockConfiguration = BlockConfiguration(blockSpec)
 		configuration = Configuration("cfg", entitySymbol, blockConfiguration)

--- a/tests/unit/Instantiation/Interface.py
+++ b/tests/unit/Instantiation/Interface.py
@@ -48,9 +48,7 @@ from pyVHDLModel.Interface  import (
 	InterfaceGroup, GenericGroup, PortGroup, ParameterGroup,
 )
 
-
-def _subtype(name: str = "bit") -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName(name))
+from tests.unit             import _subtypeSymbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -162,7 +160,7 @@ class GenericInterfaceItems(TestCase):
 	def test_GenericConstantInterfaceItem(self) -> None:
 		"""``generic (G : positive := 8);``"""
 		default = IntegerLiteral(8)
-		item = GenericConstantInterfaceItem(["G"], Mode.In, _subtype("positive"), defaultExpression=default)
+		item = GenericConstantInterfaceItem(["G"], Mode.In, _subtypeSymbol("positive"), defaultExpression=default)
 
 		self.assertEqual(("G",), item.Identifiers)
 		self.assertIs(Mode.In, item.Mode)
@@ -201,7 +199,7 @@ class GenericInterfaceItems(TestCase):
 		anything but a real ``Symbol`` (including the plain, no-docs case, since ``None`` has no
 		``Parent`` either). Fixed by adding a real ``returnType`` parameter and forwarding
 		``documentation``/``parent`` as keyword arguments."""
-		returnType = _subtype("boolean")
+		returnType = _subtypeSymbol("boolean")
 		item = GenericFunctionInterfaceItem("func", returnType)
 
 		self.assertEqual("func", item.Identifier)
@@ -219,19 +217,19 @@ class GenericInterfaceItems(TestCase):
 class ParameterInterfaceItems(TestCase):
 	def test_ParameterConstantInterfaceItem(self) -> None:
 		"""``procedure proc(constant c : in natural);``"""
-		item = ParameterConstantInterfaceItem(["c"], Mode.In, _subtype("natural"))
+		item = ParameterConstantInterfaceItem(["c"], Mode.In, _subtypeSymbol("natural"))
 
 		self.assertIs(Mode.In, item.Mode)
 
 	def test_ParameterVariableInterfaceItem(self) -> None:
 		"""``procedure proc(variable v : inout natural);``"""
-		item = ParameterVariableInterfaceItem(["v"], Mode.InOut, _subtype("natural"))
+		item = ParameterVariableInterfaceItem(["v"], Mode.InOut, _subtypeSymbol("natural"))
 
 		self.assertIs(Mode.InOut, item.Mode)
 
 	def test_ParameterFileInterfaceItem(self) -> None:
 		"""``procedure proc(file f : text);``"""
-		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+		item = ParameterFileInterfaceItem(["f"], _subtypeSymbol("text"))
 
 		self.assertEqual(("f",), item.Identifiers)
 
@@ -246,7 +244,7 @@ class ParameterInterfaceItems(TestCase):
 		call: every concrete interface item is already a documentable entity via its primary base
 		(constant, signal, variable, file, type, subprogram, or package), so the mixin never needed to
 		carry documentation of its own."""
-		item = ParameterConstantInterfaceItem(["c"], Mode.In, _subtype("natural"), documentation="some documentation")
+		item = ParameterConstantInterfaceItem(["c"], Mode.In, _subtypeSymbol("natural"), documentation="some documentation")
 
 		self.assertEqual("some documentation", item.Documentation)
 
@@ -271,7 +269,7 @@ class WithGenericsPortsParametersMixins(TestCase):
 		class _Host(WithPortsMixin):
 			pass
 
-		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
+		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtypeSymbol("bit"))
 		host = _Host([item])
 
 		self.assertEqual(1, host.PortCount)
@@ -280,7 +278,7 @@ class WithGenericsPortsParametersMixins(TestCase):
 		class _Host(WithParametersMixin):
 			pass
 
-		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+		item = ParameterFileInterfaceItem(["f"], _subtypeSymbol("text"))
 		host = _Host([item])
 
 		self.assertEqual(1, host.ParameterCount)
@@ -324,13 +322,13 @@ class Groups(TestCase):
 		``NamedEntityMixin``-based item (``GenericTypeInterfaceItem``) with a
 		``MultipleNamedEntityMixin``-based one (``GenericConstantInterfaceItem``)."""
 		typeItem = GenericTypeInterfaceItem("T")
-		constantItem = GenericConstantInterfaceItem(["G"], Mode.In, _subtype("positive"))
+		constantItem = GenericConstantInterfaceItem(["G"], Mode.In, _subtypeSymbol("positive"))
 		group = GenericGroup([typeItem, constantItem])
 
 		self.assertEqual("GenericGroup: None (2): T, G", str(group))
 
 	def test_PortGroup(self) -> None:
-		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())
+		item = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtypeSymbol("bit"))
 		group = PortGroup([item], name="ports")
 
 		self.assertEqual(1, len(group))
@@ -339,13 +337,13 @@ class Groups(TestCase):
 
 	def test_PortGroup_MultipleIdentifiersPerItem(self) -> None:
 		"""``port (p1, p2 : in bit);`` - one declaration, two port names."""
-		item = PortSimpleSignalInterfaceItem(["p1", "p2"], Mode.In, _subtype())
+		item = PortSimpleSignalInterfaceItem(["p1", "p2"], Mode.In, _subtypeSymbol("bit"))
 		group = PortGroup([item])
 
 		self.assertEqual("PortGroup: None (1): p1, p2", str(group))
 
 	def test_ParameterGroup(self) -> None:
-		item = ParameterFileInterfaceItem(["f"], _subtype("text"))
+		item = ParameterFileInterfaceItem(["f"], _subtypeSymbol("text"))
 		group = ParameterGroup([item], name="parameters")
 
 		self.assertEqual(1, len(group))

--- a/tests/unit/Instantiation/Object.py
+++ b/tests/unit/Instantiation/Object.py
@@ -51,7 +51,7 @@ class ObjBaseBehaviour(TestCase):
 	``Signal`` - any ``Obj`` subclass would do equally well, since none of this is overridden."""
 
 	def test_SingleIdentifier(self) -> None:
-		subtype = _subtypeSymbol()
+		subtype = _subtypeSymbol("natural")
 		signal = Signal(["s"], subtype)
 
 		self.assertEqual(("s",), signal.Identifiers)
@@ -69,17 +69,17 @@ class ObjBaseBehaviour(TestCase):
 	def test_ObjectVertexDefaultsToNone(self) -> None:
 		"""``ObjectVertex`` is only populated once an object graph is built elsewhere; a freshly
 		constructed object was never inserted into one."""
-		signal = Signal(["s"], _subtypeSymbol())
+		signal = Signal(["s"], _subtypeSymbol("natural"))
 
 		self.assertIsNone(signal.ObjectVertex)
 
 	def test_Documentation(self) -> None:
-		signal = Signal(["s"], _subtypeSymbol(), documentation="a signal")
+		signal = Signal(["s"], _subtypeSymbol("natural"), documentation="a signal")
 
 		self.assertEqual("a signal", signal.Documentation)
 
 	def test_NoDocumentation(self) -> None:
-		signal = Signal(["s"], _subtypeSymbol())
+		signal = Signal(["s"], _subtypeSymbol("natural"))
 
 		self.assertIsNone(signal.Documentation)
 
@@ -91,13 +91,13 @@ class WithDefaultExpression(TestCase):
 
 	def test_WithDefaultExpression(self) -> None:
 		default = IntegerLiteral(0)
-		signal = Signal(["s"], _subtypeSymbol(), defaultExpression=default)
+		signal = Signal(["s"], _subtypeSymbol("natural"), defaultExpression=default)
 
 		self.assertIs(default, signal.DefaultExpression)
 		self.assertIs(signal, default.Parent)
 
 	def test_WithoutDefaultExpression(self) -> None:
-		signal = Signal(["s"], _subtypeSymbol())
+		signal = Signal(["s"], _subtypeSymbol("natural"))
 
 		self.assertIsNone(signal.DefaultExpression)
 

--- a/tests/unit/Instantiation/Object.py
+++ b/tests/unit/Instantiation/Object.py
@@ -36,15 +36,13 @@ from pyVHDLModel.Symbol     import SimpleSubtypeSymbol
 from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Object     import Constant, DeferredConstant, Variable, Signal, SharedVariable, File
 
+from tests.unit             import _subtypeSymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _subtype(name: str = "natural") -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName(name))
 
 
 class ObjBaseBehaviour(TestCase):
@@ -53,7 +51,7 @@ class ObjBaseBehaviour(TestCase):
 	``Signal`` - any ``Obj`` subclass would do equally well, since none of this is overridden."""
 
 	def test_SingleIdentifier(self) -> None:
-		subtype = _subtype()
+		subtype = _subtypeSymbol()
 		signal = Signal(["s"], subtype)
 
 		self.assertEqual(("s",), signal.Identifiers)
@@ -63,7 +61,7 @@ class ObjBaseBehaviour(TestCase):
 
 	def test_MultipleIdentifiers(self) -> None:
 		"""``signal a, b, C : bit;`` declares three signals from one declaration."""
-		signal = Signal(["a", "b", "C"], _subtype("bit"))
+		signal = Signal(["a", "b", "C"], _subtypeSymbol("bit"))
 
 		self.assertEqual(("a", "b", "C"), signal.Identifiers)
 		self.assertEqual(("a", "b", "c"), signal.NormalizedIdentifiers)
@@ -71,17 +69,17 @@ class ObjBaseBehaviour(TestCase):
 	def test_ObjectVertexDefaultsToNone(self) -> None:
 		"""``ObjectVertex`` is only populated once an object graph is built elsewhere; a freshly
 		constructed object was never inserted into one."""
-		signal = Signal(["s"], _subtype())
+		signal = Signal(["s"], _subtypeSymbol())
 
 		self.assertIsNone(signal.ObjectVertex)
 
 	def test_Documentation(self) -> None:
-		signal = Signal(["s"], _subtype(), documentation="a signal")
+		signal = Signal(["s"], _subtypeSymbol(), documentation="a signal")
 
 		self.assertEqual("a signal", signal.Documentation)
 
 	def test_NoDocumentation(self) -> None:
-		signal = Signal(["s"], _subtype())
+		signal = Signal(["s"], _subtypeSymbol())
 
 		self.assertIsNone(signal.Documentation)
 
@@ -93,13 +91,13 @@ class WithDefaultExpression(TestCase):
 
 	def test_WithDefaultExpression(self) -> None:
 		default = IntegerLiteral(0)
-		signal = Signal(["s"], _subtype(), defaultExpression=default)
+		signal = Signal(["s"], _subtypeSymbol(), defaultExpression=default)
 
 		self.assertIs(default, signal.DefaultExpression)
 		self.assertIs(signal, default.Parent)
 
 	def test_WithoutDefaultExpression(self) -> None:
-		signal = Signal(["s"], _subtype())
+		signal = Signal(["s"], _subtypeSymbol())
 
 		self.assertIsNone(signal.DefaultExpression)
 
@@ -107,7 +105,7 @@ class WithDefaultExpression(TestCase):
 class Constants(TestCase):
 	def test_WithDefault(self) -> None:
 		default = IntegerLiteral(8)
-		constant = Constant(["BITS"], _subtype("positive"), defaultExpression=default)
+		constant = Constant(["BITS"], _subtypeSymbol("positive"), defaultExpression=default)
 
 		self.assertEqual(("BITS",), constant.Identifiers)
 		self.assertIs(default, constant.DefaultExpression)
@@ -115,7 +113,7 @@ class Constants(TestCase):
 	def test_WithoutDefault(self) -> None:
 		"""Constructible without a default even though real VHDL always requires one for a (non-
 		deferred) constant - the model doesn't enforce that grammar rule itself."""
-		constant = Constant(["BITS"], _subtype("positive"))
+		constant = Constant(["BITS"], _subtypeSymbol("positive"))
 
 		self.assertIsNone(constant.DefaultExpression)
 
@@ -124,7 +122,7 @@ class DeferredConstants(TestCase):
 	"""``constant BITS : positive;`` (in a package declaration, completed later in the package body)."""
 
 	def test_Construction(self) -> None:
-		constant = DeferredConstant(["BITS"], _subtype("positive"))
+		constant = DeferredConstant(["BITS"], _subtypeSymbol("positive"))
 
 		self.assertEqual(("BITS",), constant.Identifiers)
 		self.assertIsNone(constant.ConstantReference)
@@ -136,12 +134,12 @@ class DeferredConstants(TestCase):
 class Variables(TestCase):
 	def test_WithDefault(self) -> None:
 		default = IntegerLiteral(0)
-		variable = Variable(["result"], _subtype("natural"), defaultExpression=default)
+		variable = Variable(["result"], _subtypeSymbol("natural"), defaultExpression=default)
 
 		self.assertIs(default, variable.DefaultExpression)
 
 	def test_WithoutDefault(self) -> None:
-		variable = Variable(["result"], _subtype("natural"))
+		variable = Variable(["result"], _subtypeSymbol("natural"))
 
 		self.assertIsNone(variable.DefaultExpression)
 
@@ -149,12 +147,12 @@ class Variables(TestCase):
 class Signals(TestCase):
 	def test_WithDefault(self) -> None:
 		default = IntegerLiteral(0)
-		signal = Signal(["counter"], _subtype("unsigned"), defaultExpression=default)
+		signal = Signal(["counter"], _subtypeSymbol("unsigned"), defaultExpression=default)
 
 		self.assertIs(default, signal.DefaultExpression)
 
 	def test_WithoutDefault(self) -> None:
-		signal = Signal(["counter"], _subtype("unsigned"))
+		signal = Signal(["counter"], _subtypeSymbol("unsigned"))
 
 		self.assertIsNone(signal.DefaultExpression)
 
@@ -164,7 +162,7 @@ class SharedVariables(TestCase):
 	the class docstring)."""
 
 	def test_Construction(self) -> None:
-		variable = SharedVariable(["v"], _subtype("natural"))
+		variable = SharedVariable(["v"], _subtypeSymbol("natural"))
 
 		self.assertEqual(("v",), variable.Identifiers)
 		self.assertIs(SharedVariable, type(variable))
@@ -175,6 +173,6 @@ class Files(TestCase):
 	docstring); open-mode/logical-name are not modelled at all yet."""
 
 	def test_Construction(self) -> None:
-		file = File(["f"], _subtype("text"))
+		file = File(["f"], _subtypeSymbol("text"))
 
 		self.assertEqual(("f",), file.Identifiers)

--- a/tests/unit/Instantiation/Sequential.py
+++ b/tests/unit/Instantiation/Sequential.py
@@ -49,7 +49,7 @@ from pyVHDLModel.Sequential  import (
 )
 from pyVHDLModel.Base        import WaveformElement
 
-from tests.unit             import _signalSymbol
+from tests.unit              import _signalSymbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -82,7 +82,7 @@ class SequentialProcedureCalls(TestCase):
 
 class SequentialSignalAssignments(TestCase):
 	def test_Construction(self) -> None:
-		target = _signalSymbol()
+		target = _signalSymbol("s")
 		assignment = SequentialSignalAssignment(target, label="lbl")
 
 		self.assertIs(target, assignment.Target)
@@ -93,7 +93,7 @@ class SequentialSignalAssignments(TestCase):
 class SequentialSimpleSignalAssignments(TestCase):
 	def test_Construction(self) -> None:
 		"""``s <= '1';``"""
-		target = _signalSymbol()
+		target = _signalSymbol("s")
 		waveformElement = WaveformElement(CharacterLiteral("'1'"))
 		assignment = SequentialSimpleSignalAssignment(target, [waveformElement])
 

--- a/tests/unit/Instantiation/Sequential.py
+++ b/tests/unit/Instantiation/Sequential.py
@@ -49,15 +49,13 @@ from pyVHDLModel.Sequential  import (
 )
 from pyVHDLModel.Base        import WaveformElement
 
+from tests.unit             import _signalSymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _signalTarget(name: str = "s") -> SignalSymbol:
-	return SignalSymbol(SimpleName(name))
 
 
 class SequentialProcedureCalls(TestCase):
@@ -84,7 +82,7 @@ class SequentialProcedureCalls(TestCase):
 
 class SequentialSignalAssignments(TestCase):
 	def test_Construction(self) -> None:
-		target = _signalTarget()
+		target = _signalSymbol()
 		assignment = SequentialSignalAssignment(target, label="lbl")
 
 		self.assertIs(target, assignment.Target)
@@ -95,7 +93,7 @@ class SequentialSignalAssignments(TestCase):
 class SequentialSimpleSignalAssignments(TestCase):
 	def test_Construction(self) -> None:
 		"""``s <= '1';``"""
-		target = _signalTarget()
+		target = _signalSymbol()
 		waveformElement = WaveformElement(CharacterLiteral("'1'"))
 		assignment = SequentialSimpleSignalAssignment(target, [waveformElement])
 
@@ -261,7 +259,7 @@ class WaitStatements(TestCase):
 
 	def test_Full(self) -> None:
 		"""``wait on clock until condition for 10 ns;``"""
-		sensitivitySignal = _signalTarget("clock")
+		sensitivitySignal = _signalSymbol("clock")
 		condition = IntegerLiteral(1)
 		timeout = PhysicalIntegerLiteral(10, "ns")
 		statement = WaitStatement([sensitivitySignal], condition, timeout)

--- a/tests/unit/Instantiation/Type.py
+++ b/tests/unit/Instantiation/Type.py
@@ -44,15 +44,13 @@ from pyVHDLModel.Type       import (
 	AccessType, FileType,
 )
 
+from tests.unit             import _subtypeSymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName(name))
 
 
 def _range(left: int = 0, right: int = 15, direction: Direction = Direction.To) -> SimpleRange:

--- a/tests/unit/Instantiation/Type.py
+++ b/tests/unit/Instantiation/Type.py
@@ -86,17 +86,17 @@ class ParentAndDocumentationWiringAcrossAllLeafTypes(TestCase):
 	def test_AllLeafTypes(self) -> None:
 		parent = ModelEntity()
 		builders = (
-			("Subtype", lambda: Subtype("t", _subtypeSymbol(), "doc", parent)),
+			("Subtype", lambda: Subtype("t", _subtypeSymbol("natural"), "doc", parent)),
 			("EnumeratedType", lambda: EnumeratedType("t", [], "doc", parent)),
 			("IntegerType", lambda: IntegerType("t", _range(), "doc", parent)),
 			("RealType", lambda: RealType("t", _range(), "doc", parent)),
 			("PhysicalType", lambda: PhysicalType("t", _range(), "ps", [], "doc", parent)),
-			("ArrayType", lambda: ArrayType("t", [], _subtypeSymbol(), "doc", parent)),
+			("ArrayType", lambda: ArrayType("t", [], _subtypeSymbol("natural"), "doc", parent)),
 			("RecordType", lambda: RecordType("t", None, "doc", parent)),
 			("ProtectedType", lambda: ProtectedType("t", None, "doc", parent)),
 			("ProtectedTypeBody", lambda: ProtectedTypeBody("t", None, "doc", parent)),
-			("AccessType", lambda: AccessType("t", _subtypeSymbol(), "doc", parent)),
-			("FileType", lambda: FileType("t", _subtypeSymbol(), "doc", parent)),
+			("AccessType", lambda: AccessType("t", _subtypeSymbol("natural"), "doc", parent)),
+			("FileType", lambda: FileType("t", _subtypeSymbol("natural"), "doc", parent)),
 		)
 		for name, build in builders:
 			with self.subTest(type=name):

--- a/tests/unit/Namespace/DesignUnits.py
+++ b/tests/unit/Namespace/DesignUnits.py
@@ -36,15 +36,13 @@ from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Object     import Constant
 from pyVHDLModel.Symbol     import EntitySymbol, SimpleSubtypeSymbol
 
+from tests.unit             import _entitySymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _entitySymbol(name: str = "e") -> EntitySymbol:
-	return EntitySymbol(SimpleName(name))
 
 
 class Architectures(TestCase):

--- a/tests/unit/Namespace/DesignUnits.py
+++ b/tests/unit/Namespace/DesignUnits.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":  # pragma: no cover
 class Architectures(TestCase):
 	def test_IndexDeclaredItems_AlsoPopulatesNamespace(self) -> None:
 		constant = Constant(["C"], SimpleSubtypeSymbol(SimpleName("natural")))
-		architecture = Architecture("rtl", _entitySymbol(), declaredItems=[constant])
+		architecture = Architecture("rtl", _entitySymbol("e"), declaredItems=[constant])
 		architecture.IndexDeclaredItems()
 
 		# Keyed by the normalized identifier, which is what the Find* methods look up.

--- a/tests/unit/Namespace/Duplicates.py
+++ b/tests/unit/Namespace/Duplicates.py
@@ -1,0 +1,209 @@
+# ==================================================================================================================== #
+#             __     ___   _ ____  _     __  __           _      _                                                     #
+#   _ __  _   \ \   / / | | |  _ \| |   |  \/  | ___   __| | ___| |                                                    #
+#  | '_ \| | | \ \ / /| |_| | | | | |   | |\/| |/ _ \ / _` |/ _ \ |                                                    #
+#  | |_) | |_| |\ V / |  _  | |_| | |___| |  | | (_) | (_| |  __/ |                                                    #
+#  | .__/ \__, | \_/  |_| |_|____/|_____|_|  |_|\___/ \__,_|\___|_|                                                    #
+#  |_|    |___/                                                                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Duplicate declarations: the same identifier declared **twice in one declarative region**.
+
+This is not hiding. VHDL rejects it as *identifier already used for a declaration*, and a declarative
+region can span more than one namespace in this model - an entity and its architecture are one region,
+as are a package and its body - so the check follows those links.
+
+Overloadable declarations are exempt: several subprograms may share a name. Signatures are not compared
+yet, so any two subprograms sharing a name are accepted.
+
+The expectations below were established with the GHDL analyzer (``ghdl -a --std=08``).
+"""
+from pathlib import Path
+from unittest import TestCase
+
+from pyTooling.Warning import WarningCollector
+
+from pyVHDLModel            import Design, Document, Library
+from pyVHDLModel.DesignUnit import Architecture, Entity, Package, PackageBody
+from pyVHDLModel.Exception  import DuplicateDeclarationWarning
+from pyVHDLModel.Base       import Mode
+from pyVHDLModel.Interface  import PortSimpleSignalInterfaceItem
+from pyVHDLModel.Name       import SimpleName
+from pyVHDLModel.Object     import Constant, Signal
+from pyVHDLModel.Subprogram import Function, Procedure
+from pyVHDLModel.Symbol     import EntitySymbol, PackageSymbol, SimpleSubtypeSymbol
+
+
+if __name__ == "__main__":
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+def _subtype() -> SimpleSubtypeSymbol:
+	return SimpleSubtypeSymbol(SimpleName("bit"))
+
+
+def _signal(identifier: str) -> Signal:
+	return Signal([identifier], _subtype())
+
+
+def _duplicates(collector) -> list:
+	return [warning for warning in collector if isinstance(warning, DuplicateDeclarationWarning)]
+
+
+class OneDeclarativePart(TestCase):
+	"""Two declarations in the same declarative part."""
+
+	def test_TwoSignalsWithTheSameName(self) -> None:
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("s"), _signal("s")])
+
+		with WarningCollector() as collector:
+			architecture.IndexDeclaredItems()
+
+		self.assertEqual(1, len(_duplicates(collector)))
+
+	def test_SignalAndConstantWithTheSameName(self) -> None:
+		"""Different kinds still collide - VHDL keys on the identifier, not the kind."""
+		items = [_signal("s"), Constant(["s"], _subtype())]
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
+
+		with WarningCollector() as collector:
+			architecture.IndexDeclaredItems()
+
+		self.assertEqual(1, len(_duplicates(collector)))
+
+	def test_DistinctNamesAreAccepted(self) -> None:
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("a"), _signal("b")])
+
+		with WarningCollector() as collector:
+			architecture.IndexDeclaredItems()
+
+		self.assertEqual(0, len(_duplicates(collector)))
+
+	def test_ReIndexingIsNotADuplicate(self) -> None:
+		"""Indexing is not idempotent by construction, so re-inserting the *same* item must not report."""
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("s")])
+
+		with WarningCollector() as collector:
+			architecture.IndexDeclaredItems()
+			architecture.IndexDeclaredItems()
+
+		self.assertEqual(0, len(_duplicates(collector)))
+
+
+class OverloadableDeclarations(TestCase):
+	"""Subprograms may share a name; GHDL accepts them as long as the signatures differ."""
+
+	def test_TwoProceduresSharingAName(self) -> None:
+		package = Package("pk", declaredItems=[Procedure("foo"), Procedure("foo")])
+
+		with WarningCollector() as collector:
+			package.IndexDeclaredItems()
+
+		self.assertEqual(0, len(_duplicates(collector)))
+
+	def test_FunctionAndProcedureSharingAName(self) -> None:
+		package = Package("pk", declaredItems=[Procedure("foo"), Function("foo", _subtype())])
+
+		with WarningCollector() as collector:
+			package.IndexDeclaredItems()
+
+		self.assertEqual(0, len(_duplicates(collector)))
+
+	def test_SubprogramCollidesWithASignal(self) -> None:
+		"""A subprogram is overloadable, but not against a non-overloadable declaration."""
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("foo"), Procedure("foo")])
+
+		with WarningCollector() as collector:
+			architecture.IndexDeclaredItems()
+
+		self.assertEqual(1, len(_duplicates(collector)))
+
+
+class RegionsSpanningTwoNamespaces(TestCase):
+	"""An entity and its architecture, and a package and its body, are each one declarative region."""
+
+	def _design(self, entityItems, architectureItems, packageItems, bodyItems) -> Design:
+		design = Design()
+		library = Library("work")
+		design.AddLibrary(library)
+		document = Document(Path("virtual.vhdl"))
+
+		document._AddDesignUnit(Entity("ent", declaredItems=entityItems))
+		document._AddDesignUnit(Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=architectureItems))
+		document._AddDesignUnit(Package("pk", declaredItems=packageItems))
+		document._AddDesignUnit(PackageBody(PackageSymbol(SimpleName("pk")), declaredItems=bodyItems))
+
+		design.AddDocument(document, library)
+		design.CreateDependencyGraph()
+		design.LinkArchitectures()
+		design.LinkPackageBodies()
+		return design
+
+	def test_ArchitectureDeclarationDuplicatesEntityDeclaration(self) -> None:
+		design = self._design([_signal("x")], [_signal("x")], [], [])
+
+		with WarningCollector() as collector:
+			design.IndexEntities()
+			design.IndexArchitectures()
+
+		self.assertEqual(1, len(_duplicates(collector)))
+
+	def test_ArchitectureDeclarationDuplicatesEntityPort(self) -> None:
+		ports = [PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())]
+		design = Design()
+		library = Library("work")
+		design.AddLibrary(library)
+		document = Document(Path("virtual.vhdl"))
+		document._AddDesignUnit(Entity("ent", portItems=ports))
+		document._AddDesignUnit(Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("p")]))
+		design.AddDocument(document, library)
+		design.CreateDependencyGraph()
+		design.LinkArchitectures()
+
+		with WarningCollector() as collector:
+			design.IndexEntities()
+			design.IndexArchitectures()
+
+		self.assertEqual(1, len(_duplicates(collector)))
+
+	def test_PackageBodyDeclarationDuplicatesPackageDeclaration(self) -> None:
+		design = self._design([], [], [Constant(["c"], _subtype())], [Constant(["c"], _subtype())])
+
+		with WarningCollector() as collector:
+			design.IndexPackages()
+			design.IndexPackageBodies()
+
+		self.assertEqual(1, len(_duplicates(collector)))
+
+	def test_DistinctNamesAcrossTheRegionAreAccepted(self) -> None:
+		design = self._design([_signal("a")], [_signal("b")], [], [])
+
+		with WarningCollector() as collector:
+			design.IndexEntities()
+			design.IndexArchitectures()
+
+		self.assertEqual(0, len(_duplicates(collector)))

--- a/tests/unit/Namespace/Duplicates.py
+++ b/tests/unit/Namespace/Duplicates.py
@@ -46,9 +46,9 @@ from unittest import TestCase
 from pyTooling.Warning import WarningCollector
 
 from pyVHDLModel            import Design, Document, Library
+from pyVHDLModel.Base       import Mode
 from pyVHDLModel.DesignUnit import Architecture, Entity, Package, PackageBody
 from pyVHDLModel.Exception  import DuplicateDeclarationWarning
-from pyVHDLModel.Base       import Mode
 from pyVHDLModel.Interface  import PortSimpleSignalInterfaceItem
 from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Object     import Constant, Signal
@@ -69,7 +69,8 @@ class OneDeclarativePart(TestCase):
 	"""Two declarations in the same declarative part."""
 
 	def test_TwoSignalsWithTheSameName(self) -> None:
-		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("s"), _signal("s")])
+		items = [_signal("s", "natural"), _signal("s", "natural")]
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
 
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
@@ -78,7 +79,7 @@ class OneDeclarativePart(TestCase):
 
 	def test_SignalAndConstantWithTheSameName(self) -> None:
 		"""Different kinds still collide - VHDL keys on the identifier, not the kind."""
-		items = [_signal("s"), Constant(["s"], _subtypeSymbol("bit"))]
+		items = [_signal("s", "natural"), Constant(["s"], _subtypeSymbol("bit"))]
 		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
 
 		with WarningCollector() as collector:
@@ -87,7 +88,8 @@ class OneDeclarativePart(TestCase):
 		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_DistinctNamesAreAccepted(self) -> None:
-		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("a"), _signal("b")])
+		items = [_signal("a", "natural"), _signal("b", "natural")]
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
 
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
@@ -96,7 +98,7 @@ class OneDeclarativePart(TestCase):
 
 	def test_ReIndexingIsNotADuplicate(self) -> None:
 		"""Indexing is not idempotent by construction, so re-inserting the *same* item must not report."""
-		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("s")])
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("s", "natural")])
 
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
@@ -126,7 +128,7 @@ class OverloadableDeclarations(TestCase):
 
 	def test_SubprogramCollidesWithASignal(self) -> None:
 		"""A subprogram is overloadable, but not against a non-overloadable declaration."""
-		items = [_signal("foo"), Procedure("foo")]
+		items = [_signal("foo", "natural"), Procedure("foo")]
 		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
 
 		with WarningCollector() as collector:
@@ -156,7 +158,7 @@ class RegionsSpanningTwoNamespaces(TestCase):
 		return design
 
 	def test_ArchitectureDeclarationDuplicatesEntityDeclaration(self) -> None:
-		design = self._design([_signal("x")], [_signal("x")], [], [])
+		design = self._design([_signal("x", "natural")], [_signal("x", "natural")], [], [])
 
 		with WarningCollector() as collector:
 			design.IndexEntities()
@@ -171,7 +173,8 @@ class RegionsSpanningTwoNamespaces(TestCase):
 		design.AddLibrary(library)
 		document = Document(Path("virtual.vhdl"))
 		document._AddDesignUnit(Entity("ent", portItems=ports))
-		document._AddDesignUnit(Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("p")]))
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("p", "natural")])
+		document._AddDesignUnit(architecture)
 		design.AddDocument(document, library)
 		design.CreateDependencyGraph()
 		design.LinkArchitectures()
@@ -192,7 +195,7 @@ class RegionsSpanningTwoNamespaces(TestCase):
 		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_DistinctNamesAcrossTheRegionAreAccepted(self) -> None:
-		design = self._design([_signal("a")], [_signal("b")], [], [])
+		design = self._design([_signal("a", "natural")], [_signal("b", "natural")], [], [])
 
 		with WarningCollector() as collector:
 			design.IndexEntities()

--- a/tests/unit/Namespace/Duplicates.py
+++ b/tests/unit/Namespace/Duplicates.py
@@ -55,23 +55,14 @@ from pyVHDLModel.Object     import Constant, Signal
 from pyVHDLModel.Subprogram import Function, Procedure
 from pyVHDLModel.Symbol     import EntitySymbol, PackageSymbol, SimpleSubtypeSymbol
 
+from tests.unit             import _signal, _subtypeSymbol, _warningsOfType
+
 
 if __name__ == "__main__":
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
 
-
-def _subtype() -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName("bit"))
-
-
-def _signal(identifier: str) -> Signal:
-	return Signal([identifier], _subtype())
-
-
-def _duplicates(collector) -> list:
-	return [warning for warning in collector if isinstance(warning, DuplicateDeclarationWarning)]
 
 
 class OneDeclarativePart(TestCase):
@@ -83,17 +74,17 @@ class OneDeclarativePart(TestCase):
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
 
-		self.assertEqual(1, len(_duplicates(collector)))
+		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_SignalAndConstantWithTheSameName(self) -> None:
 		"""Different kinds still collide - VHDL keys on the identifier, not the kind."""
-		items = [_signal("s"), Constant(["s"], _subtype())]
+		items = [_signal("s"), Constant(["s"], _subtypeSymbol("bit"))]
 		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
 
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
 
-		self.assertEqual(1, len(_duplicates(collector)))
+		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_DistinctNamesAreAccepted(self) -> None:
 		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("a"), _signal("b")])
@@ -101,7 +92,7 @@ class OneDeclarativePart(TestCase):
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
 
-		self.assertEqual(0, len(_duplicates(collector)))
+		self.assertEqual(0, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_ReIndexingIsNotADuplicate(self) -> None:
 		"""Indexing is not idempotent by construction, so re-inserting the *same* item must not report."""
@@ -111,7 +102,7 @@ class OneDeclarativePart(TestCase):
 			architecture.IndexDeclaredItems()
 			architecture.IndexDeclaredItems()
 
-		self.assertEqual(0, len(_duplicates(collector)))
+		self.assertEqual(0, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 
 class OverloadableDeclarations(TestCase):
@@ -123,24 +114,25 @@ class OverloadableDeclarations(TestCase):
 		with WarningCollector() as collector:
 			package.IndexDeclaredItems()
 
-		self.assertEqual(0, len(_duplicates(collector)))
+		self.assertEqual(0, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_FunctionAndProcedureSharingAName(self) -> None:
-		package = Package("pk", declaredItems=[Procedure("foo"), Function("foo", _subtype())])
+		package = Package("pk", declaredItems=[Procedure("foo"), Function("foo", _subtypeSymbol("bit"))])
 
 		with WarningCollector() as collector:
 			package.IndexDeclaredItems()
 
-		self.assertEqual(0, len(_duplicates(collector)))
+		self.assertEqual(0, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_SubprogramCollidesWithASignal(self) -> None:
 		"""A subprogram is overloadable, but not against a non-overloadable declaration."""
-		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[_signal("foo"), Procedure("foo")])
+		items = [_signal("foo"), Procedure("foo")]
+		architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=items)
 
 		with WarningCollector() as collector:
 			architecture.IndexDeclaredItems()
 
-		self.assertEqual(1, len(_duplicates(collector)))
+		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 
 class RegionsSpanningTwoNamespaces(TestCase):
@@ -170,10 +162,10 @@ class RegionsSpanningTwoNamespaces(TestCase):
 			design.IndexEntities()
 			design.IndexArchitectures()
 
-		self.assertEqual(1, len(_duplicates(collector)))
+		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_ArchitectureDeclarationDuplicatesEntityPort(self) -> None:
-		ports = [PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtype())]
+		ports = [PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtypeSymbol("bit"))]
 		design = Design()
 		library = Library("work")
 		design.AddLibrary(library)
@@ -188,16 +180,16 @@ class RegionsSpanningTwoNamespaces(TestCase):
 			design.IndexEntities()
 			design.IndexArchitectures()
 
-		self.assertEqual(1, len(_duplicates(collector)))
+		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_PackageBodyDeclarationDuplicatesPackageDeclaration(self) -> None:
-		design = self._design([], [], [Constant(["c"], _subtype())], [Constant(["c"], _subtype())])
+		design = self._design([], [], [Constant(["c"], _subtypeSymbol("bit"))], [Constant(["c"], _subtypeSymbol("bit"))])
 
 		with WarningCollector() as collector:
 			design.IndexPackages()
 			design.IndexPackageBodies()
 
-		self.assertEqual(1, len(_duplicates(collector)))
+		self.assertEqual(1, len(_warningsOfType(collector, DuplicateDeclarationWarning)))
 
 	def test_DistinctNamesAcrossTheRegionAreAccepted(self) -> None:
 		design = self._design([_signal("a")], [_signal("b")], [], [])
@@ -206,4 +198,4 @@ class RegionsSpanningTwoNamespaces(TestCase):
 			design.IndexEntities()
 			design.IndexArchitectures()
 
-		self.assertEqual(0, len(_duplicates(collector)))
+		self.assertEqual(0, len(_warningsOfType(collector, DuplicateDeclarationWarning)))

--- a/tests/unit/Namespace/Hiding.py
+++ b/tests/unit/Namespace/Hiding.py
@@ -45,10 +45,13 @@ keeps seeing its own declaration.
 from pathlib import Path
 from unittest import TestCase
 
+from pyTooling.Warning import WarningCollector
+
 from pyVHDLModel            import Design, Document, Library
 from pyVHDLModel.Base       import Direction, SimpleRange
 from pyVHDLModel.Concurrent import ConcurrentBlockStatement, ForGenerateStatement
 from pyVHDLModel.DesignUnit import Architecture, Entity
+from pyVHDLModel.Exception  import DuplicateDeclarationWarning
 from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Object     import Signal
@@ -103,21 +106,27 @@ class EntityAndArchitecture(TestCase):
 	def test_ArchitectureNamespaceNestsInsideEntityNamespace(self) -> None:
 		self.assertIs(self._entity._namespace, self._architecture._namespace.ParentNamespace)
 
-	def test_ArchitectureDeclarationShadowsEntityDeclaration_ButIsIllegalVHDL(self) -> None:
+	def test_ArchitectureDeclarationDuplicatesEntityDeclaration(self) -> None:
 		"""
-		Documents current *model* behaviour, which does **not** match VHDL.
-
-		An entity declaration and its architecture body form a **single** declarative region
-		(LRM 12.1), so re-declaring an entity-level name in the architecture is an error, not hiding.
-		Confirmed against GHDL: ``signal s`` in an architecture whose entity declares ``s`` gives
-		"identifier "s" already used for a declaration" - whereas a *process* variable shadowing an
+		An entity declaration and its architecture body form a **single** declarative region (LRM 12.1),
+		so re-declaring an entity-level name in the architecture is an error, not hiding. GHDL reports
+		"identifier "x" already used for a declaration", whereas a *process* variable shadowing an
 		architecture signal only warns (``-Whide``).
 
-		The model represents the entity/architecture pair as two nested namespaces, which gets
-		*visibility* right (see the next test) but silently resolves a duplicate instead of rejecting
-		it. Duplicate-declaration detection is a separate, missing feature - see
-		``pyVHDLModel.Findings.md``.
+		The namespaces stay nested - that is what makes the entity's declarations visible below - but the
+		link is marked as sharing its region, so the duplicate is reported.
 		"""
+		self.assertTrue(self._architecture._namespace._sharesRegionWithParent)
+
+		with WarningCollector() as collector:
+			self._architecture.IndexDeclaredItems()
+
+		duplicates = [w for w in collector if isinstance(w, DuplicateDeclarationWarning)]
+		self.assertEqual(1, len(duplicates))
+		self.assertIn("x", str(duplicates[0]))
+
+	def test_ArchitectureDeclarationStillResolvesToTheInnerOne(self) -> None:
+		"""Reporting the duplicate does not change resolution: the innermost declaration still wins."""
 		found = self._architecture._namespace.FindObject(SignalSymbol(SimpleName("x")))
 
 		self.assertIs(self._architectureSignal, found)

--- a/tests/unit/Namespace/Hiding.py
+++ b/tests/unit/Namespace/Hiding.py
@@ -57,15 +57,13 @@ from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Object     import Signal
 from pyVHDLModel.Symbol     import EntitySymbol, SignalSymbol, SimpleSubtypeSymbol
 
+from tests.unit             import _signal, _warningsOfType
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest %s'" % __file__)
 	exit(1)
-
-
-def _signal(identifier: str) -> Signal:
-	return Signal((identifier, ), SimpleSubtypeSymbol(SimpleName("natural")))
 
 
 class EntityAndArchitecture(TestCase):
@@ -116,12 +114,12 @@ class EntityAndArchitecture(TestCase):
 		The namespaces stay nested - that is what makes the entity's declarations visible below - but the
 		link is marked as sharing its region, so the duplicate is reported.
 		"""
-		self.assertTrue(self._architecture._namespace._sharesRegionWithParent)
+		self.assertTrue(self._architecture._namespace.SharesRegion)
 
 		with WarningCollector() as collector:
 			self._architecture.IndexDeclaredItems()
 
-		duplicates = [w for w in collector if isinstance(w, DuplicateDeclarationWarning)]
+		duplicates = _warningsOfType(collector, DuplicateDeclarationWarning)
 		self.assertEqual(1, len(duplicates))
 		self.assertIn("x", str(duplicates[0]))
 

--- a/tests/unit/Namespace/Hiding.py
+++ b/tests/unit/Namespace/Hiding.py
@@ -85,12 +85,12 @@ class EntityAndArchitecture(TestCase):
 		design.AddLibrary(library)
 		document = Document(Path("virtual.vhdl"))
 
-		self._entitySignal = _signal("x")
-		self._entityOnlySignal = _signal("entityOnly")
+		self._entitySignal = _signal("x", "natural")
+		self._entityOnlySignal = _signal("entityOnly", "natural")
 		self._entity = Entity("ent", declaredItems=[self._entitySignal, self._entityOnlySignal])
 		document._AddDesignUnit(self._entity)
 
-		self._architectureSignal = _signal("x")
+		self._architectureSignal = _signal("x", "natural")
 		self._architecture = Architecture("rtl", EntitySymbol(SimpleName("ent")), declaredItems=[self._architectureSignal])
 		document._AddDesignUnit(self._architecture)
 
@@ -114,7 +114,7 @@ class EntityAndArchitecture(TestCase):
 		The namespaces stay nested - that is what makes the entity's declarations visible below - but the
 		link is marked as sharing its region, so the duplicate is reported.
 		"""
-		self.assertTrue(self._architecture._namespace.SharesRegion)
+		self.assertTrue(self._architecture._namespace.SharesRegionWithParent)
 
 		with WarningCollector() as collector:
 			self._architecture.IndexDeclaredItems()
@@ -145,8 +145,8 @@ class BlocksInsideArchitecture(TestCase):
 	"""A block's declarative region nests inside the enclosing architecture's."""
 
 	def setUp(self) -> None:
-		self._architectureSignal = _signal("x")
-		self._architectureOnlySignal = _signal("architectureOnly")
+		self._architectureSignal = _signal("x", "natural")
+		self._architectureOnlySignal = _signal("architectureOnly", "natural")
 		self._architecture = Architecture(
 			"rtl",
 			EntitySymbol(SimpleName("ent")),
@@ -154,7 +154,7 @@ class BlocksInsideArchitecture(TestCase):
 		)
 		self._architecture.IndexDeclaredItems()
 
-		self._blockSignal = _signal("x")
+		self._blockSignal = _signal("x", "natural")
 		self._block = ConcurrentBlockStatement("blk", declaredItems=[self._blockSignal])
 		self._block.Parent = self._architecture
 		self._block.IndexDeclaredItems()
@@ -180,16 +180,16 @@ class NestedBlocks(TestCase):
 	"""Three levels of nesting: the innermost declaration wins, and each level keeps its own."""
 
 	def setUp(self) -> None:
-		self._outerSignal = _signal("x")
+		self._outerSignal = _signal("x", "natural")
 		self._outer = ConcurrentBlockStatement("outer", declaredItems=[self._outerSignal])
 		self._outer.IndexDeclaredItems()
 
-		self._middleSignal = _signal("x")
+		self._middleSignal = _signal("x", "natural")
 		self._middle = ConcurrentBlockStatement("middle", declaredItems=[self._middleSignal])
 		self._middle.Parent = self._outer
 		self._middle.IndexDeclaredItems()
 
-		self._innerSignal = _signal("x")
+		self._innerSignal = _signal("x", "natural")
 		self._inner = ConcurrentBlockStatement("inner", declaredItems=[self._innerSignal])
 		self._inner.Parent = self._middle
 		self._inner.IndexDeclaredItems()
@@ -203,7 +203,7 @@ class NestedBlocks(TestCase):
 
 	def test_UndeclaredNameWalksTheWholeChain(self) -> None:
 		"""A name declared only at the outermost level is still reachable from the innermost scope."""
-		onlyOutside = _signal("onlyOutside")
+		onlyOutside = _signal("onlyOutside", "natural")
 		self._outer._namespace._elements["onlyoutside"] = onlyOutside
 
 		self.assertIs(onlyOutside, self._inner._namespace.FindObject(SignalSymbol(SimpleName("onlyOutside"))))
@@ -213,7 +213,7 @@ class GeneratesInsideArchitecture(TestCase):
 	"""A for-generate's declarative region nests inside the enclosing architecture's."""
 
 	def setUp(self) -> None:
-		self._architectureSignal = _signal("x")
+		self._architectureSignal = _signal("x", "natural")
 		self._architecture = Architecture(
 			"rtl",
 			EntitySymbol(SimpleName("ent")),
@@ -221,7 +221,7 @@ class GeneratesInsideArchitecture(TestCase):
 		)
 		self._architecture.IndexDeclaredItems()
 
-		self._generateSignal = _signal("x")
+		self._generateSignal = _signal("x", "natural")
 		self._generate = ForGenerateStatement(
 			"gen",
 			"i",

--- a/tests/unit/Namespace/InterfaceItems.py
+++ b/tests/unit/Namespace/InterfaceItems.py
@@ -63,11 +63,11 @@ if __name__ == "__main__":  # pragma: no cover
 
 
 def _port(*identifiers: str) -> PortSimpleSignalInterfaceItem:
-	return PortSimpleSignalInterfaceItem(identifiers, Mode.In, _subtypeSymbol())
+	return PortSimpleSignalInterfaceItem(identifiers, Mode.In, _subtypeSymbol("natural"))
 
 
 def _generic(*identifiers: str) -> GenericConstantInterfaceItem:
-	return GenericConstantInterfaceItem(identifiers, Mode.In, _subtypeSymbol())
+	return GenericConstantInterfaceItem(identifiers, Mode.In, _subtypeSymbol("natural"))
 
 
 class EntityInterfaceItems(TestCase):
@@ -116,7 +116,7 @@ class EntityInterfaceItems(TestCase):
 	def test_GenericsPortsAndDeclarationsShareOneNamespace(self) -> None:
 		generic = _generic("width")
 		port = _port("clk")
-		signal = Signal(("internal", ), _subtypeSymbol())
+		signal = Signal(("internal", ), _subtypeSymbol("natural"))
 		entity = Entity("ent", genericItems=[generic], portItems=[port], declaredItems=[signal])
 		entity.IndexDeclaredItems()
 
@@ -178,7 +178,7 @@ class SubprogramInterfaceItems(TestCase):
 	"""
 
 	def test_ParameterIsIndexed(self) -> None:
-		parameter = ParameterVariableInterfaceItem(("p", ), Mode.In, _subtypeSymbol())
+		parameter = ParameterVariableInterfaceItem(("p", ), Mode.In, _subtypeSymbol("natural"))
 		procedure = Procedure("helper", parameterItems=[parameter])
 		procedure.IndexDeclaredItems()
 
@@ -186,7 +186,7 @@ class SubprogramInterfaceItems(TestCase):
 		self.assertIs(parameter, procedure.Namespace.FindObject(VariableSymbol(SimpleName("p"))))
 
 	def test_EveryIdentifierOfAMultiIdentifierParameterIsIndexed(self) -> None:
-		parameter = ParameterVariableInterfaceItem(("p", "q"), Mode.In, _subtypeSymbol())
+		parameter = ParameterVariableInterfaceItem(("p", "q"), Mode.In, _subtypeSymbol("natural"))
 		procedure = Procedure("helper", parameterItems=[parameter])
 		procedure.IndexDeclaredItems()
 
@@ -195,7 +195,7 @@ class SubprogramInterfaceItems(TestCase):
 
 	def test_GenericAndParameterShareTheNamespace(self) -> None:
 		generic = _generic("g")
-		parameter = ParameterVariableInterfaceItem(("p", ), Mode.In, _subtypeSymbol())
+		parameter = ParameterVariableInterfaceItem(("p", ), Mode.In, _subtypeSymbol("natural"))
 		procedure = Procedure("helper", genericItems=[generic], parameterItems=[parameter])
 		procedure.IndexDeclaredItems()
 

--- a/tests/unit/Namespace/InterfaceItems.py
+++ b/tests/unit/Namespace/InterfaceItems.py
@@ -53,15 +53,13 @@ from pyVHDLModel.Object     import Signal
 from pyVHDLModel.Subprogram import Procedure
 from pyVHDLModel.Symbol     import EntitySymbol, SignalSymbol, SimpleSubtypeSymbol, VariableSymbol
 
+from tests.unit             import _subtypeSymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _subtypeSymbol() -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName("natural"))
 
 
 def _port(*identifiers: str) -> PortSimpleSignalInterfaceItem:

--- a/tests/unit/Namespace/Namespace.py
+++ b/tests/unit/Namespace/Namespace.py
@@ -54,15 +54,13 @@ from pyVHDLModel.Symbol     import (
 )
 from pyVHDLModel.Type       import IntegerType, Subtype
 
+from tests.unit             import _subtypeSymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName(name))
 
 
 def _integerType(identifier: str = "myInteger") -> IntegerType:

--- a/tests/unit/Namespace/Namespace.py
+++ b/tests/unit/Namespace/Namespace.py
@@ -165,7 +165,7 @@ class FindSubtype(TestCase):
 
 	def test_FoundSubtype(self) -> None:
 		namespace = Namespace("package")
-		subtype = Subtype("byte", _subtypeSymbol())
+		subtype = Subtype("byte", _subtypeSymbol("natural"))
 		namespace._elements["byte"] = subtype
 
 		symbol = Symbol(SimpleName("byte"), PossibleReference.Subtype)
@@ -183,7 +183,7 @@ class FindSubtype(TestCase):
 
 	def test_FoundSubtypeButNotExpected_RaisesTypeError(self) -> None:
 		namespace = Namespace("package")
-		namespace._elements["byte"] = Subtype("byte", _subtypeSymbol())
+		namespace._elements["byte"] = Subtype("byte", _subtypeSymbol("natural"))
 
 		symbol = Symbol(SimpleName("byte"), PossibleReference.Signal)
 
@@ -208,7 +208,7 @@ class FindSubtype(TestCase):
 
 	def test_FoundButWrongKind_RaisesTypeError(self) -> None:
 		namespace = Namespace("package")
-		namespace._elements["sig"] = Signal(("sig", ), _subtypeSymbol())
+		namespace._elements["sig"] = Signal(("sig", ), _subtypeSymbol("natural"))
 
 		symbol = Symbol(SimpleName("sig"), PossibleReference.Subtype)
 
@@ -233,7 +233,7 @@ class FindSubtype(TestCase):
 	def test_NotFoundLocally_FoundInParent(self) -> None:
 		parent = Namespace("package")
 		namespace = Namespace("architecture", parent)
-		subtype = Subtype("byte", _subtypeSymbol())
+		subtype = Subtype("byte", _subtypeSymbol("natural"))
 		parent._elements["byte"] = subtype
 
 		symbol = Symbol(SimpleName("byte"), PossibleReference.Subtype)
@@ -261,14 +261,14 @@ class FindObject(TestCase):
 
 	def test_FoundSignal(self) -> None:
 		namespace = Namespace("architecture")
-		signal = Signal(("clk", ), _subtypeSymbol())
+		signal = Signal(("clk", ), _subtypeSymbol("natural"))
 		namespace._elements["clk"] = signal
 
 		self.assertIs(signal, namespace.FindObject(SignalSymbol(SimpleName("clk"))))
 
 	def test_FoundSignalViaSignalAttribute(self) -> None:
 		namespace = Namespace("architecture")
-		signal = Signal(("clk", ), _subtypeSymbol())
+		signal = Signal(("clk", ), _subtypeSymbol("natural"))
 		namespace._elements["clk"] = signal
 
 		# A signal attribute (e.g. `clk'event`) resolves to the signal itself.
@@ -278,7 +278,7 @@ class FindObject(TestCase):
 
 	def test_FoundConstant(self) -> None:
 		namespace = Namespace("architecture")
-		constant = Constant(("width", ), _subtypeSymbol())
+		constant = Constant(("width", ), _subtypeSymbol("natural"))
 		namespace._elements["width"] = constant
 
 		symbol = Symbol(SimpleName("width"), PossibleReference.Constant)
@@ -287,14 +287,14 @@ class FindObject(TestCase):
 
 	def test_FoundVariable(self) -> None:
 		namespace = Namespace("process")
-		variable = Variable(("index", ), _subtypeSymbol())
+		variable = Variable(("index", ), _subtypeSymbol("natural"))
 		namespace._elements["index"] = variable
 
 		self.assertIs(variable, namespace.FindObject(VariableSymbol(SimpleName("index"))))
 
 	def test_FoundButNotExpected_RaisesTypeError(self) -> None:
 		namespace = Namespace("architecture")
-		namespace._elements["clk"] = Signal(("clk", ), _subtypeSymbol())
+		namespace._elements["clk"] = Signal(("clk", ), _subtypeSymbol("natural"))
 
 		symbol = Symbol(SimpleName("clk"), PossibleReference.Constant)
 
@@ -305,7 +305,7 @@ class FindObject(TestCase):
 
 	def test_FoundButWrongKind_RaisesTypeError(self) -> None:
 		namespace = Namespace("architecture")
-		namespace._elements["byte"] = Subtype("byte", _subtypeSymbol())
+		namespace._elements["byte"] = Subtype("byte", _subtypeSymbol("natural"))
 
 		with self.assertRaises(TypeError) as context:
 			namespace.FindObject(SignalSymbol(SimpleName("byte")))
@@ -329,7 +329,7 @@ class FindObject(TestCase):
 	def test_NotFoundLocally_FoundInParent(self) -> None:
 		parent = Namespace("entity")
 		namespace = Namespace("architecture", parent)
-		signal = Signal(("clk", ), _subtypeSymbol())
+		signal = Signal(("clk", ), _subtypeSymbol("natural"))
 		parent._elements["clk"] = signal
 
 		self.assertIs(signal, namespace.FindObject(SignalSymbol(SimpleName("clk"))))

--- a/tests/unit/Namespace/SequentialRegions.py
+++ b/tests/unit/Namespace/SequentialRegions.py
@@ -82,7 +82,7 @@ class ProcessNamespaces(TestCase):
 
 	def test_IndexDeclaredItemsPopulatesVariables(self) -> None:
 		"""A variable is exactly what a concurrent region can *not* declare."""
-		variable = _variable("counter")
+		variable = _variable("counter", "natural")
 		process = ProcessStatement("proc", declaredItems=[variable])
 		process.IndexDeclaredItems()
 
@@ -91,8 +91,8 @@ class ProcessNamespaces(TestCase):
 
 	def test_IndexDeclaredItemsPopulatesEveryKind(self) -> None:
 		integerType = IntegerType("nibble", None)
-		constant = Constant(("width", ), _subtypeSymbol())
-		variable = _variable("index")
+		constant = Constant(("width", ), _subtypeSymbol("natural"))
+		variable = _variable("index", "natural")
 		nestedProcedure = Procedure("helper")
 
 		process = ProcessStatement("proc", declaredItems=[integerType, constant, variable, nestedProcedure])
@@ -112,10 +112,10 @@ class ProcessNamespaces(TestCase):
 		self.assertIs(architecture._namespace, process.Namespace.ParentNamespace)
 
 	def test_ProcessVariableHidesArchitectureSignal(self) -> None:
-		architectureSignal = _signal("x")
+		architectureSignal = _signal("x", "natural")
 		architecture = _architecture(architectureSignal)
 
-		processVariable = _variable("x")
+		processVariable = _variable("x", "natural")
 		process = ProcessStatement("proc", declaredItems=[processVariable])
 		process.Parent = architecture
 		process.IndexDeclaredItems()
@@ -125,7 +125,7 @@ class ProcessNamespaces(TestCase):
 		self.assertIs(architectureSignal, architecture._namespace.FindObject(SignalSymbol(SimpleName("x"))))
 
 	def test_ProcessInheritsArchitectureDeclaration(self) -> None:
-		architectureSignal = _signal("clk")
+		architectureSignal = _signal("clk", "natural")
 		architecture = _architecture(architectureSignal)
 
 		process = ProcessStatement("proc")
@@ -152,8 +152,8 @@ class SubprogramNamespaces(TestCase):
 		self.assertEqual("doit", procedure.Namespace.Name)
 
 	def test_IndexDeclaredItemsPopulatesVariables(self) -> None:
-		variable = _variable("temp")
-		function = Function("compute", _subtypeSymbol(), declaredItems=[variable])
+		variable = _variable("temp", "natural")
+		function = Function("compute", _subtypeSymbol("natural"), declaredItems=[variable])
 		function.IndexDeclaredItems()
 
 		self.assertIs(variable, function.Variables["temp"])
@@ -167,10 +167,10 @@ class SubprogramNamespaces(TestCase):
 		self.assertIs(architecture._namespace, procedure.Namespace.ParentNamespace)
 
 	def test_SubprogramVariableHidesArchitectureSignal(self) -> None:
-		architectureSignal = _signal("x")
+		architectureSignal = _signal("x", "natural")
 		architecture = _architecture(architectureSignal)
 
-		subprogramVariable = _variable("x")
+		subprogramVariable = _variable("x", "natural")
 		procedure = Procedure("helper", declaredItems=[subprogramVariable])
 		procedure.Parent = architecture
 		procedure.IndexDeclaredItems()
@@ -179,7 +179,7 @@ class SubprogramNamespaces(TestCase):
 		self.assertIs(architectureSignal, architecture._namespace.FindObject(SignalSymbol(SimpleName("x"))))
 
 	def test_SubprogramInheritsArchitectureDeclaration(self) -> None:
-		constant = Constant(("width", ), _subtypeSymbol())
+		constant = Constant(("width", ), _subtypeSymbol("natural"))
 		architecture = _architecture(constant)
 
 		procedure = Procedure("helper")
@@ -191,7 +191,7 @@ class SubprogramNamespaces(TestCase):
 
 	def test_NestedSubprogramNestsInsideTheOuterSubprogram(self) -> None:
 		"""A subprogram is itself a sequential declaration region, so subprograms nest."""
-		outerVariable = _variable("outer")
+		outerVariable = _variable("outer", "natural")
 		inner = Procedure("inner")
 		outer = Procedure("outer", declaredItems=[outerVariable, inner])
 		outer.IndexDeclaredItems()
@@ -200,8 +200,8 @@ class SubprogramNamespaces(TestCase):
 		self.assertIs(outerVariable, inner.Namespace.FindObject(VariableSymbol(SimpleName("outer"))))
 
 	def test_NestedSubprogramVariableHidesTheOuterOne(self) -> None:
-		outerVariable = _variable("x")
-		innerVariable = _variable("x")
+		outerVariable = _variable("x", "natural")
+		innerVariable = _variable("x", "natural")
 		inner = Procedure("inner", declaredItems=[innerVariable])
 		outer = Procedure("outer", declaredItems=[outerVariable, inner])
 		outer.IndexDeclaredItems()

--- a/tests/unit/Namespace/SequentialRegions.py
+++ b/tests/unit/Namespace/SequentialRegions.py
@@ -53,23 +53,13 @@ from pyVHDLModel.Symbol     import (
 )
 from pyVHDLModel.Type       import IntegerType
 
+from tests.unit             import _signal, _subtypeSymbol, _variable
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _subtypeSymbol() -> SimpleSubtypeSymbol:
-	return SimpleSubtypeSymbol(SimpleName("natural"))
-
-
-def _variable(identifier: str) -> Variable:
-	return Variable((identifier, ), _subtypeSymbol())
-
-
-def _signal(identifier: str) -> Signal:
-	return Signal((identifier, ), _subtypeSymbol())
 
 
 def _architecture(*declaredItems) -> Architecture:

--- a/tests/unit/Namespace/Statements.py
+++ b/tests/unit/Namespace/Statements.py
@@ -54,15 +54,13 @@ from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Name       import SimpleName
 from pyVHDLModel.Symbol     import EntitySymbol
 
+from tests.unit             import _entitySymbol
+
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
 	print("Use: 'python -m unitest <testcase module>'")
 	exit(1)
-
-
-def _entitySymbol(name: str = "e") -> EntitySymbol:
-	return EntitySymbol(SimpleName(name))
 
 
 class BlockStatements(TestCase):

--- a/tests/unit/Namespace/Statements.py
+++ b/tests/unit/Namespace/Statements.py
@@ -80,7 +80,7 @@ class IfGenerateStatements(TestCase):
 		``namespace._name == ""``, but an unlabelled ``GenerateBranch`` always constructs its
 		namespace with ``_normalizedAlternativeLabel``, which defaults to ``None`` - not ``""`` - so
 		the fallback never actually fired. Fixed to compare against ``None``."""
-		architecture = Architecture("rtl", _entitySymbol())
+		architecture = Architecture("rtl", _entitySymbol("e"))
 		ifBranch = IfGenerateBranch(IntegerLiteral(1))
 		elsifBranch = ElsifGenerateBranch(IntegerLiteral(2))
 		elseBranch = ElseGenerateBranch()
@@ -96,7 +96,7 @@ class IfGenerateStatements(TestCase):
 
 class CaseGenerateStatements(TestCase):
 	def test_CaseConnectsToTheArchitecture(self) -> None:
-		architecture = Architecture("rtl", _entitySymbol())
+		architecture = Architecture("rtl", _entitySymbol("e"))
 		case = GenerateCase([IndexedGenerateChoice(IntegerLiteral(0))])
 		statement = CaseGenerateStatement("gen", IntegerLiteral(0), [case])
 
@@ -107,7 +107,7 @@ class CaseGenerateStatements(TestCase):
 
 class ForGenerateStatements(TestCase):
 	def test_ConnectsToTheArchitecture(self) -> None:
-		architecture = Architecture("rtl", _entitySymbol())
+		architecture = Architecture("rtl", _entitySymbol("e"))
 		rng = SimpleRange(IntegerLiteral(0), IntegerLiteral(3), Direction.To)
 		statement = ForGenerateStatement("gen", "i", rng)
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -33,8 +33,8 @@
 """Shared construction helpers for the unit tests.
 
 Building a model object needs a symbol, a subtype and often a name, which every test module was
-re-declaring. The defaults below are the ones most modules used; a module wanting a different name
-passes it explicitly.
+re-declaring. Names are always passed explicitly - a helper that defaults one hides what a test
+actually builds.
 """
 from typing import List, Type, TypeVar
 
@@ -46,32 +46,32 @@ from pyVHDLModel.Symbol import EntitySymbol, SignalSymbol, SimpleSubtypeSymbol, 
 _Warning = TypeVar("_Warning", bound=BaseException)
 
 
-def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
+def _subtypeSymbol(name: str) -> SimpleSubtypeSymbol:
 	"""Reference to a subtype, for anything needing a subtype indication."""
 	return SimpleSubtypeSymbol(SimpleName(name))
 
 
-def _entitySymbol(name: str = "e") -> EntitySymbol:
+def _entitySymbol(name: str) -> EntitySymbol:
 	"""Reference to an entity, e.g. for an architecture."""
 	return EntitySymbol(SimpleName(name))
 
 
-def _signalSymbol(name: str = "s") -> SignalSymbol:
+def _signalSymbol(name: str) -> SignalSymbol:
 	"""Reference to a signal, e.g. as an assignment target."""
 	return SignalSymbol(SimpleName(name))
 
 
-def _variableSymbol(name: str = "v") -> VariableSymbol:
+def _variableSymbol(name: str) -> VariableSymbol:
 	"""Reference to a variable, e.g. as an assignment target."""
 	return VariableSymbol(SimpleName(name))
 
 
-def _signal(identifier: str, subtypeName: str = "natural") -> Signal:
+def _signal(identifier: str, subtypeName: str) -> Signal:
 	"""A signal declaration."""
 	return Signal((identifier, ), _subtypeSymbol(subtypeName))
 
 
-def _variable(identifier: str, subtypeName: str = "natural") -> Variable:
+def _variable(identifier: str, subtypeName: str) -> Variable:
 	"""A variable declaration."""
 	return Variable((identifier, ), _subtypeSymbol(subtypeName))
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -29,3 +29,53 @@
 # SPDX-License-Identifier: Apache-2.0                                                                                  #
 # ==================================================================================================================== #
 #
+
+"""Shared construction helpers for the unit tests.
+
+Building a model object needs a symbol, a subtype and often a name, which every test module was
+re-declaring. The defaults below are the ones most modules used; a module wanting a different name
+passes it explicitly.
+"""
+from typing import List, Type, TypeVar
+
+from pyVHDLModel.Name   import SimpleName
+from pyVHDLModel.Object import Signal, Variable
+from pyVHDLModel.Symbol import EntitySymbol, SignalSymbol, SimpleSubtypeSymbol, VariableSymbol
+
+
+_Warning = TypeVar("_Warning", bound=BaseException)
+
+
+def _subtypeSymbol(name: str = "natural") -> SimpleSubtypeSymbol:
+	"""Reference to a subtype, for anything needing a subtype indication."""
+	return SimpleSubtypeSymbol(SimpleName(name))
+
+
+def _entitySymbol(name: str = "e") -> EntitySymbol:
+	"""Reference to an entity, e.g. for an architecture."""
+	return EntitySymbol(SimpleName(name))
+
+
+def _signalSymbol(name: str = "s") -> SignalSymbol:
+	"""Reference to a signal, e.g. as an assignment target."""
+	return SignalSymbol(SimpleName(name))
+
+
+def _variableSymbol(name: str = "v") -> VariableSymbol:
+	"""Reference to a variable, e.g. as an assignment target."""
+	return VariableSymbol(SimpleName(name))
+
+
+def _signal(identifier: str, subtypeName: str = "natural") -> Signal:
+	"""A signal declaration."""
+	return Signal((identifier, ), _subtypeSymbol(subtypeName))
+
+
+def _variable(identifier: str, subtypeName: str = "natural") -> Variable:
+	"""A variable declaration."""
+	return Variable((identifier, ), _subtypeSymbol(subtypeName))
+
+
+def _warningsOfType(collector, warningType: Type[_Warning]) -> List[_Warning]:
+	"""The warnings of one type collected by a :class:`~pyTooling.Warning.WarningCollector`."""
+	return [warning for warning in collector if isinstance(warning, warningType)]


### PR DESCRIPTION
Findings item 1 - the last of the four you ordered, and the only genuine correctness gap of the set.

The model silently overwrote a namespace entry when two declarations shared an identifier. `Namespace.AddElement` now reports a `DuplicateDeclarationWarning`, and every insertion in the three region mixins goes through it.

## Which pairs are one region - measured, not assumed

| Construct | GHDL `-a --std=08` |
|---|---|
| two declarations in one declarative part | **error** |
| architecture declaration vs entity declaration | **error** |
| architecture declaration vs entity port | **error** |
| **package body declaration vs package declaration** | **error** |
| block / generate / process / subprogram | hiding (`-Whide`), legal |

The **package/body** pair was the open question in the finding. It is one region, so `_sharesRegionWithParent` marks that namespace link and the entity/architecture one. The check walks outwards only while that flag is set, so genuinely nested regions still hide as before, and resolution is unchanged - the innermost declaration still wins.

## Two traps worth reading

**Overloading.** Naive detection would flag legal VHDL. Measured:

| Case | GHDL |
|---|---|
| two procedures, different signature | legal |
| two procedures, identical signature | **error** |
| function and procedure, same name | legal |
| same enumeration literal in two types | legal |
| enumeration literal vs a signal | **error** |

Subprogram insertions pass `overloadable=True`. Signatures are **not** compared yet, so an identical-signature redeclaration is still missed - that needs real overload resolution, and is recorded in the findings file along with the enumeration-literal cases (literals are never indexed into a namespace today).

**Re-indexing.** `IndexDeclaredItems` is not idempotent, and `Analyze()` plus the explicit `Index*` entry points call it more than once. My first version reported **every predefined `std.standard` declaration as a duplicate**. Re-inserting the *same* object is now recognised as a re-index rather than a second declaration, and there is a test for it.

## Severity

`DuplicateDeclarationWarning` extends `VHDLModelCriticalWarning` - "likely indicates a defect in the model or its input", which fits. Reporting goes through `WarningCollector`, so it is visible to a caller that collects warnings and **silently dropped otherwise**, exactly like the existing warnings. Detection is opt-in and breaks no existing caller. Say the word if you would rather it raised.

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit` | **442** passed (+12), 69 subtests |
| pyGHDL `testsuite/pyunit` (real VHDL, incl. the predefined libraries) | 185 passed, 17 xfailed - **no false positives** |
| Forced annotation evaluation (3.11-3.13) | clean |
| ReST parse | 0 problems |
| `interrogate` | 97.4% (minimum 90.0%) |
| New lines > 120 chars | 0 |

`tests/unit/Namespace/Hiding.py` previously documented this as a known gap; it now asserts the duplicate is reported. New `tests/unit/Namespace/Duplicates.py` covers the region pairs, overloading and re-indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)