### PR TITLE
A parenthesis name may also be a type conversion

### DIFF
--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -1071,15 +1071,24 @@ class SimpleObjectOrFunctionCallSymbol(Symbol):
 @export
 class IndexedObjectOrFunctionCallSymbol(Symbol):
 	"""
-	Represents a reference that is either an indexed object or a function call.
+	Represents a reference that is an indexed object, a function call or a type conversion.
 
-	An expression like ``f(0)`` may index an array or call a function; both look identical until the
-	name is resolved. The referenced language entity is available as :data:`Reference` once resolved.
+	All three are written the same way - ``arr(0)``, ``f(0)`` and ``integer(0)`` are indistinguishable
+	as syntax, so a parser produces one shape for them and only name resolution tells them apart. The
+	referenced language entity is available as :data:`Reference` once resolved.
+
+	.. seealso::
+
+	   * :class:`Type conversion <pyVHDLModel.Expression.TypeConversion>`
+	   * :class:`Simple object or function call <pyVHDLModel.Symbol.SimpleObjectOrFunctionCallSymbol>`
 	"""
 	def __init__(self, name: Name) -> None:
 		"""
-		Initializes a reference that is either an indexed object or a function call.
+		Initializes a reference that is an indexed object, a function call or a type conversion.
 
 		:param name: The name to reference the language entity.
 		"""
-		super().__init__(name, PossibleReference.Object | PossibleReference.Function)
+		super().__init__(
+			name,
+			PossibleReference.Object | PossibleReference.Function | PossibleReference.Type | PossibleReference.Subtype
+		)

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -1071,11 +1071,14 @@ class SimpleObjectOrFunctionCallSymbol(Symbol):
 @export
 class IndexedObjectOrFunctionCallSymbol(Symbol):
 	"""
-	Represents a reference that is an indexed object, a function call or a type conversion.
+	Represents a reference that is either an indexed object, a function call or a type conversion.
 
-	All three are written the same way - ``arr(0)``, ``f(0)`` and ``integer(0)`` are indistinguishable
-	as syntax, so a parser produces one shape for them and only name resolution tells them apart. The
-	referenced language entity is available as :data:`Reference` once resolved.
+	The referenced language entity is available as :data:`Reference` once resolved.
+
+	.. attention::
+
+	   All three are written the same way - ``arr(0)``, ``f(0)`` and ``integer(0)`` are indistinguishable
+	   as syntax, so a parser produces one shape for them and only name resolution tells them apart.
 
 	.. seealso::
 
@@ -1084,7 +1087,7 @@ class IndexedObjectOrFunctionCallSymbol(Symbol):
 	"""
 	def __init__(self, name: Name) -> None:
 		"""
-		Initializes a reference that is an indexed object, a function call or a type conversion.
+		Initializes a reference that is either an indexed object, a function call or a type conversion.
 
 		:param name: The name to reference the language entity.
 		"""

--- a/tests/unit/Instantiation/Symbol.py
+++ b/tests/unit/Instantiation/Symbol.py
@@ -163,9 +163,15 @@ class NoPropertyReferenceSymbols(TestCase):
 		self.assertIs(PossibleReference.SimpleNameInExpression, symbol._possibleReferences)
 
 	def test_IndexedObjectOrFunctionCallSymbol(self) -> None:
+		"""``arr(0)``, ``f(0)`` and ``integer(0)`` are written identically, so all three possibilities
+		are carried until the name resolves."""
 		symbol = IndexedObjectOrFunctionCallSymbol(SimpleName("x"))
 
-		self.assertIs(PossibleReference.Object | PossibleReference.Function, symbol._possibleReferences)
+		expected = (
+			PossibleReference.Object | PossibleReference.Function |
+			PossibleReference.Type | PossibleReference.Subtype
+		)
+		self.assertIs(expected, symbol._possibleReferences)
 
 
 class SubtypeSymbols(TestCase):


### PR DESCRIPTION
Companion to Paebbels/GHDL#18, from investigating why `TypeConversion` is never constructed.

`IndexedObjectOrFunctionCallSymbol` declared `Object | Function`. But the syntax it represents has a **third** reading: `arr(0)`, `f(0)` and `integer(0)` are written identically, so a parser cannot tell an indexed name from a function call from a **type conversion**.

`Type` and `Subtype` join its possible references, and the doc-string names all three readings.

## Why this matters beyond tidiness

GHDL's parser emits `Parenthesis_Name` for all three; only semantic analysis rewrites one into `Type_Conversion`. `pyGHDL.dom` parses without that pass, so **this symbol is what a type conversion actually becomes today** - and it was under-declaring that. Anything filtering on `_possibleReferences` would have excluded a legitimate resolution target.

| Check | Result |
|---|---|
| `pytest tests/unit` | 446 passed, 69 subtests |
| ReST parse | 0 problems |
| `interrogate` | 97.4% (minimum 90.0%) |
| New lines > 120 chars | 0 |

The existing test asserted the old pair and is updated, with a note on why all three are carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)