### PR TITLE
Model a block statement's complete block header

### DIFF
--- a/pyVHDLModel/Association.py
+++ b/pyVHDLModel/Association.py
@@ -34,9 +34,10 @@ This module contains parts of an abstract document language model for VHDL.
 
 Associations are used in generic maps, port maps and parameter maps.
 """
-from typing               import Optional as Nullable, Union
+from typing               import Iterable, List, Optional as Nullable, Union
 
 from pyTooling.Decorators import export, readonly
+from pyTooling.MetaClasses import ExtendedType
 
 from pyVHDLModel.Base       import ModelEntity
 from pyVHDLModel.Symbol     import Symbol
@@ -135,3 +136,77 @@ class ParameterAssociationItem(AssociationItem):
 	"""
 	A base-class for all parameter association items used in parameter map aspects.
 	"""
+
+
+@export
+class GenericMapAspectMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language constructs with a generic map aspect.
+
+	.. seealso::
+
+	   * :class:`Instantiation <pyVHDLModel.Concurrent.Instantiation>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Binding indication <pyVHDLModel.Configuration.BindingIndication>`
+	   * :class:`Port map aspect <pyVHDLModel.Association.PortMapAspectMixin>`
+	"""
+
+	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations.
+
+	def __init__(self, genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None) -> None:
+		"""
+		Initializes a generic map aspect.
+
+		:param genericAssociationItems: List of all generic associations.
+		"""
+		self._genericAssociationItems = []
+		if genericAssociationItems is not None:
+			for association in genericAssociationItems:
+				self._genericAssociationItems.append(association)
+				association.Parent = self
+
+	@readonly
+	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
+		"""
+		Read-only property to access the generic associations (:attr:`_genericAssociationItems`).
+
+		:returns: List of generic association items.
+		"""
+		return self._genericAssociationItems
+
+
+@export
+class PortMapAspectMixin(metaclass=ExtendedType, mixin=True):
+	"""
+	A mixin-class for language constructs with a port map aspect.
+
+	.. seealso::
+
+	   * :class:`Instantiation <pyVHDLModel.Concurrent.Instantiation>`
+	   * :class:`Concurrent block statement <pyVHDLModel.Concurrent.ConcurrentBlockStatement>`
+	   * :class:`Binding indication <pyVHDLModel.Configuration.BindingIndication>`
+	   * :class:`Generic map aspect <pyVHDLModel.Association.GenericMapAspectMixin>`
+	"""
+
+	_portAssociationItems: List[PortAssociationItem]  #: List of all port associations.
+
+	def __init__(self, portAssociationItems: Nullable[Iterable[PortAssociationItem]] = None) -> None:
+		"""
+		Initializes a port map aspect.
+
+		:param portAssociationItems: List of all port associations.
+		"""
+		self._portAssociationItems = []
+		if portAssociationItems is not None:
+			for association in portAssociationItems:
+				self._portAssociationItems.append(association)
+				association.Parent = self
+
+	@readonly
+	def PortAssociationItems(self) -> List[PortAssociationItem]:
+		"""
+		Read-only property to access the port associations (:attr:`_portAssociationItems`).
+
+		:returns: List of port association items.
+		"""
+		return self._portAssociationItems

--- a/pyVHDLModel/Concurrent.py
+++ b/pyVHDLModel/Concurrent.py
@@ -48,7 +48,10 @@ from pyVHDLModel.Symbol      import ComponentInstantiationSymbol, EntityInstanti
 from pyVHDLModel.Symbol      import SignalSymbol
 from pyVHDLModel.Expression  import BaseExpression, QualifiedExpression, FunctionCall, TypeConversion, Literal
 from pyVHDLModel.Association import AssociationItem, ParameterAssociationItem
+from pyVHDLModel.Association import GenericAssociationItem, PortAssociationItem
+from pyVHDLModel.Association import GenericMapAspectMixin, PortMapAspectMixin
 from pyVHDLModel.Interface   import PortInterfaceItemMixin, WithPortsMixin
+from pyVHDLModel.Interface   import GenericInterfaceItemMixin, WithGenericsMixin
 from pyVHDLModel.Common      import Statement, ProcedureCallMixin, SignalAssignmentMixin, AllowBlackboxMixin
 from pyVHDLModel.Common      import ConditionalWaveform, SelectedWaveform, OthersSelectedWaveform
 from pyVHDLModel.Common      import ConditionalWaveformsMixin, WaveformMixin
@@ -152,7 +155,7 @@ class ConcurrentStatementsMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
-class Instantiation(ConcurrentStatement):
+class Instantiation(ConcurrentStatement, GenericMapAspectMixin, PortMapAspectMixin):
 	"""
 	A base-class for all (component) instantiations.
 
@@ -163,14 +166,11 @@ class Instantiation(ConcurrentStatement):
 	   * :class:`Configuration instantiation <pyVHDLModel.Concurrent.ConfigurationInstantiation>`
 	"""
 
-	_genericAssociationItems: List[AssociationItem]  #: List of all generic associations in the generic map aspect.
-	_portAssociationItems:    List[AssociationItem]  #: List of all port associations in the port map aspect.
-
 	def __init__(
 		self,
 		label: str,
-		genericAssociationItems: Nullable[Iterable[AssociationItem]] = None,
-		portAssociationItems:    Nullable[Iterable[AssociationItem]] = None,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
+		portAssociationItems:    Nullable[Iterable[PortAssociationItem]] = None,
 		parent: Nullable[ModelEntity] = None
 	) -> None:
 		"""
@@ -182,38 +182,10 @@ class Instantiation(ConcurrentStatement):
 		:param parent:                  The parent model entity of this entity.
 		"""
 		super().__init__(label, parent)
+		GenericMapAspectMixin.__init__(self, genericAssociationItems)
+		PortMapAspectMixin.__init__(self, portAssociationItems)
 
-		# TODO: extract to mixin
-		self._genericAssociationItems = []
-		if genericAssociationItems is not None:
-			for association in genericAssociationItems:
-				self._genericAssociationItems.append(association)
-				association.Parent = self
 
-		# TODO: extract to mixin
-		self._portAssociationItems = []
-		if portAssociationItems is not None:
-			for association in portAssociationItems:
-				self._portAssociationItems.append(association)
-				association.Parent = self
-
-	@readonly
-	def GenericAssociationItems(self) -> List[AssociationItem]:
-		"""
-		Read-only property to access the generic association items (:attr:`_genericAssociationItems`).
-
-		:returns: List of generic association items.
-		"""
-		return self._genericAssociationItems
-
-	@readonly
-	def PortAssociationItems(self) -> List[AssociationItem]:
-		"""
-		Read-only property to access the port association items (:attr:`_portAssociationItems`).
-
-		:returns: List of port association items.
-		"""
-		return self._portAssociationItems
 
 
 @export
@@ -500,34 +472,48 @@ class ConcurrentProcedureCall(ConcurrentStatement, ProcedureCallMixin):
 
 
 @export
-class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, LabeledEntityMixin, WithPortsMixin, ConcurrentDeclarationRegionMixin, ConcurrentStatementsMixin, DocumentedEntityMixin, AllowBlackboxMixin):
+class ConcurrentBlockStatement(
+	ConcurrentStatement,
+	BlockStatementMixin,
+	LabeledEntityMixin,
+	WithGenericsMixin,
+	WithPortsMixin,
+	GenericMapAspectMixin,
+	PortMapAspectMixin,
+	ConcurrentDeclarationRegionMixin,
+	ConcurrentStatementsMixin,
+	DocumentedEntityMixin,
+	AllowBlackboxMixin
+):
 	"""
 	Represents a block statement.
 
 	A block groups concurrent statements (:data:`Statements`) and may declare its own items
-	(:data:`DeclaredItems`). It always forms a hierarchy level; independently of that, it may also
-	have a port clause (:data:`PortItems`).
+	(:data:`DeclaredItems`). It always forms a hierarchy level; independently of that, it may also have
+	a block header: a generic clause (:data:`GenericItems`) with its generic map aspect
+	(:data:`GenericAssociationItems`), and a port clause (:data:`PortItems`) with its port map aspect
+	(:data:`PortAssociationItems`).
 
 	.. admonition:: Example
 
 	   .. code-block:: VHDL
 
 	        blk : block
-	      --^^^                            <- Label
+	      --^^^                              <- Label
+	          generic (G : positive := 1);
+	      --          ^^^^^^^^^^^^^^^^^^     <- GenericItems
+	          generic map (G => 2);
+	      --              ^^^^^^^^           <- GenericAssociationItems
 	          port (bp : in bit);
-	      --        ^^^^^^^^^^^            <- PortItems
+	      --        ^^^^^^^^^^^              <- PortItems
 	          port map (bp => clock);
+	      --           ^^^^^^^^^^^^          <- PortAssociationItems
 	          signal inner : bit := '0';
-	      --  ^^^^^^^^^^^^^^^^^^^^^^^^^^   <- DeclaredItems
+	      --  ^^^^^^^^^^^^^^^^^^^^^^^^^^     <- DeclaredItems
 	        begin
 	          inner <= bp;
-	      --  ^^^^^^^^^^^^                 <- Statements
+	      --  ^^^^^^^^^^^^                   <- Statements
 	        end block;
-
-	.. note::
-
-	   The block's *port map aspect* (``port map (bp => clock);`` above) is not represented by the
-	   model yet - there is no field for the association items, so it has no marker.
 
 	.. seealso::
 
@@ -537,24 +523,30 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 
 	def __init__(
 		self,
-		label:         str,
-		portItems:     Nullable[Iterable[PortInterfaceItemMixin]] = None,
-		declaredItems: Nullable[Iterable] = None,
-		statements:    Iterable['ConcurrentStatement'] = None,
-		documentation: Nullable[str] = None,
-		allowBlackbox: Nullable[bool] = None,
-		parent:        Nullable[ModelEntity] = None
+		label:                   str,
+		genericItems:            Nullable[Iterable[GenericInterfaceItemMixin]] = None,
+		genericAssociationItems: Nullable[Iterable[GenericAssociationItem]] = None,
+		portItems:               Nullable[Iterable[PortInterfaceItemMixin]] = None,
+		portAssociationItems:    Nullable[Iterable[PortAssociationItem]] = None,
+		declaredItems:           Nullable[Iterable] = None,
+		statements:              Iterable['ConcurrentStatement'] = None,
+		documentation:           Nullable[str] = None,
+		allowBlackbox:           Nullable[bool] = None,
+		parent:                  Nullable[ModelEntity] = None
 	) -> None:
 		"""
 		Initializes a block statement.
 
-		:param label:         The label of a model entity.
-		:param portItems:     List of all ports, in declaration order.
-		:param declaredItems: List of all declared items in this concurrent declaration region.
-		:param statements:    List of all concurrent statements in this construct.
-		:param documentation: The documentation comment associated with this declaration.
-		:param allowBlackbox: Allow blackboxes for components in language entity.
-		:param parent:        The parent model entity of this entity.
+		:param label:                   The label of a model entity.
+		:param genericItems:            List of all generics, in declaration order.
+		:param genericAssociationItems: List of all generic associations in the generic map aspect.
+		:param portItems:               List of all ports, in declaration order.
+		:param portAssociationItems:    List of all port associations in the port map aspect.
+		:param declaredItems:           List of all declared items in this concurrent declaration region.
+		:param statements:              List of all concurrent statements in this construct.
+		:param documentation:           The documentation comment associated with this declaration.
+		:param allowBlackbox:           Allow blackboxes for components in language entity.
+		:param parent:                  The parent model entity of this entity.
 		"""
 		super().__init__(label, parent)
 
@@ -564,7 +556,10 @@ class ConcurrentBlockStatement(ConcurrentStatement, BlockStatementMixin, Labeled
 
 		BlockStatementMixin.__init__(self)
 		LabeledEntityMixin.__init__(self, label)
+		WithGenericsMixin.__init__(self, genericItems)
 		WithPortsMixin.__init__(self, portItems)
+		GenericMapAspectMixin.__init__(self, genericAssociationItems)
+		PortMapAspectMixin.__init__(self, portAssociationItems)
 		ConcurrentDeclarationRegionMixin.__init__(self, declaredItems)
 		ConcurrentStatementsMixin.__init__(self, statements)
 		DocumentedEntityMixin.__init__(self, documentation)

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -204,13 +204,12 @@ class BindingIndication(ModelEntity, GenericMapAspectMixin, PortMapAspectMixin):
 		:param parent:                  The parent model entity of this entity.
 		"""
 		super().__init__(parent)
+		GenericMapAspectMixin.__init__(self, genericAssociationItems)
+		PortMapAspectMixin.__init__(self, portAssociationItems)
 
 		self._entityAspect = entityAspect
 		if entityAspect is not None:
 			entityAspect.Parent = self
-
-		GenericMapAspectMixin.__init__(self, genericAssociationItems)
-		PortMapAspectMixin.__init__(self, portAssociationItems)
 
 	@readonly
 	def EntityAspect(self) -> Nullable[EntityAspect]:

--- a/pyVHDLModel/Configuration.py
+++ b/pyVHDLModel/Configuration.py
@@ -44,6 +44,7 @@ from pyVHDLModel.Name        import Name
 from pyVHDLModel.Symbol      import Symbol, EntitySymbol, ArchitectureSymbol, ConfigurationSymbol
 from pyVHDLModel.Symbol      import ComponentInstantiationSymbol
 from pyVHDLModel.Association import GenericAssociationItem, PortAssociationItem
+from pyVHDLModel.Association import GenericMapAspectMixin, PortMapAspectMixin
 
 
 @export
@@ -177,7 +178,7 @@ class EntityAspectOpen(EntityAspect):
 
 
 @export
-class BindingIndication(ModelEntity):
+class BindingIndication(ModelEntity, GenericMapAspectMixin, PortMapAspectMixin):
 	"""
 	Represents a binding indication: which design entity a component is bound to.
 
@@ -185,9 +186,7 @@ class BindingIndication(ModelEntity):
 	(:data:`GenericAssociations`, :data:`PortAssociations`).
 	"""
 
-	_entityAspect:            Nullable[EntityAspect]        #: The bound design entity, or ``None`` if not given.
-	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations in the generic map aspect.
-	_portAssociationItems:    List[PortAssociationItem]     #: List of all port associations in the port map aspect.
+	_entityAspect: Nullable[EntityAspect]  #: The bound design entity, or ``None`` if not given.
 
 	def __init__(
 		self,
@@ -210,17 +209,8 @@ class BindingIndication(ModelEntity):
 		if entityAspect is not None:
 			entityAspect.Parent = self
 
-		self._genericAssociationItems = []
-		if genericAssociationItems is not None:
-			for association in genericAssociationItems:
-				self._genericAssociationItems.append(association)
-				association.Parent = self
-
-		self._portAssociationItems = []
-		if portAssociationItems is not None:
-			for association in portAssociationItems:
-				self._portAssociationItems.append(association)
-				association.Parent = self
+		GenericMapAspectMixin.__init__(self, genericAssociationItems)
+		PortMapAspectMixin.__init__(self, portAssociationItems)
 
 	@readonly
 	def EntityAspect(self) -> Nullable[EntityAspect]:
@@ -231,23 +221,7 @@ class BindingIndication(ModelEntity):
 		"""
 		return self._entityAspect
 
-	@readonly
-	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
-		"""
-		Read-only property to access the generic association items (:attr:`_genericAssociationItems`).
 
-		:returns: List of generic association items.
-		"""
-		return self._genericAssociationItems
-
-	@readonly
-	def PortAssociationItems(self) -> List[PortAssociationItem]:
-		"""
-		Read-only property to access the port association items (:attr:`_portAssociationItems`).
-
-		:returns: List of port association items.
-		"""
-		return self._portAssociationItems
 
 
 @export

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -101,7 +101,6 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, GenericMapAspectMi
 		:param genericAssociationItems: List of all generic associations in the generic map aspect.
 		"""
 		super().__init__()
-
 		GenericMapAspectMixin.__init__(self, genericAssociationItems)
 
 		self._subprogramReference = subprogramReference
@@ -257,7 +256,6 @@ class PackageInstantiation(Package, GenericInstantiationMixin, GenericMapAspectM
 		"""
 		super().__init__(identifier, contextItems, documentation=documentation, parent=parent)
 		GenericEntityInstantiationMixin.__init__(self)
-
 		GenericMapAspectMixin.__init__(self, genericAssociationItems)
 
 		self._packageReference = genericPackage

--- a/pyVHDLModel/Instantiation.py
+++ b/pyVHDLModel/Instantiation.py
@@ -42,7 +42,7 @@ from pyTooling.MetaClasses   import ExtendedType
 from pyVHDLModel             import VHDLModelException
 from pyVHDLModel.Base        import ModelEntity
 from pyVHDLModel.DesignUnit  import Package, ContextUnion
-from pyVHDLModel.Association import GenericAssociationItem
+from pyVHDLModel.Association import GenericAssociationItem, GenericMapAspectMixin
 from pyVHDLModel.Subprogram  import Procedure, Function, Subprogram
 from pyVHDLModel.Symbol      import PackageReferenceSymbol, SubprogramReferenceSymbol, SubtypeSymbol
 
@@ -78,7 +78,7 @@ class GenericEntityInstantiationMixin(GenericInstantiationMixin, mixin=True):
 
 
 @export
-class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
+class SubprogramInstantiationMixin(GenericInstantiationMixin, GenericMapAspectMixin, mixin=True):
 	"""
 	A mixin-class for instantiations of a generic subprogram.
 
@@ -87,8 +87,7 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 	   * :class:`Procedure instantiation <pyVHDLModel.Instantiation.ProcedureInstantiation>`
 	   * :class:`Function instantiation <pyVHDLModel.Instantiation.FunctionInstantiation>`
 	"""
-	_subprogramReference:     SubprogramReferenceSymbol     #: Reference to the instantiated generic subprogram.
-	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations in the generic map aspect.
+	_subprogramReference: SubprogramReferenceSymbol  #: Reference to the instantiated generic subprogram.
 
 	def __init__(
 		self,
@@ -103,14 +102,10 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 		"""
 		super().__init__()
 
+		GenericMapAspectMixin.__init__(self, genericAssociationItems)
+
 		self._subprogramReference = subprogramReference
 		subprogramReference.Parent = self
-
-		self._genericAssociationItems = []
-		if genericAssociationItems is not None:
-			for association in genericAssociationItems:
-				self._genericAssociationItems.append(association)
-				association.Parent = self
 
 	@readonly
 	def SubprogramReference(self) -> SubprogramReferenceSymbol:
@@ -121,14 +116,6 @@ class SubprogramInstantiationMixin(GenericInstantiationMixin, mixin=True):
 		"""
 		return self._subprogramReference
 
-	@readonly
-	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
-		"""
-		Read-only property to access the generic association items (:attr:`_genericAssociationItems`).
-
-		:returns: List of generic association items.
-		"""
-		return self._genericAssociationItems
 
 
 @export
@@ -234,7 +221,8 @@ class FunctionInstantiation(Function, SubprogramInstantiationMixin):
 
 
 @export
-class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a PackageBase class is needed to share members.
+# TODO: maybe a PackageBase class is needed to share members.
+class PackageInstantiation(Package, GenericInstantiationMixin, GenericMapAspectMixin):
 	"""
 	Represents the instantiation of a generic package.
 
@@ -246,8 +234,7 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 	      --      ^                                   <- Identifier
 	      --               ^^                         <- PackageReference
 	"""
-	_packageReference:        PackageReferenceSymbol        #: Reference to the instantiated generic package.
-	_genericAssociationItems: List[GenericAssociationItem]  #: List of all generic associations in the generic map aspect.
+	_packageReference: PackageReferenceSymbol  #: Reference to the instantiated generic package.
 
 	def __init__(
 		self,
@@ -271,15 +258,10 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 		super().__init__(identifier, contextItems, documentation=documentation, parent=parent)
 		GenericEntityInstantiationMixin.__init__(self)
 
+		GenericMapAspectMixin.__init__(self, genericAssociationItems)
+
 		self._packageReference = genericPackage
 		self._packageReference.Parent = self
-
-		# TODO: extract to mixin
-		self._genericAssociationItems = []
-		if genericAssociationItems is not None:
-			for association in genericAssociationItems:
-				self._genericAssociationItems.append(association)
-				association.Parent = self
 
 	@readonly
 	def PackageReference(self) -> PackageReferenceSymbol:
@@ -290,14 +272,6 @@ class PackageInstantiation(Package, GenericInstantiationMixin):  # TODO: maybe a
 		"""
 		return self._packageReference
 
-	@readonly
-	def GenericAssociationItems(self) -> List[GenericAssociationItem]:
-		"""
-		Read-only property to access the generic association items (:attr:`_genericAssociationItems`).
-
-		:returns: List of generic association items.
-		"""
-		return self._genericAssociationItems
 
 	def Instantiate(self) -> None:
 		genericPackage: Package = self._packageReference.Package

--- a/tests/unit/Instantiation/Concurrent.py
+++ b/tests/unit/Instantiation/Concurrent.py
@@ -35,7 +35,7 @@ tests/unit/Assignment.py (conditional/selected signal assignments) or tests/unit
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base        import Direction, SimpleRange
+from pyVHDLModel.Base        import Direction, Mode, SimpleRange
 from pyVHDLModel.Name        import SimpleName
 from pyVHDLModel.Symbol      import (
 	ComponentInstantiationSymbol, EntityInstantiationSymbol, ArchitectureSymbol,
@@ -45,6 +45,7 @@ from pyVHDLModel.Expression  import IntegerLiteral, CharacterLiteral
 from pyVHDLModel.Association import GenericAssociationItem, PortAssociationItem
 from pyVHDLModel.Base        import WaveformElement
 from pyVHDLModel.DesignUnit  import Architecture
+from pyVHDLModel.Interface   import GenericConstantInterfaceItem, PortSimpleSignalInterfaceItem
 from pyVHDLModel.Concurrent  import (
 	ComponentInstantiation, EntityInstantiation, ConfigurationInstantiation,
 	ProcessStatement, ConcurrentProcedureCall, ConcurrentBlockStatement,
@@ -54,7 +55,7 @@ from pyVHDLModel.Concurrent  import (
 	ForGenerateStatement, ConcurrentSimpleSignalAssignment, ConcurrentAssertStatement,
 )
 
-from tests.unit              import _entitySymbol
+from tests.unit              import _entitySymbol, _subtypeSymbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -129,16 +130,51 @@ class ConcurrentProcedureCalls(TestCase):
 
 class ConcurrentBlockStatements(TestCase):
 	"""``BlockStatementMixin``/``LabeledEntityMixin`` wiring is already covered in tests/unit/Base.py;
-	this covers the block-specific state (port items, declared items/statements via
-	``ConcurrentDeclarationRegionMixin``/``ConcurrentStatementsMixin``) instead."""
+	this covers the block-specific state: the block header (generic and port clauses with their map
+	aspects) and the declared items/statements via
+	``ConcurrentDeclarationRegionMixin``/``ConcurrentStatementsMixin``."""
 
 	def test_WithPortItems(self) -> None:
-		portItem = PortAssociationItem(SimpleName("p"), SimpleName("s"))
+		portItem = PortSimpleSignalInterfaceItem(["p"], Mode.In, _subtypeSymbol("bit"))
 		block = ConcurrentBlockStatement("blk", portItems=[portItem])
 
 		self.assertEqual(1, len(block.PortItems))
 		self.assertIs(portItem, block.PortItems[0])
 		self.assertIs(block, portItem.Parent)
+
+	def test_WithGenericItems(self) -> None:
+		genericItem = GenericConstantInterfaceItem(["G"], Mode.In, _subtypeSymbol("positive"))
+		block = ConcurrentBlockStatement("blk", genericItems=[genericItem])
+
+		self.assertEqual(1, len(block.GenericItems))
+		self.assertIs(genericItem, block.GenericItems[0])
+		self.assertIs(block, genericItem.Parent)
+
+	def test_WithGenericMapAspect(self) -> None:
+		association = GenericAssociationItem(SimpleName("G"), IntegerLiteral(2))
+		block = ConcurrentBlockStatement("blk", genericAssociationItems=[association])
+
+		self.assertEqual(1, len(block.GenericAssociationItems))
+		self.assertIs(association, block.GenericAssociationItems[0])
+		self.assertIs(block, association.Parent)
+
+	def test_WithPortMapAspect(self) -> None:
+		association = PortAssociationItem(SimpleName("p"), SimpleName("s"))
+		block = ConcurrentBlockStatement("blk", portAssociationItems=[association])
+
+		self.assertEqual(1, len(block.PortAssociationItems))
+		self.assertIs(association, block.PortAssociationItems[0])
+		self.assertIs(block, association.Parent)
+
+	def test_WithoutBlockHeader(self) -> None:
+		"""A block header is optional; all four lists stay empty."""
+		block = ConcurrentBlockStatement("blk")
+
+		self.assertEqual(0, len(block.GenericItems))
+		self.assertEqual(0, len(block.GenericAssociationItems))
+		self.assertEqual(0, len(block.PortItems))
+		self.assertEqual(0, len(block.PortAssociationItems))
+
 
 class GenerateBranches(TestCase):
 	def test_IfGenerateBranch(self) -> None:


### PR DESCRIPTION
Findings item 4, the last of the four you ordered.

⚠️ **Needs the companion pyGHDL PR**: Paebbels/GHDL#17.

## The gap

A block statement could only model its **port clause**. Its generic clause and both map aspects were dropped, so this legal VHDL lost three quarters of its header:

```vhdl
blk : block
    generic (G : positive := 1);
    generic map (G => 2);
    port (bp : in bit);
    port map (bp => clock);
begin
end block;
```

## The TODOs were the fix

`GenericMapAspectMixin` and `PortMapAspectMixin` are new in `Association.py`. That resolves the `# TODO: extract to mixin` markers you had left - the association fields were hand-rolled in **four** places, not just the two in `Instantiation`:

| Class | Was |
|---|---|
| `Instantiation` | both fields, both marked TODO |
| `PackageInstantiation` | generic only, marked TODO |
| `SubprogramInstantiationMixin` | generic only |
| `BindingIndication` | both fields |

All four now use the mixins, and `ConcurrentBlockStatement` gains both plus `WithGenericsMixin`.

The mixins type their fields as `GenericAssociationItem`/`PortAssociationItem` rather than the base `AssociationItem` that `Instantiation` used. I checked pyGHDL first: it already constructs the specific types, so nothing downstream loosens.

## A wrong test this surfaced

`test_WithPortItems` passed a **`PortAssociationItem` as a port item** - an association where an interface item belongs. It only passed because nothing type-checks that argument. Fixed to a `PortSimpleSignalInterfaceItem`, and joined by coverage for the generic clause, both map aspects, and a block with no header at all.

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit` | **446** passed (+4), 69 subtests |
| pyGHDL `testsuite/pyunit` (with the companion PR) | 185 passed, 17 xfailed |
| Round-trip on real VHDL: block with full header | all four lists populated |
| Block with partial / no header | correct, no crash |
| `# TODO: extract to mixin` remaining | **0** (was 3) |
| ReST / caret alignment | 0 problems |
| Forced annotation evaluation (3.11-3.13) | clean |
| `interrogate` | 97.4% (minimum 90.0%) |
| New lines > 120 chars | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)