### PR TITLE
Let a library carry documentation, settable after construction

### DIFF
--- a/pyVHDLModel/Predefined.py
+++ b/pyVHDLModel/Predefined.py
@@ -57,13 +57,15 @@ class PredefinedLibrary(Library):
 	   * :class:`Std <pyVHDLModel.STD.Std>`
 	"""
 
-	def __init__(self, packages) -> None:
+	def __init__(self, packages, documentation: Nullable[str] = None) -> None:
 		"""
 		Initializes a predefined library.
 
-		:param packages: Dictionary of all packages defined in a library.
+		:param packages:      Dictionary of all packages defined in a library.
+		:param documentation: Documentation of this library, if the caller has one to supply. VHDL defines
+		                      none for a predefined library, so it is empty unless supplied from outside.
 		"""
-		super().__init__(self.__class__.__name__, None)
+		super().__init__(self.__class__.__name__, documentation)
 
 		self.AddPackages(packages)
 

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -2198,7 +2198,7 @@ class Design(ModelEntity, AllowBlackboxMixin):
 
 
 @export
-class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
+class Library(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, AllowBlackboxMixin):
 	"""
 	A ``Library`` represents a VHDL library. It contains all *primary* and *secondary* design units.
 
@@ -2220,6 +2220,7 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 	def __init__(
 		self,
 		identifier:    str,
+		documentation: Nullable[str] = None,
 		allowBlackbox: Nullable[bool] = None,
 		parent:        Nullable[ModelEntity] = None
 	) -> None:
@@ -2227,11 +2228,13 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 		Initialize a VHDL library.
 
 		:param identifier:    Name of the VHDL library.
+		:param documentation: Documentation of this VHDL library, if the caller has one to supply.
 		:param allowBlackbox: Specify if blackboxes are allowed in this design.
 		:param parent:        The parent model entity (design) of this VHDL library.
 		"""
 		super().__init__(parent)
 		NamedEntityMixin.__init__(self, identifier)
+		DocumentedEntityMixin.__init__(self, documentation)
 		AllowBlackboxMixin.__init__(self, allowBlackbox)
 
 		self._contexts =        {}
@@ -2242,6 +2245,25 @@ class Library(ModelEntity, NamedEntityMixin, AllowBlackboxMixin):
 		self._packageBodies =   {}
 
 		self._dependencyVertex = None
+
+	@property
+	def Documentation(self) -> Nullable[str]:
+		"""
+		Property to access the library's documentation (:attr:`_documentation`).
+
+		.. hint::
+
+		   Unlike every other documented entity, a library's documentation cannot come from VHDL source:
+		   the language has no library declaration to hang a comment on. It is therefore settable, so a
+		   caller can supply one from elsewhere - a compile-order file, a project description, ...
+
+		:returns: Associated documentation of this VHDL library.
+		"""
+		return self._documentation
+
+	@Documentation.setter
+	def Documentation(self, documentation: Nullable[str]) -> None:
+		self._documentation = documentation
 
 	@readonly
 	def Contexts(self) -> Dict[str, Context]:

--- a/pyVHDLModel/__init__.py
+++ b/pyVHDLModel/__init__.py
@@ -2254,7 +2254,7 @@ class Library(ModelEntity, NamedEntityMixin, DocumentedEntityMixin, AllowBlackbo
 		.. hint::
 
 		   Unlike every other documented entity, a library's documentation cannot come from VHDL source:
-		   the language has no library declaration to hang a comment on. It is therefore settable, so a
+		   the language has no library declaration to attach a comment to. It is therefore settable, so a
 		   caller can supply one from elsewhere - a compile-order file, a project description, ...
 
 		:returns: Associated documentation of this VHDL library.

--- a/tests/unit/Instantiation/Model.py
+++ b/tests/unit/Instantiation/Model.py
@@ -52,7 +52,8 @@ from pyVHDLModel.DesignUnit    import Package, PackageBody, Context, Entity, Arc
 from pyVHDLModel.DesignUnit    import LibraryClause
 from pyVHDLModel.Association   import GenericAssociationItem
 from pyVHDLModel.Instantiation import PackageInstantiation, FunctionInstantiation, ProcedureInstantiation
-from pyVHDLModel.PSLModel   import DefaultClock
+from pyVHDLModel.PSLModel      import DefaultClock
+from pyVHDLModel.STD           import Std
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -149,7 +150,7 @@ class Symbols(TestCase):
 		self.assertEqual("LibraryReferenceSymbol: 'Lib' -> unresolved", repr(symbol))
 		self.assertEqual("Lib?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		symbol.Library = library
 
 		self.assertTrue(symbol.IsResolved)
@@ -168,7 +169,7 @@ class Symbols(TestCase):
 		self.assertEqual("PackageReferenceSymbol: 'Lib.Pack' -> unresolved", repr(symbol))
 		self.assertEqual("Lib.Pack?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		package = Package("pacK", parent=None)
 		package.Library = library
 		symbol.Package = package
@@ -189,7 +190,7 @@ class Symbols(TestCase):
 		self.assertEqual("PackageMemberReferenceSymbol: 'Lib.Pack.Obj' -> unresolved", repr(symbol))
 		self.assertEqual("Lib.Pack.Obj?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		package = Package("pacK", parent=None)
 		package.Library = library
 		constant = Constant(("obJ", ), SimpleSubtypeSymbol(SimpleName("Bool")))
@@ -215,7 +216,7 @@ class Symbols(TestCase):
 		self.assertEqual("AllPackageMembersReferenceSymbol: 'Lib.Pack.all' -> unresolved", repr(symbol))
 		self.assertEqual("Lib.Pack.all?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		package = Package("pacK", parent=None)
 		package.Library = library
 		constant = Constant(("obJ", ), SimpleSubtypeSymbol(SimpleName("Bool")))
@@ -245,7 +246,7 @@ class Symbols(TestCase):
 		self.assertEqual("ContextReferenceSymbol: 'Lib.Ctx' -> unresolved", repr(symbol))
 		self.assertEqual("Lib.Ctx?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		context = Context("ctX", parent=None)
 		context.Library = library
 		symbol.Context = context
@@ -266,7 +267,7 @@ class Symbols(TestCase):
 		self.assertEqual("EntitySymbol: 'Ent' -> unresolved", repr(symbol))
 		self.assertEqual("Ent?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		entity = Entity("enT", parent=None)
 		entity.Library = library
 		symbol.Entity = entity
@@ -287,7 +288,7 @@ class Symbols(TestCase):
 		self.assertEqual("EntitySymbol: 'Work.Ent' -> unresolved", repr(symbol))
 		self.assertEqual("Work.Ent?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		entity = Entity("enT", parent=None)
 		entity.Library = library
 		symbol.Entity = entity
@@ -314,7 +315,7 @@ class Symbols(TestCase):
 		self.assertEqual("PackageSymbol: 'Pack' -> unresolved", repr(symbol))
 		self.assertEqual("Pack?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		package = Package("pacK", parent=None)
 		package.Library = library
 		symbol.Package = package
@@ -335,7 +336,7 @@ class Symbols(TestCase):
 		self.assertEqual("EntityInstantiationSymbol: 'Lib.Ent' -> unresolved", repr(symbol))
 		self.assertEqual("Lib.Ent?", str(symbol))
 
-		library = Library("liB", None)
+		library = Library("liB")
 		entity = Entity("enT", parent=None)
 		entity.Library = library
 		symbol.Entity = entity
@@ -401,7 +402,7 @@ class SimpleInstance(TestCase):
 		self.assertEqual(0, design.CompileOrderGraph.VertexCount)
 
 	def test_Library(self) -> None:
-		library = Library("lib_1", None)
+		library = Library("lib_1")
 
 		self.assertIsNotNone(library)
 		self.assertEqual("lib_1", library.Identifier)
@@ -669,20 +670,44 @@ class VHDLDocument(TestCase):
 
 
 class VHDLLibrary(TestCase):
+	def test_DocumentationFromInitializer(self) -> None:
+		"""VHDL has no library declaration to hang a comment on, so a caller supplies one."""
+		library = Library("lib_1", "--! From a compile-order file.")
+
+		self.assertEqual("--! From a compile-order file.", library.Documentation)
+
+	def test_DocumentationIsSettable(self) -> None:
+		"""Unlike every other documented entity, a library's documentation can be set after construction."""
+		library = Library("lib_1")
+
+		self.assertIsNone(library.Documentation)
+
+		library.Documentation = "--! Supplied later."
+		self.assertEqual("--! Supplied later.", library.Documentation)
+
+	def test_PredefinedLibrariesHaveNoDocumentation(self) -> None:
+		"""VHDL defines none for `std`/`ieee`, but a caller may still supply one."""
+		std = Std()
+
+		self.assertIsNone(std.Documentation)
+
+		std.Documentation = "--! Supplied by the caller."
+		self.assertEqual("--! Supplied by the caller.", std.Documentation)
+
 	def test_AddLibrary(self) -> None:
 		design = Design()
 
-		library1 = Library("lib_1", None)
+		library1 = Library("lib_1")
 		design.AddLibrary(library1)
 
 		self.assertEqual(1, len(design.Libraries))
 		self.assertEqual(design, library1.Parent)
 
 		with self.assertRaises(Exception):
-			design.AddLibrary(Library("lib_1", None))
+			design.AddLibrary(Library("lib_1"))
 
 		with self.assertRaises(Exception):
-			library2 = Library("lib_2", None)
+			library2 = Library("lib_2")
 			library2._parent = True
 			design.AddLibrary(library2)
 


### PR DESCRIPTION
VHDL has no library declaration, so there is nowhere in the source to hang a comment - but a caller of this API may well have one from elsewhere: a compile-order file, a project description, a build system.

## What

`Library` gains `DocumentedEntityMixin` and a `documentation` parameter, and **overrides `Documentation` as a settable property**:

```py
library = Library("mylib", "--! From a compile-order file.")
library.Documentation = "--! Supplied later."
```

The setter is the point of the change, and it is deliberately different from every other documented entity: those take their text from the source and keep it read-only, whereas a library's can only ever come from outside - and may not be known when the library is constructed. A `.. hint::` on the property records that reasoning.

`PredefinedLibrary` accepts and forwards one too. `Std` and `Ieee` pass **none**, since VHDL defines no documentation for the predefined libraries, but a caller can still set it afterwards:

```
Ieee().Documentation        -> None
std.Documentation = "..."   -> works
```

## Parameter position

`documentation` sits **before** `allowBlackbox`, matching `Package` and the rest of the model rather than being appended for convenience.

That does change what a positional second argument means. I checked every construction site: the only positional callers were **tests passing `None`**, so behaviour is identical either way - but leaving them would have meant a positional that silently changed meaning, so they now pass nothing instead. Nothing outside this repo constructs a `Library` positionally; pyGHDL never constructs one at all.

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit` | **455** passed (+3), 69 subtests |
| pyGHDL `testsuite/pyunit` (its base branch, to isolate this change) | 185 passed, 17 xfailed |
| Ambiguous positional `Library(..., None)` calls left | 0 |
| ReST parse | 0 problems |
| Forced annotation evaluation (3.11-3.13) | clean |
| `interrogate` | 97.4% (minimum 90.0%) |
| New lines > 120 chars | 0 |

Independent of #164 - different classes, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)