### PR TITLE
Require a range constraint in ConstrainedScalarSubtypeSymbol

### DIFF
--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -873,10 +873,7 @@ class ScalarConstraint(Constraint, mixin=True):
 	"""
 	A mixin-class for a scalar constraint: a range.
 
-	The range is available as :data:`Constraint`. It is mandatory, because VHDL's ``range_constraint``
-	rule is ``range range``: a type mark is either written without a constraint at all, which is a
-	:class:`~pyVHDLModel.Symbol.SimpleSubtypeSymbol`, or with a range following the ``range`` keyword.
-	A form like ``integer range`` doesn't exist.
+	The range is available as :data:`Constraint`.
 
 	.. seealso::
 
@@ -897,7 +894,7 @@ class ScalarConstraint(Constraint, mixin=True):
 		"""
 		Read-only property to access the scalar type's range constraint (:attr:`_constraint`).
 
-		:returns: The constraint.
+		:returns: The constraint of the scalar subtype.
 		"""
 		return self._constraint
 

--- a/pyVHDLModel/Symbol.py
+++ b/pyVHDLModel/Symbol.py
@@ -873,28 +873,31 @@ class ScalarConstraint(Constraint, mixin=True):
 	"""
 	A mixin-class for a scalar constraint: a range.
 
-	The range is available as :data:`Constraint`.
+	The range is available as :data:`Constraint`. It is mandatory, because VHDL's ``range_constraint``
+	rule is ``range range``: a type mark is either written without a constraint at all, which is a
+	:class:`~pyVHDLModel.Symbol.SimpleSubtypeSymbol`, or with a range following the ``range`` keyword.
+	A form like ``integer range`` doesn't exist.
 
 	.. seealso::
 
 	   * :class:`Constrained scalar subtype symbol <pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol>`
 	"""
-	_constraint: Nullable[Range]  #: The range constraining the scalar subtype, or ``None`` if unconstrained.
+	_constraint: Range  #: The range constraining the scalar subtype.
 
-	def __init__(self, constraint: Nullable[Range]) -> None:
+	def __init__(self, constraint: Range) -> None:
 		"""
 		Initializes a scalar constraint.
 
-		:param constraint: The range constraining the scalar subtype, or ``None`` if unconstrained.
+		:param constraint: The range constraining the scalar subtype.
 		"""
 		self._constraint = constraint
 
 	@readonly
-	def Constraint(self) -> Nullable[Range]:
+	def Constraint(self) -> Range:
 		"""
 		Read-only property to access the scalar type's range constraint (:attr:`_constraint`).
 
-		:returns: The constraint, or ``None`` if not set.
+		:returns: The constraint.
 		"""
 		return self._constraint
 
@@ -904,7 +907,8 @@ class ConstrainedScalarSubtypeSymbol(SubtypeSymbol, ScalarConstraint):
 	"""
 	Represents a reference to a scalar subtype narrowed by a range.
 
-	The referenced language entity is available as :data:`Reference` once resolved.
+	The referenced language entity is available as :data:`Reference` once resolved. The range is
+	mandatory: a type mark without a range constraint is a :class:`~pyVHDLModel.Symbol.SimpleSubtypeSymbol`.
 
 	.. admonition:: Example
 
@@ -913,14 +917,23 @@ class ConstrainedScalarSubtypeSymbol(SubtypeSymbol, ScalarConstraint):
 	      for i in integer range 0 to 3 loop
 	      --       ^^^^^^^                     <- Name
 	      --                     ^^^^^^        <- Constraint
+
+	   A range constraint written as a range attribute is a :class:`~pyVHDLModel.Base.RangeFromName`
+	   referring to a :class:`~pyVHDLModel.Symbol.RangeAttributeSymbol`:
+
+	   .. code-block:: VHDL
+
+	      subtype index is natural range vector'range;
+	      --               ^^^^^^^                      <- Name
+	      --                             ^^^^^^^^^^^^   <- Constraint
 	"""
 
-	def __init__(self, name: Name, constraint: Nullable[Range] = None) -> None:
+	def __init__(self, name: Name, constraint: Range) -> None:
 		"""
 		Initializes a reference to a scalar subtype narrowed by a range.
 
 		:param name:       The name to reference the language entity.
-		:param constraint: The range constraining the scalar subtype, or ``None`` if unconstrained.
+		:param constraint: The range constraining the scalar subtype.
 		"""
 		super().__init__(name)
 		ScalarConstraint.__init__(self, constraint)

--- a/tests/unit/Instantiation/Model.py
+++ b/tests/unit/Instantiation/Model.py
@@ -365,9 +365,9 @@ class Symbols(TestCase):
 		self.assertIs(rng, symbol.Constraint)
 
 	def test_ConstrainedScalarSubtypeSymbol_withoutConstraint(self) -> None:
-		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"))
-
-		self.assertIsNone(symbol.Constraint)
+		"""The range constraint is mandatory - ``integer range`` isn't a VHDL construct."""
+		with self.assertRaises(TypeError):
+			ConstrainedScalarSubtypeSymbol(SimpleName("integer"))
 
 
 class PSLEntities(TestCase):

--- a/tests/unit/Instantiation/Symbol.py
+++ b/tests/unit/Instantiation/Symbol.py
@@ -39,8 +39,8 @@ itself, the object/function-call symbols with no dedicated property) get their o
 """
 from unittest import TestCase
 
-from pyVHDLModel.Base   import Direction, SimpleRange
-from pyVHDLModel.Name   import SimpleName, AllName
+from pyVHDLModel.Base   import Direction, SimpleRange, RangeFromName
+from pyVHDLModel.Name   import SimpleName, AllName, AttributeName
 from pyVHDLModel.Expression import IntegerLiteral
 from pyVHDLModel.Symbol import (
 	PossibleReference, Symbol,
@@ -49,7 +49,7 @@ from pyVHDLModel.Symbol import (
 	PackageMemberReferenceSymbol, AllPackageMembersReferenceSymbol,
 	EntityInstantiationSymbol, ComponentInstantiationSymbol, ConfigurationInstantiationSymbol,
 	EntitySymbol, ArchitectureSymbol, PackageSymbol,
-	RecordElementSymbol, SubtypeSymbol, SimpleSubtypeSymbol,
+	RangeAttributeSymbol, RecordElementSymbol, SubtypeSymbol, SimpleSubtypeSymbol,
 	ConstrainedScalarSubtypeSymbol, ConstrainedArraySubtypeSymbol, ConstrainedRecordSubtypeSymbol,
 	SimpleObjectOrFunctionCallSymbol, IndexedObjectOrFunctionCallSymbol,
 )
@@ -203,13 +203,19 @@ class ConstrainedSubtypeSymbols(TestCase):
 
 		self.assertIs(constraint, symbol.Constraint)
 
-	def test_ScalarConstraint_WithoutRange(self) -> None:
-		"""``None`` only means the range constraint was written as an attribute name
-		(``subtype s is t'range;``), which isn't implemented yet - not that the source omitted a
-		constraint (it never does for a constrained scalar subtype). See ``Constraint``'s docstring."""
-		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("integer"))
+	def test_ScalarConstraint_RangeIsMandatory(self) -> None:
+		"""``integer range`` isn't a VHDL construct - a type mark without a range constraint is a
+		``SimpleSubtypeSymbol``, so the range can't be omitted here."""
+		with self.assertRaises(TypeError):
+			ConstrainedScalarSubtypeSymbol(SimpleName("integer"))
 
-		self.assertIsNone(symbol.Constraint)
+	def test_ScalarConstraint_WithRangeAttribute(self) -> None:
+		"""``subtype index is natural range vector'range;`` - the range constraint is a range attribute,
+		which is a range denoted by a name."""
+		constraint = RangeFromName(RangeAttributeSymbol(AttributeName("range", SimpleName("vector"))))
+		symbol = ConstrainedScalarSubtypeSymbol(SimpleName("natural"), constraint)
+
+		self.assertIs(constraint, symbol.Constraint)
 
 	def test_ArrayConstraint(self) -> None:
 		constraint = SimpleRange(IntegerLiteral(7), IntegerLiteral(0), Direction.DownTo)


### PR DESCRIPTION
## Changes

`ConstrainedScalarSubtypeSymbol`'s range constraint is now mandatory.

VHDL's grammar leaves no state in which this class has no constraint:

```
subtype_indication ::= [ resolution_indication ] type_mark [ constraint ]
constraint         ::= range_constraint | array_constraint | record_constraint
range_constraint   ::= **range** range
range              ::= range_attribute_name | simple_expression direction simple_expression
```

The `range` keyword is always followed by a range, so a subtype indication is either a bare type mark — modelled as `SimpleSubtypeSymbol` — or a type mark with a range. There is `integer` and there is `integer range 0 to 5`, but no `integer range`.

* `constraint` loses its `None` default and is typed `Range` instead of `Nullable[Range]`, in `ScalarConstraint` as well as in `ConstrainedScalarSubtypeSymbol`.
* The `Constraint` property returns `Range`.

## Documentation

* `ScalarConstraint` states why the range is mandatory, citing the `range_constraint` rule.
* `ConstrainedScalarSubtypeSymbol` gained a second example for the range-attribute form, `subtype index is natural range vector'range;`, which is a `RangeFromName` referring to a `RangeAttributeSymbol`. That form was the reason the parameter was optional, and it is a range like any other.

## Unit Tests

* `test_ScalarConstraint_RangeIsMandatory` and `test_ConstrainedScalarSubtypeSymbol_withoutConstraint` now assert that omitting the constraint raises a `TypeError`; previously both asserted that `Constraint` is `None`.
* `test_ScalarConstraint_WithRangeAttribute` covers the range-attribute form.

465 tests pass (was 464).

## Notes

`range <>` — as in `type matrix is array (natural range <>) of bit;` — is an `index_subtype_definition`, not a subtype indication. `ArrayType` models it as a dimension (`List[Range]`), so it never reaches this class.

**This is a breaking change**, so the next release is a minor one: v0.39.0 rather than v0.38.1. #168 has to be retitled and its version bump adjusted once this is merged.

**pyGHDL.dom needs a companion change.** `GetScalarConstrainedSubtypeFromNode` passes `None` when GHDL reports the range constraint as an `Attribute_Name`, with a `# TODO: Get actual range from AttributeName node?`. Nothing raises, so this is not a crash — but `Constraint` would hold `None` in violation of its type. `_Translate.py` already builds exactly the right object one function further down (`RangeFromName(node, RangeAttributeSymbol(node, GetName(node)))`), so the fix is a few lines. Filed in the findings notebook.
